### PR TITLE
Moved terminal/dmenu spawn commands to config

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -9,7 +9,6 @@ local background = 0x5E4055
 
 -- Programs that Way Cooler can run
 way_cooler.programs = {
-  terminal = "weston-terminal", -- Use the terminal of your choice
   -- Name of the window that will be the bar window.
   -- This is a hack to get X11 bars and non-Way Cooler supported bars working.
   --
@@ -68,9 +67,9 @@ local key = way_cooler.key
 
 local keys = {
   -- Open dmenu
-  key({ mod }, "d", "launch_dmenu"),
+  key({ mod }, "d", util.program.spawn_once("dmenu_run")),
   -- Open terminal
-  key({ mod }, "return", "launch_terminal"),
+  key({ mod }, "return", util.program.spawn_once("weston-terminal")),
 
   -- Lua methods can be bound as well
   key({ mod, "Shift" }, "h", function () print("Hello world!") end),

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -6,8 +6,6 @@ use std::thread;
 use std::io::prelude::*;
 use layout::commands as layout_cmds;
 
-use uuid::Uuid;
-use registry::{self};
 use commands::{self, CommandFn};
 use layout::try_lock_tree;
 use lua::{self, LuaQuery};
@@ -25,8 +23,6 @@ pub fn register_defaults() {
     };
 
     register("way_cooler_quit", Arc::new(way_cooler_quit));
-    register("launch_terminal", Arc::new(launch_terminal));
-    register("launch_dmenu", Arc::new(launch_dmenu));
     register("print_pointer", Arc::new(print_pointer));
 
     register("dmenu_eval", Arc::new(dmenu_eval));
@@ -107,27 +103,6 @@ pub fn register_defaults() {
 
 // All of the methods defined should be registered.
 #[deny(dead_code)]
-
-fn launch_terminal() {
-    let lock = registry::clients_read();
-    let client = lock.client(Uuid::nil()).unwrap();
-    let handle = registry::ReadHandle::new(&client);
-    let command = handle.read("programs".into())
-        .expect("programs category didn't exist")
-        .get("terminal".into())
-        .and_then(|data| data.as_string().map(str::to_string))
-        .unwrap_or("weston-terminal".into());
-
-    Command::new("sh").arg("-c")
-        .arg(command)
-        .spawn().expect("Error launching terminal");
-}
-
-fn launch_dmenu() {
-    Command::new("sh").arg("-c")
-        .arg("dmenu_run")
-        .spawn().expect("Error launching terminal");
-}
 
 fn print_pointer() {
     use lua;


### PR DESCRIPTION
Fixes #257.

Removes the commands `launch_terminal` and `launch_dmenu`. These have been replaced in the default configuration with explicit calls to the programs.

(e.g: `util.program.spawn_once("dmenu_run")`)

Thanks for the suggestion @joehillen