### PR TITLE
Possible layout feature: Scrollable tiling (don't merge)

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -138,7 +138,7 @@ pub extern fn view_created(view: WlcView) -> bool {
     }
     if let Ok(mut tree) = lock_tree() {
         let result = tree.add_view(view).and_then(|_| {
-            view.set_state(VIEW_MAXIMIZED, true);
+            // view.set_state(VIEW_MAXIMIZED, true);
             match tree.set_active_view(view) {
                 // If blocked by fullscreen, we don't focus on purpose
                 Err(TreeError::Focus(FocusError::BlockedByFullscreen(_, _))) => Ok(()),

--- a/src/ipc/layout.rs
+++ b/src/ipc/layout.rs
@@ -54,6 +54,7 @@ dbus_interface! {
         // TODO Tree commands need to have these defined on the Tree,
         // for now this is _ok_, but we are swallowing an potential Tree lock error here.
         match axis {
+            Layout::Scroll => layout_cmd::split_horizontal(),
             Layout::Horizontal => layout_cmd::split_horizontal(),
             Layout::Vertical => layout_cmd::split_vertical()
         }

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -85,6 +85,8 @@ impl LayoutTree {
         match self.tree[parent_ix] {
             Container::Container { layout, .. } => {
                 match (layout, direction) {
+                    (Layout::Scroll, Direction::Left) |
+                    (Layout::Scroll, Direction::Right) |
                     (Layout::Horizontal, Direction::Left) |
                     (Layout::Horizontal, Direction::Right) |
                     (Layout::Vertical, Direction::Up) |

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -339,13 +339,14 @@ impl LayoutTree {
                     let node_c =  &self.tree[node_ix];
                     geometry_c = node_c.get_geometry()
                         .expect("Had no geometry");
-                    match *node_c {
-                        Container::View { handle, .. } => {
-                            resolution = handle.get_output().get_resolution()
-                                .expect("Output had no resolution");
-                        }
+                    let output_ix = self.tree.ancestor_of_type(node_ix, ContainerType::Output)
+                                         .expect("Node had no output parent");
+                    resolution = match self.tree[output_ix] {
+                        Container::Output { handle, .. } => {
+                            handle.get_resolution().expect("Output had no resolution")
+                        },
                         _ => return
-                    }
+                    };
                 }
                 let x = geometry_c.origin.x;
                 let mut new_geometry = geometry_p.clone();
@@ -368,7 +369,8 @@ impl LayoutTree {
                 }
 
             }
-            _ => {}
+            // Try to scroll the parent into view
+            _ => { &self.scroll_into_view(parent_ix); }
         }
     }
 

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -311,6 +311,17 @@ impl LayoutTree {
         }
         match layout_p {
             Layout::Scroll => {
+                // How much of the prev/next container should be visible
+                let overlap = {
+                    let children = self.tree.grounded_children(parent_ix);
+                    if children.len() > 0 && (children[0] == node_ix
+                         || children[children.len() - 1] == node_ix) {
+                            0 /* Don't show the background (showing the background
+                                 incidentially seem to cause some rendering bugs) */
+                        } else {
+                            25
+                        }
+                };
                 let resolution;
                 let geometry_c;
                 {
@@ -330,7 +341,7 @@ impl LayoutTree {
                 if x < 0 {
                     new_geometry = Geometry {
                         origin: Point {
-                            x: geometry_p.origin.x - x,
+                            x: geometry_p.origin.x - x + overlap,
                             y: geometry_p.origin.y
                         },
                         size: geometry_p.size.clone()
@@ -341,7 +352,7 @@ impl LayoutTree {
                 } else if x as u32 + geometry_c.size.w > resolution.w {
                     new_geometry = Geometry {
                         origin: Point {
-                            x: geometry_p.origin.x - x
+                            x: geometry_p.origin.x - x - overlap
                                 + (resolution.w as i32 - geometry_c.size.w as i32),
                             y: geometry_p.origin.y
                         },

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -337,27 +337,15 @@ impl LayoutTree {
                     }
                 }
                 let x = geometry_c.origin.x;
-                let new_geometry;
+                let mut new_geometry = geometry_p.clone();
                 if x < 0 {
-                    new_geometry = Geometry {
-                        origin: Point {
-                            x: geometry_p.origin.x - x + overlap,
-                            y: geometry_p.origin.y
-                        },
-                        size: geometry_p.size.clone()
-                    };
+                    new_geometry.origin.x = geometry_p.origin.x - x + overlap;
                     let mut fullscreen_apps = Vec::new();
                     self.layout_helper(parent_ix, new_geometry, &mut fullscreen_apps);
                 // x >= 0 so as u32 is safe
                 } else if x as u32 + geometry_c.size.w > resolution.w {
-                    new_geometry = Geometry {
-                        origin: Point {
-                            x: geometry_p.origin.x - x - overlap
-                                + (resolution.w as i32 - geometry_c.size.w as i32),
-                            y: geometry_p.origin.y
-                        },
-                        size: geometry_p.size.clone()
-                    };
+                    new_geometry.origin.x = geometry_p.origin.x - x - overlap
+                        + (resolution.w as i32 - geometry_c.size.w as i32);
                     let mut fullscreen_apps = Vec::new();
                     self.layout_helper(parent_ix, new_geometry, &mut fullscreen_apps);
                 }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -61,7 +61,8 @@ impl ContainerType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Layout {
     Horizontal,
-    Vertical
+    Vertical,
+    Scroll
 }
 
 /// Represents an item in the container tree.
@@ -156,7 +157,7 @@ impl Container {
     /// Creates a new container
     pub fn new_container(geometry: Geometry) -> Container {
         Container::Container {
-            layout: Layout::Horizontal,
+            layout: Layout::Scroll,
             floating: false,
             fullscreen: false,
             geometry: geometry,

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -216,6 +216,7 @@ impl LayoutTree {
         self.tree[node_ix].active_border_color()
             .expect("Could set active border color");
         self.active_container = Some(node_ix);
+        self.scroll_into_view(node_ix);
         let c_type; let id;
         {
             let container = &self.tree[node_ix];


### PR DESCRIPTION
Hi, I've made a working mockup of what could be called scrollable tiling. Here's a concept picture:

![scrollable-container](https://cloud.githubusercontent.com/assets/71978/24581086/d2fa6e28-1714-11e7-9608-3cf2a92f7f94.jpeg)

It's just a wide container which scrolls the active window into view.

My brother (@olejorgenb) and I have been using a [prototype in Notion](https://github.com/olejorgenb/notion/tree/paper-wm) for a while now, and would like to find a home for the concept in Wayland.

We often found ourselves using several workspaces for a single project since a workspace isn't all that big. A workspace grid where each row is a named group is a natural solution to this problem, but grids are hard to navigate and forces you to artificial screen sized groupings. Merging the row into a scrollable strip is a much cleaner solution with less limitations. This way you'll always have space for a new window without having to worry about how it affects the rest of the layout. We think it gives a lot of the freedom with floating windows, but with the structure of tiling.

To test out it just pull and cargo build. I've hardcoded the Scroll layout as default, so just spawn a bunch of terminals (hardcoded to 500px wide at the moment) and use `meta+left/right` to move around as usual.

So yeah, wondering if you're interested in having support for something like this in Way-cooler?

(Edit: there's a few rendering bugs and a bunch of failed tests, but should give you an idea of the concept)