### PR TITLE
Improved last active container algorithm

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -312,13 +312,8 @@ impl LayoutTree {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::LayoutTree;
     use super::super::super::core::tree::tests::basic_tree;
-    use super::super::super::core::container::*;
-    use super::super::super::core::InnerTree;
-    use super::*;
     use rustwlc::*;
-    use uuid::Uuid;
 
     /// Tests the new algorithm, the one that i3 uses, to determine which
     /// sibling to focus on when the active one is closed.

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -147,6 +147,23 @@ impl InnerTree {
         Err(node_ix)
     }
 
+    /// Gets the view following the lowest active path number in the tree.
+    /// Starts at the given `node_ix`.
+    ///
+    /// If there are no children (e.g empty container), then `None` is returned.
+    pub fn lowest_active_view(&self, node_ix: NodeIndex) -> Option<NodeIndex> {
+        let mut cur_ix = node_ix;
+        while self[cur_ix].get_type() != ContainerType::View {
+            let maybe_edge = self.graph.edges(cur_ix).min_by_key(|e| e.weight().active);
+            if let Some(edge) = maybe_edge {
+                cur_ix = edge.target();
+            } else {
+                return None
+            }
+        }
+        Some(cur_ix)
+    }
+
     /// Gets the weight of a possible edge between two notes
     pub fn get_edge_weight_between(&self, parent_ix: NodeIndex,
                                    child_ix: NodeIndex) -> Option<&Path> {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -348,7 +348,6 @@ impl InnerTree {
                 .expect("Could not get the weight of the edge between target sibling and target parent");
             trace!("Sibling {:?} previously had an edge weight of {:?} to {:?}", sibling_ix, weight, target_parent);
             **weight = **weight + 1;
-            // TODO does this work?
             weight.active += 1;
             trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
         }
@@ -394,7 +393,6 @@ impl InnerTree {
                     trace!("Sibling {:?} previously had an edge weight of {:?} to {:?}", sibling_ix, weight, target_parent);
                     **weight = **weight + 1;
                     trace!("Deactivating path {:?}", sibling_edge);
-                    // TODO does this work?
                     weight.active += 1;
                     trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
                 }
@@ -703,7 +701,6 @@ impl InnerTree {
                 .expect("Could not get edge index between parent and child");
             let edge = self.graph.edge_weight_mut(edge_ix)
                 .expect("Could not associate edge index with an edge weight");
-            // TODO does this work?
             edge.active += 1;
         }
         while let Ok(parent_ix) = self.parent_of(node_ix) {
@@ -712,7 +709,6 @@ impl InnerTree {
                     .expect("Could not get edge index between parent and child");
                 let edge = self.graph.edge_weight_mut(edge_ix)
                     .expect("Could not associate edge index with an edge weight");
-                // TODO does this work?
                 edge.active += 1;
             }
             let edge_ix = self.graph.find_edge(parent_ix, node_ix)

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -240,7 +240,6 @@ impl InnerTree {
             self.graph.update_edge(parent_ix, sibling_ix, edge_weight);
             counter += 1;
         }
-        // TODO 0?
         let last_pos = Path::new(child_pos, 0);
         self.graph.update_edge(parent_ix, child_ix, last_pos);
         self.normalize_edge_weights(parent_ix);
@@ -315,7 +314,6 @@ impl InnerTree {
                 self.graph.edge_weight(target_parent_edge).map(|weight| {
                     let mut new_weight = *weight;
                     *new_weight = *new_weight + 1;
-                    // TODO 0?
                     new_weight.active = 0;
                     new_weight
                 })
@@ -364,7 +362,6 @@ impl InnerTree {
             ShiftDirection::Left => {
                 trace!("place_node edge case: placing in the last place of the sibling list");
                 self.graph.remove_edge(source_parent_edge);
-                // TODO 0?
                 let new_weight = Path::new(siblings.len() as u32 + 1, 0);
                 self.graph.update_edge(target_parent, source, new_weight);
                 self.normalize_edge_weights(target_parent);
@@ -709,7 +706,6 @@ impl InnerTree {
                 .expect("Could not get edge index between parent and child");
             let edge = self.graph.edge_weight_mut(edge_ix)
                 .expect("Could not associate edge index with an edge weight");
-            // TODO 0? Probably
             edge.active = 0;
             node_ix = parent_ix;
         }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use rustwlc::WlcView;
 
-use super::path::{Path, PathBuilder};
+use super::path::Path;
 use ::debug_enabled;
 
 use layout::{Container, ContainerType, Handle};
@@ -235,7 +235,7 @@ impl InnerTree {
             self.graph.update_edge(parent_ix, sibling_ix, edge_weight);
             counter += 1;
         }
-        let last_pos = PathBuilder::new(child_pos).active(true).build();
+        let last_pos = Path::new(child_pos, true);
         self.graph.update_edge(parent_ix, child_ix, last_pos);
         self.normalize_edge_weights(parent_ix);
     }
@@ -277,7 +277,7 @@ impl InnerTree {
         self.graph.remove_edge(source_parent_edge);
         let mut highest_weight = self.graph.edges(target)
             .map(|edge| *edge.weight()).max()
-            .unwrap_or(PathBuilder::new(0).build());
+            .unwrap_or(Path::new(0, false));
         highest_weight.weight = *highest_weight + 1;
         self.graph.update_edge(target, source, highest_weight);
         if !self[source].floating() {
@@ -354,7 +354,7 @@ impl InnerTree {
             ShiftDirection::Left => {
                 trace!("place_node edge case: placing in the last place of the sibling list");
                 self.graph.remove_edge(source_parent_edge);
-                let new_weight = PathBuilder::new(siblings.len() as u32 + 1).active(true).build();
+                let new_weight = Path::new(siblings.len() as u32 + 1, true);
                 self.graph.update_edge(target_parent, source, new_weight);
                 self.normalize_edge_weights(target_parent);
                 self.normalize_edge_weights(source_parent);
@@ -375,7 +375,7 @@ impl InnerTree {
                     trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
                 }
                 self.graph.remove_edge(source_parent_edge);
-                let new_weight = PathBuilder::new(1u32).active(true).build();
+                let new_weight = Path::new(1u32, true);
                 self.graph.update_edge(target_parent, source, new_weight);
                 self.normalize_edge_weights(target_parent);
                 self.normalize_edge_weights(source_parent);

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -186,7 +186,6 @@ impl InnerTree {
         } else {
             let mut weight = self.graph.edge_weight_mut(edge)
                 .expect("Could not get edge weight of parent/child");
-            // TODO 1?
             weight.active = 1;
         }
         self.id_map.insert(id, child_ix);
@@ -332,9 +331,8 @@ impl InnerTree {
                 .expect("Could not get the weight of the edge between target sibling and target parent");
             trace!("Sibling {:?} previously had an edge weight of {:?} to {:?}", sibling_ix, weight, target_parent);
             **weight = **weight + 1;
-            // TODO 1?
-            // no this should be the increment thing I think
-            weight.active = 1;
+            // TODO does this work?
+            weight.active += 1;
             trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
         }
         trace!("Removing edge between child {:?} and parent {:?}", source, source_parent);
@@ -379,14 +377,12 @@ impl InnerTree {
                     trace!("Sibling {:?} previously had an edge weight of {:?} to {:?}", sibling_ix, weight, target_parent);
                     **weight = **weight + 1;
                     trace!("Deactivating path {:?}", sibling_edge);
-                    // TODO 1?
-                    // Probably not, cause loop
-                    weight.active = 1;
+                    // TODO does this work?
+                    weight.active += 1;
                     trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
                 }
                 self.graph.remove_edge(source_parent_edge);
-                // TODO 1?
-                let new_weight = Path::new(1u32, 1);
+                let new_weight = Path::new(1u32, 0);
                 self.graph.update_edge(target_parent, source, new_weight);
                 self.normalize_edge_weights(target_parent);
                 self.normalize_edge_weights(source_parent);
@@ -690,8 +686,8 @@ impl InnerTree {
                 .expect("Could not get edge index between parent and child");
             let edge = self.graph.edge_weight_mut(edge_ix)
                 .expect("Could not associate edge index with an edge weight");
-            // TODO 1? Probably not cause loop
-            edge.active = 1;
+            // TODO does this work?
+            edge.active += 1;
         }
         while let Ok(parent_ix) = self.parent_of(node_ix) {
             for child_ix in self.children_of(parent_ix) {
@@ -699,8 +695,8 @@ impl InnerTree {
                     .expect("Could not get edge index between parent and child");
                 let edge = self.graph.edge_weight_mut(edge_ix)
                     .expect("Could not associate edge index with an edge weight");
-                // TODO 1? Probably not cause loop
-                edge.active = 1;
+                // TODO does this work?
+                edge.active += 1;
             }
             let edge_ix = self.graph.find_edge(parent_ix, node_ix)
                 .expect("Could not get edge index between parent and child");

--- a/src/layout/core/path.rs
+++ b/src/layout/core/path.rs
@@ -12,32 +12,14 @@ pub struct Path {
     pub active: bool
 }
 
-/// Builder for `Path`, allows more fields to be added and maintain backwards
-/// compatibility for `Path` construction
-pub struct PathBuilder {
-    path: Path
-}
-
-impl PathBuilder {
-    /// Construct new builder, with the given weight.
-    ///
-    /// Active is set to false automatically
-    pub fn new(weight: u32) -> Self {
-        PathBuilder { path: Path { weight: weight, active: false } }
-    }
-
-    pub fn active(mut self, value: bool) -> Self {
-        self.path.active = value;
-        self
-    }
-
-    pub fn build(self) -> Path {
-        self.path
-    }
-}
-
 impl Path {
-    /// Returns an active path with a weight of zero
+    /// Constructs a new Path, with the given weight and active number.
+    pub fn new(weight: u32, active: bool) -> Self {
+        Path { weight: weight, active: active }
+    }
+
+    /// Returns an active path with a weight of zero and with the active
+    /// bit set to true.
     pub fn zero() -> Self {
         Path { weight: 0, active: true }
     }

--- a/src/layout/core/path.rs
+++ b/src/layout/core/path.rs
@@ -8,20 +8,29 @@ pub struct Path {
     /// The weight used to order this `Path` with other `Paths`.
     pub weight: u32,
     /// A flag to indicate if this path has been active lately.
-    // This allows the tree to 'remember' recently used paths.
-    pub active: bool
+    /// This allows the tree to 'remember' recently used paths.
+    ///
+    /// The closer it is to 0, the more recently it was made active,
+    /// with 0 meaning it is currently the active path.
+    /// e.g 1 means it was just the active path.
+    pub active: u32
 }
 
 impl Path {
     /// Constructs a new Path, with the given weight and active number.
-    pub fn new(weight: u32, active: bool) -> Self {
+    pub fn new(weight: u32, active: u32) -> Self {
         Path { weight: weight, active: active }
     }
 
-    /// Returns an active path with a weight of zero and with the active
-    /// bit set to true.
+    /// Returns an active path with a weight of zero and an active number of 0.
     pub fn zero() -> Self {
-        Path { weight: 0, active: true }
+        Path { weight: 0, active: 0 }
+    }
+
+    /// Determines if the path is active.
+    /// The path is active when self.active == 0
+    pub fn is_active(&self) -> bool {
+        self.active == 0
     }
 }
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -731,6 +731,8 @@ impl LayoutTree {
         while let Some(cur_ix) = next_ix {
             next_ix = None;
             let mut flipped = false;
+            // Ensure that the numbers are unique and atomically increasing.
+            let mut seen = vec![];
             for child_ix in self.tree.children_of(cur_ix) {
                 let weight = *self.tree.get_edge_weight_between(cur_ix, child_ix)
                     .expect("Could not get edge weights between child and parent");
@@ -743,6 +745,13 @@ impl LayoutTree {
                     flipped = true;
                     next_ix = Some(child_ix);
                 }
+                if seen.contains(&weight.active) {
+                    error!("Active number already used!");
+                    error!("Found {:?} in {:?}", weight.active, seen);
+                    trace!("Tree: {:#?}", self);
+                    panic!("Duplicate active number found");
+                }
+                seen.push(weight.active);
             }
             if next_ix.is_none() {
                 match self.tree[cur_ix].get_type() {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -734,11 +734,12 @@ impl LayoutTree {
             for child_ix in self.tree.children_of(cur_ix) {
                 let weight = *self.tree.get_edge_weight_between(cur_ix, child_ix)
                     .expect("Could not get edge weights between child and parent");
-                if weight.active && flipped {
-                    error!("Divergent paths detected!");
-                    trace!("Tree: {:#?}", self);
-                    panic!("Divergent paths detected!");
-                }  else if weight.active {
+                if weight.is_active() {
+                    if flipped {
+                        error!("Divergent paths detected!");
+                        trace!("Tree: {:#?}", self);
+                        panic!("Divergent paths detected!");
+                    }
                     flipped = true;
                     next_ix = Some(child_ix);
                 }


### PR DESCRIPTION
The last active container algorithm should now behave exactly as i3 does (e.g, unlike Sway it remembers what to focus on within in a container's group of siblings).

Still needs to be tested, but preliminary testing seems to imply it works.

Fixes #204 