### PR TITLE
Pointer snap while resizing now configurable

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -39,6 +39,12 @@ way_cooler.windows = {
   }
 }
 
+-- Options that change how the mouse behaves.
+way_cooler.mouse = {
+  -- Locks the mouse to the corner of the window the user is resizing.
+  lock_to_corner_on_resize = false
+}
+
 --
 -- Keybindings
 --

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -72,7 +72,7 @@ pub extern fn view_created(view: WlcView) -> bool {
     let client = lock.client(Uuid::nil()).unwrap();
     let handle = registry::ReadHandle::new(&client);
     let bar = handle.read("programs".into())
-        .expect("layout category didn't exist")
+        .expect("programs category didn't exist")
         .get("x11_bar".into())
         .and_then(|data| data.as_string().map(str::to_string));
     // TODO Move this hack, probably could live somewhere else

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -378,7 +378,7 @@ pub extern fn pointer_motion(view: WlcView, _time: u32, point: &Point) -> bool {
                         match tree.resize_container(active_id, action.edges, *point) {
                             // Return early here to not set the pointer
                             Ok(_) => return EVENT_BLOCKED,
-                            Err(err) => error!("Error: {:#?}", err)
+                            Err(err) => warn!("Could not resize: {:#?}", err)
                         }
                     }
                 }
@@ -387,7 +387,8 @@ pub extern fn pointer_motion(view: WlcView, _time: u32, point: &Point) -> bool {
                     match tree.try_drag_active(*point) {
                         Ok(_) => result = EVENT_BLOCKED,
                         Err(TreeError::PerformingAction(_)) |
-                        Err(TreeError::Movement(MovementError::NotFloating(_))) => result = EVENT_PASS_THROUGH,
+                        Err(TreeError::Movement(MovementError::NotFloating(_))) =>
+                            result = EVENT_PASS_THROUGH,
                         Err(err) => {
                             error!("Error: {:#?}", err);
                             result = EVENT_PASS_THROUGH

--- a/src/layout/actions/pointer.rs
+++ b/src/layout/actions/pointer.rs
@@ -32,6 +32,6 @@ impl LayoutTree {
             origin.y += size.h as i32;
             input::pointer::set_position(origin);
         }
-        Ok((origin))
+        Ok(origin)
     }
 }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -36,5 +36,8 @@ pub fn init() {
         .expect("Could not add windows category");
     // Construct the programs category
     registry.add_category("programs".into())
-        .expect("Could not add windows category");
+        .expect("Could not add programs category");
+    // Construct the mouse category
+    registry.add_category("mouse".into())
+        .expect("Could not add mouse category");
 }


### PR DESCRIPTION
This is primarily a fix for #265 and other pointer issues that necessitated fixes such as #187. Resizing sometimes does not work well if there is mouse snapping done when using Way Cooler straight from a TTY, and the reverse is true when using a login manager such as GDM (e.g mouse snapping makes it work *better*).

In order to mitigate these issues once and for all, and to give the user more options to configure their experience, there is now an option in the configuration file to dictate whether or not the cursor should snap to the edge of the window.

By default, it is false. It is configurable by setting this option:

```
-- Options that change how the mouse behaves.
way_cooler.mouse = {
  -- Locks the mouse to the corner of the window the user is resizing.
  lock_to_corner_on_resize = false
}
```