### PR TITLE
Title borders now update when view title changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ getopts = "0.2"
 cairo-rs = "0.1.1"
 
 [dev-dependencies]
-dummy-rustwlc = "0.6.0"
+dummy-rustwlc = "0.6.1"
 
 [features]
 static-wlc = ["rustwlc/static-wlc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-rustwlc = "0.5.6"
+rustwlc = "0.6.0"
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"
@@ -28,7 +28,7 @@ getopts = "0.2"
 cairo-rs = "0.1.1"
 
 [dev-dependencies]
-dummy-rustwlc = "0.4.4"
+dummy-rustwlc = "0.6.0"
 
 [features]
 static-wlc = ["rustwlc/static-wlc"]

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -165,7 +165,7 @@ pub extern fn view_focus(current: WlcView, focused: bool) {
 pub extern fn view_props_changed(view: WlcView, prop: ViewPropertyType) {
     if prop.contains(PROPERTY_TITLE) {
         if let Ok(mut tree) = try_lock_tree() {
-            match tree.draw_borders(view) {
+            match tree.update_title(view) {
                 Ok(_) => {},
                 Err(err) => {
                     error!("Could not draw border for view {:?} because {:#?}",

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -168,7 +168,7 @@ pub extern fn view_props_changed(view: WlcView, prop: ViewPropertyType) {
             match tree.update_title(view) {
                 Ok(_) => {},
                 Err(err) => {
-                    error!("Could not draw border for view {:?} because {:#?}",
+                    error!("Could not update title for view {:?} because {:#?}",
                            view, err);
                 }
             }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,7 +4,7 @@
 
 use rustwlc::handle::{WlcOutput, WlcView};
 use rustwlc::types::{ButtonState, KeyboardModifiers, KeyState, KeyboardLed, ScrollAxis, Size,
-                     Point, Geometry, ResizeEdge, ViewState,
+                     Point, Geometry, ResizeEdge, ViewState, ViewPropertyType, PROPERTY_TITLE,
                      VIEW_MAXIMIZED, VIEW_ACTIVATED, VIEW_RESIZING, VIEW_FULLSCREEN,
                      MOD_NONE, RESIZE_LEFT, RESIZE_RIGHT, RESIZE_TOP, RESIZE_BOTTOM};
 use rustwlc::input::{pointer, keyboard};
@@ -157,6 +157,20 @@ pub extern fn view_focus(current: WlcView, focused: bool) {
             Ok(_) => {},
             Err(err) => {
                 error!("Could not set {:?} to be active view: {:?}", current, err);
+            }
+        }
+    }
+}
+
+pub extern fn view_props_changed(view: WlcView, prop: ViewPropertyType) {
+    if prop.contains(PROPERTY_TITLE) {
+        if let Ok(mut tree) = try_lock_tree() {
+            match tree.draw_borders(view) {
+                Ok(_) => {},
+                Err(err) => {
+                    error!("Could not draw border for view {:?} because {:#?}",
+                           view, err);
+                }
             }
         }
     }
@@ -447,6 +461,7 @@ pub fn init() {
     callback::view_request_state(view_request_state);
     callback::view_request_move(view_request_move);
     callback::view_request_resize(view_request_resize);
+    callback::view_properties_changed(view_props_changed);
     callback::keyboard_key(keyboard_key);
     callback::pointer_button(pointer_button);
     callback::pointer_scroll(pointer_scroll);

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -389,6 +389,15 @@ impl Tree {
         }
     }
 
+    pub fn update_title(&mut self, view: WlcView) -> CommandResult {
+        let id = try!(self.lookup_view(view)
+                      .map_err(|_|TreeError::ViewNotFound(view)));
+        let container = try!(self.0.lookup_mut(id));
+        container.set_name(Container::get_title(view));
+        container.draw_borders();
+        Ok(())
+    }
+
     /// Sets the view to be the new active container.
     /// Will fail if the container is floating.
     pub fn set_active_view(&mut self, view: WlcView) -> CommandResult {
@@ -545,14 +554,6 @@ impl Tree {
                       .map_err(|_|TreeError::ViewNotFound(view)));
         let container = try!(self.0.lookup_mut(id));
         container.render_borders();
-        Ok(())
-    }
-
-    pub fn draw_borders(&mut self, view: WlcView) -> CommandResult {
-        let id = try!(self.lookup_view(view)
-                      .map_err(|_|TreeError::ViewNotFound(view)));
-        let container = try!(self.0.lookup_mut(id));
-        container.draw_borders();
         Ok(())
     }
 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -547,4 +547,12 @@ impl Tree {
         container.render_borders();
         Ok(())
     }
+
+    pub fn draw_borders(&mut self, view: WlcView) -> CommandResult {
+        let id = try!(self.lookup_view(view)
+                      .map_err(|_|TreeError::ViewNotFound(view)));
+        let container = try!(self.0.lookup_mut(id));
+        container.draw_borders();
+        Ok(())
+    }
 }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -469,18 +469,34 @@ impl Container {
     /// Container::Container: Layout style (e.g horizontal)
     /// Container::View: The name taken from `WlcView`
     pub fn name(&self) -> String {
-        match  *self {
+        match *self {
             Container::Root(_)  => "Root Container".into(),
             Container::Output { handle, .. } => {
                 handle.get_name()
             },
             Container::Workspace { ref name, .. } => name.clone(),
-            Container::Container { layout, .. } => {
-                format!("{:?}", layout)
+            Container::Container { ref borders, layout, .. } => {
+                borders.as_ref().map(|b| b.title().into())
+                    .unwrap_or_else(|| format!("{:?}", layout))
             },
             Container::View { handle, ..} => {
-                handle.get_title()
+                Container::get_title(handle)
             }
+        }
+    }
+
+    pub fn set_name(&mut self, new_name: String) {
+        let c_type = self.get_type();
+        match *self {
+            Container::View { ref mut borders, .. } |
+            Container::Container { ref mut borders, .. } => {
+                borders.as_mut().map(|b| b.title = new_name);
+            },
+            Container::Workspace { ref mut name, .. } => {
+                *name = new_name;
+            },
+            _ => warn!("Tried to set name of {:?} to {}",
+                       c_type, new_name)
         }
     }
 


### PR DESCRIPTION
Whenever the name property updates, the borders are now immediately redrawn.

This also opens up the possibility to rename workspaces, though currently this feature is not implemented.

Borders still do not store the view they are attached to, in order to remain flexible for the future. This means if necessary it is also possible to specify a title for a window that isn't controlled by the window itself. However, this feature is also not implemented but could be if there is enough interest in it (and would probably be exposed via D-Bus).