### PR TITLE
Add Redshift support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -447,6 +448,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wayland-scanner"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +473,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xml-rs"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
@@ -523,6 +540,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d00f09fd9ed6ff158ca265f8df240f8ee052fbe10def3bfd48750fd0ef37669a"
 "checksum wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a6dd94a0fbbd2fa8fdcd95466d602284743adff37dde0250ad1c71f5b60eeeb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "cairo-rs 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dummy-rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dummy-rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,11 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dummy-rustwlc"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -526,7 +527,7 @@ dependencies = [
 "checksum dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1e013b945c57472e5c016f3695114b00c774f03feed9b03df78a9759bb42beb"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
-"checksum dummy-rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "89a33bab553d8c640d236fc241f187409cbe80f5ee0d06410b723ba67840752e"
+"checksum dummy-rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "11dc11a78bd7081ca9122944f00500c57674ab40b35aca12ba07d4158dda410d"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,17 +6,17 @@ dependencies = [
  "cairo-rs 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dummy-rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dummy-rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustwlc 0.6.1",
+ "rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-server 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -105,7 +105,7 @@ name = "dlib"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libloading 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dummy-rustwlc"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -221,11 +221,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libloading"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -284,7 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ordermap"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -293,7 +293,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -327,7 +327,7 @@ name = "phf_shared"
 version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "siphasher 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -375,7 +375,8 @@ dependencies = [
 
 [[package]]
 name = "rustwlc"
-version = "0.6.1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -389,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -400,12 +401,12 @@ dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -489,7 +490,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -525,7 +526,7 @@ dependencies = [
 "checksum dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1e013b945c57472e5c016f3695114b00c774f03feed9b03df78a9759bb42beb"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
-"checksum dummy-rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79471193a628ca27e1c224f4f809d24befee9579d7ea57272a34d9babaf59853"
+"checksum dummy-rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "89a33bab553d8c640d236fc241f187409cbe80f5ee0d06410b723ba67840752e"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
@@ -537,16 +538,16 @@ dependencies = [
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cae828a10b461ca79f7a1e366e4aead4c4bd8fc9c39a57546c39cbda8ee3a0c1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
+"checksum lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4732c563b9a21a406565c4747daa7b46742f082911ae4753f390dc9ec7ee1a97"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
-"checksum libloading 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fd1835a714c1f67ba073a493493c23686a480e2614e208c921834808b1f19d8f"
+"checksum libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a020ac941774eb37e9d13d418c37b522e76899bfc4e7b1a600d529a53f83a66"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum lua52-sys 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bb32f267c555c38517c56ae28a84838ebb484ed2ac0d3c724245c95e9dfd871e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
 "checksum nix 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "314a973a94409e39b78fa3a9cfb4ec4831791879079af087f64bf01394dc6c03"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum ordermap 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fdaf30b4edcc481e006518450305ada0149955758851ac87b78128bfbfdf310b"
+"checksum ordermap 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "06e5d34d852e6396cf5fceaa24313f753d960a3b7e3abdadcdf43730e791aa3d"
 "checksum petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "28814c774eeabfe38b20e1651f9e9a5ff6efeb3b2a66df25e056f579051ee4b3"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
@@ -558,10 +559,11 @@ dependencies = [
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1bc415a8f138e6a231c7f9ff696eb2f98ac13d2aeda1a30bc7ec2fe5b36133f1"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a702319c807c016e51f672e5c77d6f0b46afddd744b5e437d6b8436b888b458f"
+"checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
 "checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
-"checksum siphasher 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ffc669b726f2bc9a3bcff66e5e23b56ba6bf70e22a34c3d7b6d0b3450b65b84"
+"checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f42dc058080c19c6a58bdd1bf962904ee4f5ef1fe2a81b529f31dacc750c679f"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustwlc 0.6.1",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-server 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -376,7 +376,6 @@ dependencies = [
 [[package]]
 name = "rustwlc"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -559,7 +558,6 @@ dependencies = [
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8843ac13ec51c08c79371e7ce9942bde922431568d1399bd135c25b294c30fcd"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a702319c807c016e51f672e5c77d6f0b46afddd744b5e437d6b8436b888b458f"
 "checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,8 @@ dependencies = [
  "rustwlc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-server 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -210,11 +211,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -267,6 +263,17 @@ dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -373,6 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -456,12 +464,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-server"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -508,7 +538,6 @@ dependencies = [
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cae828a10b461ca79f7a1e366e4aead4c4bd8fc9c39a57546c39cbda8ee3a0c1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum libloading 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fd1835a714c1f67ba073a493493c23686a480e2614e208c921834808b1f19d8f"
@@ -516,6 +545,7 @@ dependencies = [
 "checksum lua52-sys 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bb32f267c555c38517c56ae28a84838ebb484ed2ac0d3c724245c95e9dfd871e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
+"checksum nix 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "314a973a94409e39b78fa3a9cfb4ec4831791879079af087f64bf01394dc6c03"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum ordermap 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fdaf30b4edcc481e006518450305ada0149955758851ac87b78128bfbfdf310b"
 "checksum petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "28814c774eeabfe38b20e1651f9e9a5ff6efeb3b2a66df25e056f579051ee4b3"
@@ -541,7 +571,9 @@ dependencies = [
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wayland-scanner 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d00f09fd9ed6ff158ca265f8df240f8ee052fbe10def3bfd48750fd0ef37669a"
+"checksum wayland-server 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28b7efabb5c3d5f227784c2801da81c004681def688e797cbaaf9899067dc261"
 "checksum wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a6dd94a0fbbd2fa8fdcd95466d602284743adff37dde0250ad1c71f5b60eeeb"
+"checksum wayland-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "850a106fc706e136794d852cdd7887b76088e765e28446e6c41790ef8b796281"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-rustwlc = "0.6.1"
+rustwlc = { version = "0.6.1", features = ["wlc-wayland"] }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"
@@ -23,7 +23,8 @@ rustc-serialize = "0.3"
 json_macro = "0.1"
 nix = "0.6"
 uuid = { version = "0.3", features = ["v4", "rustc-serialize"]}
-wayland-sys = { version = "^0.6.0", features = ["client", "dlopen"] }
+wayland-sys = { version = "0.9.1", features = ["client", "dlopen"] }
+wayland-server = { version = "0.9.1" }
 getopts = "0.2"
 cairo-rs = "0.1.1"
 
@@ -31,7 +32,7 @@ cairo-rs = "0.1.1"
 dummy-rustwlc = "0.6.1"
 
 [build-dependencies]
-wayland-scanner = { version = "~0.9.1" }
+wayland-scanner = { version = "0.9.1" }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-rustwlc = { path = "../rust-wlc", features = ["wlc-wayland"] }
+rustwlc = { version = "0.6.2", features = ["wlc-wayland"] }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ cairo-rs = "0.1.1"
 [dev-dependencies]
 dummy-rustwlc = "0.6.1"
 
+[build-dependencies]
+wayland-scanner = { version = "~0.9.1" }
+
+
 [features]
 static-wlc = ["rustwlc/static-wlc"]
 disable-debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ getopts = "0.2"
 cairo-rs = "0.1.1"
 
 [dev-dependencies]
-dummy-rustwlc = "0.6.1"
+dummy-rustwlc = "0.6.3"
 
 [build-dependencies]
 wayland-scanner = { version = "0.9.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-rustwlc = { version = "0.6.1", features = ["wlc-wayland"] }
+rustwlc = { path = "../rust-wlc", features = ["wlc-wayland"] }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -66,7 +66,10 @@ fn generate_wayland_protocols() {
     for protocol_path in protocols {
         let protocol_path: fs::DirEntry = protocol_path.unwrap();
         let path: PathBuf = protocol_path.path().into();
-        let file_name: String = protocol_path.file_name().into_string().unwrap();
+        let mut file_name: String = protocol_path.file_name().into_string().unwrap();
+        if let Some(extension) = file_name.find(".xml") {
+            file_name.truncate(extension);
+        }
         generate_code(
             path.clone(),
             out_dir.join(file_name.clone() + "_api.rs"),

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,16 @@
+extern crate wayland_scanner;
+
+use wayland_scanner::{Side, generate_code, generate_interfaces};
+
 use std::env;
 use std::process::Command;
-use std::fs::File;
+use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
     dump_git_version();
+    generate_wayland_protocols();
 }
 
 /// Writes the current git hash to a file that is read by Way Cooler
@@ -15,7 +20,7 @@ fn dump_git_version() {
     let out_dir = env::var("OUT_DIR")
         .expect("Could not find out directory!");
     let dest_path = Path::new(&out_dir).join("git-version.txt");
-    let mut f = File::create(&dest_path)
+    let mut f = fs::File::create(&dest_path)
         .expect("Could not write git version to out directory");
     if let Some(git_version) = git_version() {
         f.write_all(git_version.as_ref())
@@ -49,4 +54,27 @@ fn in_release_commit() -> bool {
         .arg("HEAD")
         .output().unwrap();
     result.status.success()
+}
+
+
+fn generate_wayland_protocols() {
+    let protocols = fs::read_dir("./protocols")
+        .expect("No <Way Cooler>/protocols/ directory");
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir);
+
+    for protocol_path in protocols {
+        let protocol_path: fs::DirEntry = protocol_path.unwrap();
+        let path: PathBuf = protocol_path.path().into();
+        let file_name: String = protocol_path.file_name().into_string().unwrap();
+        generate_code(
+            path.clone(),
+            out_dir.join(file_name.clone() + "_api.rs"),
+            Side::Server
+        );
+        generate_interfaces(
+            path,
+            out_dir.join(file_name + "_interface.rs")
+        );
+    }
 }

--- a/protocols/gamma-control.xml
+++ b/protocols/gamma-control.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="gamma_control">
+
+    <copyright>
+        Copyright © 2015 Giulio camuffo
+
+        Permission to use, copy, modify, distribute, and sell this
+        software and its documentation for any purpose is hereby granted
+        without fee, provided that the above copyright notice appear in
+        all copies and that both that copyright notice and this permission
+        notice appear in supporting documentation, and that the name of
+        the copyright holders not be used in advertising or publicity
+        pertaining to distribution of the software without specific,
+        written prior permission.  The copyright holders make no
+        representations about the suitability of this software for any
+        purpose.  It is provided "as is" without express or implied
+        warranty.
+
+        THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+        SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+        WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+        AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+        ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+        THIS SOFTWARE.
+    </copyright>
+
+    <interface name="gamma_control_manager" version="1">
+        <request name="destroy" type="destructor"/>
+
+        <request name="get_gamma_control">
+            <arg name="id" type="new_id" interface="gamma_control"/>
+            <arg name="output" type="object" interface="wl_output"/>
+        </request>
+    </interface>
+
+    <interface name="gamma_control" version="1">
+        <enum name="error">
+            <entry name="invalid_gamma" value="0"/>
+        </enum>
+
+        <request name="destroy" type="destructor"/>
+
+        <request name="set_gamma">
+            <arg name="red" type="array"/>
+            <arg name="green" type="array"/>
+            <arg name="blue" type="array"/>
+        </request>
+
+        <request name="reset_gamma"/>
+
+        <event name="gamma_size">
+            <arg name="size" type="uint"/>
+        </event>
+    </interface>
+</protocol>

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@
 
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
 extern crate bitflags;
-#[macro_use]
 extern crate dbus_macros;
 #[cfg(not(test))]
 extern crate rustwlc;
@@ -14,10 +12,8 @@ extern crate dummy_rustwlc as rustwlc;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-#[macro_use]
 extern crate hlua;
 extern crate rustc_serialize;
-#[macro_use]
 extern crate json_macro;
 extern crate nix;
 extern crate petgraph;
@@ -26,7 +22,6 @@ extern crate dbus;
 extern crate cairo;
 #[macro_use]
 extern crate wayland_sys;
-#[macro_use]
 extern crate wayland_server;
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ extern crate petgraph;
 extern crate uuid;
 extern crate dbus;
 extern crate cairo;
+#[macro_use]
+extern crate wayland_sys;
+#[macro_use]
+extern crate wayland_server;
 
 #[macro_use]
 mod macros;
@@ -40,6 +44,8 @@ mod ipc;
 mod layout;
 
 mod render;
+
+mod wayland;
 
 use std::env;
 use std::fs::File;
@@ -184,6 +190,7 @@ fn main() {
     // This prepares wlc, doesn't run main loop until run_wlc is called
     let run_wlc = rustwlc::init()
         .expect("Unable to initialize wlc!");
+    wayland::init_wayland_protocols();
     rustwlc::log_set_rust_handler(log_handler);
     callbacks::init();
     commands::init();

--- a/src/wayland/gamma_control.rs
+++ b/src/wayland/gamma_control.rs
@@ -1,13 +1,38 @@
-//pub use self::generated::server::gamma_control_manager as gamma_control;
+//! Module that defines the bindings for the patched redshift protocol.
+//! See https://github.com/giucam/redshift/blob/master/src/gamma-control.xml
+//! and https://github.com/jonls/redshift/issues/55
+//! for more information about the spec and its status in regards to upstream.
 pub use wayland::gamma_control::generated
     ::server::gamma_control::{GammaControl, Handler as GammaControlHandler};
 pub use wayland::gamma_control::generated
     ::server::gamma_control_manager::{GammaControlManager, Handler as ManagerHandler};
+use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
+use rustwlc::render::{wlc_output_set_gamma, wlc_output_get_gamma_size};
+use wayland_server::Resource;
+use wayland_sys::common::{wl_array};
+use wayland_sys::server::{WAYLAND_SERVER_HANDLE, wl_client, wl_resource};
+use std::os::raw::c_void;
+use nix::libc::{c_int, c_uint, uint32_t, uint16_t};
+use std::sync::{Mutex};
 
-use wayland_server::{EventLoopHandle, Client};
-use wayland_server::protocol::{wl_output};
+static SET_GAMMA_ERROR: &'static str = "The gamma ramps don't have the same size!";
+static INVALID_GAMMA_CODE: u32 = 0;
 
+lazy_static!(
+    static ref GAMMA_CONTROL_MANAGER: Mutex<GammaControlManagerInterface> =
+        Mutex::new(GammaControlManagerInterface {
+            destroy: destroy,
+            get_gamma_control: get_gamma_control
+        });
+    static ref GAMMA_CONTROL: Mutex<GammaControlInterface> =
+        Mutex::new(GammaControlInterface {
+            destroy: destroy,
+            set_gamma: set_gamma,
+            reset_gamma: reset_gamma
+        });
+);
 
+/// Generated modules from the XML protocol spec.
 mod generated {
     // Generated code generally doesn't follow standards
     #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
@@ -32,79 +57,141 @@ mod generated {
     }
 }
 
-pub struct GammaHandler {}
-pub struct GammaManagerHandler {}
-
-impl GammaManagerHandler {
-    pub fn new() -> Self {
-        GammaManagerHandler {}
-    }
+#[repr(C)]
+/// Controls access to the gamma control interface.
+/// Right now we let anyone through that wants to access it, but this
+/// will allow us to limit who access to it in the future.
+pub struct GammaControlManagerInterface {
+    destroy: unsafe extern "C" fn (client: *mut wl_client,
+                                   resource: *mut wl_resource),
+    get_gamma_control: unsafe extern "C" fn (client: *mut wl_client,
+                                             resource: *mut wl_resource,
+                                             id: u32,
+                                             output: *mut wl_resource)
 }
 
-impl ManagerHandler for GammaManagerHandler {
-    fn get_gamma_control(&mut self,
-                         evqh: &mut EventLoopHandle,
-                         client: &Client,
-                         resource: &GammaControlManager,
-                         id: super::gamma_control::GammaControl,
-                         output: &wl_output::WlOutput) {
-        error!("Trying to get gamma control");
-        println!("Trying to get gamma control");
-        println!("HEEEREEE");
-        //panic!()
-    }
-
-    fn destroy(&mut self,
-               evqh: &mut EventLoopHandle,
-               client: &Client,
-               resource: &GammaControlManager) {
-        error!("Destroyed the manager!");
-        //panic!()
-    }
+#[repr(C)]
+/// The interface that allows a client to control the gamma ramps.
+pub struct GammaControlInterface {
+    destroy: unsafe extern "C" fn (client: *mut wl_client,
+                                   resource: *mut wl_resource),
+    set_gamma: unsafe extern "C" fn (client: *mut wl_client,
+                                     resource: *mut wl_resource,
+                                     red: *mut wl_array,
+                                     green: *mut wl_array,
+                                     blue: *mut wl_array),
+    reset_gamma: unsafe extern "C" fn (client: *mut wl_client,
+                                       resource: *mut wl_resource)
 }
 
-impl GammaHandler {
-    pub fn new() -> Self {
-        GammaHandler {}
+/// Sets the gamma to the provided values.
+/// If the sizes of the arrays are not all the same,
+/// nothing is done and we post an error to the client
+/// through the Wayland IPC.
+unsafe extern "C" fn set_gamma(_client: *mut wl_client,
+                               resource: *mut wl_resource,
+                               red: *mut wl_array,
+                               green: *mut wl_array,
+                               blue: *mut wl_array) {
+    debug!("Setting gamma");
+    if (*red).size != (*green).size || (*red).size != (*blue).size {
+        ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_post_error,
+            resource,
+            INVALID_GAMMA_CODE,
+            SET_GAMMA_ERROR.as_bytes().as_ptr() as *const i8);
+        warn!("Color size error, can't continue");
+        return
     }
+    let r = (*red).data as *mut u16;
+    let g = (*green).data as *mut u16;
+    let b = (*blue).data as *mut u16;
+    let user_data = ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_get_user_data,
+        resource) as *const _;
+    let output = WlcOutput(wlc_handle_from_wl_output_resource(user_data));
+    // TODO Make this less stupid to check if it's a null index
+    if output.as_view().is_root() {
+        warn!("wl_resource didn't correspond to a wlc output");
+        return;
+    }
+    wlc_output_set_gamma(output.0, ((*red).size / 2) as u16, r, g, b)
+
 }
 
-impl GammaControlHandler for GammaHandler {
-    fn set_gamma(&mut self,
-                 evqh: &mut EventLoopHandle,
-                 client: &Client,
-                 resource: &GammaControl,
-                 red: Vec<u8>,
-                 green: Vec<u8>,
-                 blue: Vec<u8>) {
-        error!("Hey look you set the gamma to {:?} {:?} {:?}", red, green, blue);
-        panic!()
-    }
+/// Resets the gamma to the original value set by the hardware.
+/// This action is performed properly by `set_gamma`, so method only
+/// logs that the action occured.
+unsafe extern "C" fn reset_gamma(_client: *mut wl_client,
+                                 _resource: *mut wl_resource) {
+    debug!("Resetting gamma");
 }
 
-use wayland_sys::server::*;
-use wayland_server::Resource;
-use std::os::raw::c_void;
-use super::{GAMMA_CONTROL, GAMMA_CONTROL_MANAGER};
-use nix::libc::c_int;
+/// Destroys the wl_resource.
+unsafe extern "C" fn destroy(_client: *mut wl_client,
+                             resource: *mut wl_resource) {
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_destroy,
+        resource
+    );
+}
+
+/// The method that is called when a client attempts to access the gamma
+/// control interface. If successful, this method grants access by
+/// setting the implementation of the passed in wl_resource to the gamma
+/// control singleton and responding to the client with the size of the gamma
+/// ramps for the specified output.
+unsafe extern "C" fn get_gamma_control(client: *mut wl_client,
+                                       _resource: *mut wl_resource,
+                                       id: uint32_t,
+                                       output: *mut wl_resource) {
+    debug!("Request received for control of the gamma ramps");
+    let manager_resource = ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_create,
+        client,
+        GammaControl::interface_ptr(),
+        GammaControl::supported_version() as i32,
+        id);
+    let wlc_output = WlcOutput(wlc_handle_from_wl_output_resource(output as *const _));
+    // TODO Make this less stupid to check if it's a null index
+    if wlc_output.as_view().is_root() {
+        warn!("This is triggering, dis bad?");
+        return;
+    }
+    debug!("Client requested control of the gamma ramps for {:?}", wlc_output);
+    let mut gamma_control = GAMMA_CONTROL.try_lock().unwrap();
+    let gamma_control_ptr = &mut *gamma_control as *mut _ as *mut c_void;
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_set_implementation,
+        manager_resource,
+        gamma_control_ptr,
+        output as *mut c_void,
+        None
+    );
+    debug!("Request granted for gamma ramp control of {:?}", wlc_output);
+    gamma_control_send_gamma_size(manager_resource,
+                                  wlc_output_get_gamma_size(wlc_output.0))
+}
 
 /// Binds the handler to a new Wayland resource, created by the client.
 /// See https://github.com/vberger/wayland-rs/blob/451ccab330b3d0ec18eaaf72ae17ac35cf432370/wayland-server/src/event_loop.rs#L617
 /// to see where I got this particular bit of magic from.
 pub unsafe extern "C" fn bind(client: *mut wl_client,
-                              data: *mut c_void,
+                              _data: *mut c_void,
                               version: u32,
                               id: u32) {
-    // Initialize the gamma control manager, which manages the gamma control.
-    error!("BINDING HERE!");
-    println!("BINDING HERE");
+    debug!("Binding Gamma Control resource");
     let cur_version = GammaControlManager::supported_version();
     if version > cur_version {
         warn!("Unsupported gamma control protocol version {}!", version);
         warn!("We only support version {}", cur_version);
         return
     }
-    error!("Making resource");
     let resource = ffi_dispatch!(
         WAYLAND_SERVER_HANDLE,
         wl_resource_create,
@@ -114,26 +201,34 @@ pub unsafe extern "C" fn bind(client: *mut wl_client,
         id
     );
     if resource.is_null() {
+        warn!("Out of memory, could not make a new wl_resource \
+               for gamma control");
         ffi_dispatch!(
             WAYLAND_SERVER_HANDLE,
             wl_client_post_no_memory,
             client
         );
     }
-    error!("Resource made");
-    println!("Resource made");
     let mut manager = GAMMA_CONTROL_MANAGER.try_lock().unwrap();
     let global_manager_ptr = &mut *manager as *mut _ as *mut c_void;
-    error!("Setting impl");
     ffi_dispatch!(
         WAYLAND_SERVER_HANDLE,
         wl_resource_set_implementation,
         resource,
-        // This is safe because our lazy static won't move anywhere
         global_manager_ptr,
         ::std::ptr::null_mut(),
         None
     );
-    error!("Impl set");
-    println!("Impl set");
 }
+
+/// Send the size of the gamma ramps of the output specified by the wl_resource
+/// to the client.
+unsafe extern "C" fn gamma_control_send_gamma_size(resource: *mut wl_resource,
+                                                   size: uint16_t) {
+    ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                  wl_resource_post_event,
+                  resource,
+                  0,
+                  size as c_uint);
+}
+

--- a/src/wayland/gamma_control.rs
+++ b/src/wayland/gamma_control.rs
@@ -48,7 +48,9 @@ impl ManagerHandler for GammaManagerHandler {
                          resource: &GammaControlManager,
                          id: super::gamma_control::GammaControl,
                          output: &wl_output::WlOutput) {
-        error!("Tried to get gamma control");
+        error!("Trying to get gamma control");
+        println!("Trying to get gamma control");
+        println!("HEEEREEE");
         //panic!()
     }
 

--- a/src/wayland/gamma_control.rs
+++ b/src/wayland/gamma_control.rs
@@ -1,0 +1,132 @@
+//pub use self::generated::server::gamma_control_manager as gamma_control;
+pub use wayland::gamma_control::generated
+    ::server::gamma_control::{GammaControl, Handler as GammaControlHandler};
+pub use wayland::gamma_control::generated
+    ::server::gamma_control_manager::{GammaControlManager, Handler as ManagerHandler};
+
+use wayland_server::{EventLoopHandle, Client};
+use wayland_server::protocol::{wl_output};
+
+
+mod generated {
+    // Generated code generally doesn't follow standards
+    #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
+    #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
+
+    pub mod interfaces {
+        #[doc(hidden)]
+        pub use wayland_server::protocol_interfaces::{wl_output_interface};
+        include!(concat!(env!("OUT_DIR"), "/gamma-control_interface.rs"));
+    }
+
+    pub mod server {
+        #[doc(hidden)]
+        pub use wayland_server::{Resource, Handler,
+                                 Client, Liveness,
+                                 EventLoopHandle, EventResult};
+        #[doc(hidden)]
+        pub use wayland_server::protocol::{wl_output};
+        #[doc(hidden)]
+        pub use super::interfaces;
+        include!(concat!(env!("OUT_DIR"), "/gamma-control_api.rs"));
+    }
+}
+
+pub struct GammaHandler {}
+pub struct GammaManagerHandler {}
+
+impl GammaManagerHandler {
+    pub fn new() -> Self {
+        GammaManagerHandler {}
+    }
+}
+
+impl ManagerHandler for GammaManagerHandler {
+    fn get_gamma_control(&mut self,
+                         evqh: &mut EventLoopHandle,
+                         client: &Client,
+                         resource: &GammaControlManager,
+                         id: super::gamma_control::GammaControl,
+                         output: &wl_output::WlOutput) {
+        error!("Tried to get gamma control");
+        //panic!()
+    }
+
+    fn destroy(&mut self,
+               evqh: &mut EventLoopHandle,
+               client: &Client,
+               resource: &GammaControlManager) {
+        error!("Destroyed the manager!");
+        //panic!()
+    }
+}
+
+impl GammaHandler {
+    pub fn new() -> Self {
+        GammaHandler {}
+    }
+}
+
+impl GammaControlHandler for GammaHandler {
+    fn set_gamma(&mut self,
+                 evqh: &mut EventLoopHandle,
+                 client: &Client,
+                 resource: &GammaControl,
+                 red: Vec<u8>,
+                 green: Vec<u8>,
+                 blue: Vec<u8>) {
+        error!("Hey look you set the gamma to {:?} {:?} {:?}", red, green, blue);
+        panic!()
+    }
+}
+
+use wayland_sys::server::*;
+use wayland_server::Resource;
+use std::os::raw::c_void;
+use super::{GAMMA_CONTROL, GAMMA_CONTROL_MANAGER};
+
+/// Binds the handler to a new Wayland resource, created by the client.
+/// See https://github.com/vberger/wayland-rs/blob/451ccab330b3d0ec18eaaf72ae17ac35cf432370/wayland-server/src/event_loop.rs#L617
+/// to see where I got this particular bit of magic from.
+pub unsafe extern "C" fn bind(client: *mut wl_client,
+                              data: *mut c_void,
+                              version: u32,
+                              id: u32) {
+    // Initialize the gamma control manager, which manages the gamma control.
+    error!("BINDING HERE!");
+    println!("BINDING HERE");
+    let cur_version = GammaControlManager::supported_version();
+    if version > cur_version {
+        warn!("Unsupported gamma control protocol version {}!", version);
+        warn!("We only support version {}", cur_version);
+    }
+    error!("Making resource");
+    let resource = ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_create,
+        client,
+        GammaControlManager::interface_ptr(),
+        cur_version as i32,
+        id
+    );
+    error!("Resource made");
+    println!("Resource made");
+    let mut manager = GAMMA_CONTROL_MANAGER.try_lock().unwrap();
+    let global_manager_ptr = &mut *manager as *mut _ as *mut c_void;
+    error!("Setting impl");
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_set_implementation,
+        resource,
+        // TODO IMPORTANT need to be a pointer to our lazy static
+        // This is safe because our lazy static won't move anywhere
+        global_manager_ptr,
+        ::std::ptr::null_mut(),
+        None
+    );
+    error!("Impl set");
+    println!("Impl set");
+    // TODO move to init for manager
+    //let mut gamma = GAMMA_CONTROL.try_lock().unwrap();
+    //let global_gamma_ptr = &mut *gamma as *mut _ as *mut c_void;
+}

--- a/src/wayland/gamma_control.rs
+++ b/src/wayland/gamma_control.rs
@@ -111,8 +111,7 @@ unsafe extern "C" fn set_gamma(_client: *mut wl_client,
         wl_resource_get_user_data,
         resource) as *const _;
     let output = WlcOutput(wlc_handle_from_wl_output_resource(user_data));
-    // TODO Make this less stupid to check if it's a null index
-    if output.as_view().is_root() {
+    if output.is_null() {
         warn!("wl_resource didn't correspond to a wlc output");
         return;
     }
@@ -156,8 +155,7 @@ unsafe extern "C" fn get_gamma_control(client: *mut wl_client,
         GammaControl::supported_version() as i32,
         id);
     let wlc_output = WlcOutput(wlc_handle_from_wl_output_resource(output as *const _));
-    // TODO Make this less stupid to check if it's a null index
-    if wlc_output.as_view().is_root() {
+    if wlc_output.is_null() {
         warn!("This is triggering, dis bad?");
         return;
     }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,24 +1,8 @@
 pub mod gamma_control;
 
-use wayland_server::Resource;
-use wayland_server::sys::WAYLAND_SERVER_HANDLE;
-use rustwlc::wayland;
-use std::ptr;
-
 /// Initializes the appropriate handlers for each wayland protocol
 /// that Way Cooler supports.
 pub fn init_wayland_protocols() {
     debug!("Initializing wayland protocols");
-    let w_display = wayland::get_display();
-    unsafe {
-        debug!("Initializing gamma control manager");
-        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                      wl_global_create,
-                      w_display as *mut _,
-                      gamma_control::GammaControlManager::interface_ptr(),
-                      gamma_control::GammaControlManager::supported_version() as i32,
-                      ptr::null_mut(),
-                      gamma_control::bind
-        );
-    }
+    gamma_control::init();
 }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -80,12 +80,12 @@ unsafe extern "C" fn set_gamma(client: *mut wl_client,
     // TODO Make this less stupid to check if it's a null index
     if output.as_view().is_root() {
         warn!("Output thing was wrong");
-        //return;
+        return;
     }
     debug!("Setting gamma for output {:?}", output);
     warn!("Setting gamma for output {:?}", output);
     error!("Setting gamma for output {:?}", output);
-    wlc_output_set_gamma(output.0, (*red).size as u16 / 16, r, g, b)
+    wlc_output_set_gamma(output.0, ((*red).size / 2) as u16, r, g, b)
 
 }
 unsafe extern "C" fn reset_gamma(client: *mut wl_client,
@@ -95,8 +95,12 @@ unsafe extern "C" fn reset_gamma(client: *mut wl_client,
 
 unsafe extern "C" fn destroy(wl_client: *mut wl_client,
                 resource: *mut wl_resource) {
-    // TODO wl_destroy_resource
-    unimplemented!()
+    warn!("Destroying resource!");
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_destroy,
+        resource
+    );
 }
 
 unsafe extern "C" fn get_gamma_control(client: *mut wl_client,

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,0 +1,39 @@
+pub mod gamma_control;
+
+use std::ptr;
+use wayland_server::Resource;
+use wayland_server::sys::WAYLAND_SERVER_HANDLE;
+use self::gamma_control::{GammaHandler, GammaManagerHandler};
+use rustwlc::wayland;
+
+use std::sync::{Mutex};
+
+lazy_static!(
+    static ref GAMMA_CONTROL_MANAGER: Mutex<GammaManagerHandler> =
+        Mutex::new(GammaManagerHandler::new());
+    static ref GAMMA_CONTROL: Mutex<GammaHandler> =
+        Mutex::new(GammaHandler::new());
+);
+
+/// Initializes the appropriate handlers for each wayland protocol
+/// that Way Cooler supports.
+pub fn init_wayland_protocols() {
+    error!("Initializing wayland protocols");
+    let w_display = wayland::get_display();
+    //declare_handler!(GammaHandler,
+    //                 gamma_control::Handler,
+    //                 gamma_control::GammaControl);
+    unsafe {
+        // Initalize the gamma control manager
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                      wl_global_create,
+                      w_display as *mut _,
+                      gamma_control::GammaControlManager::interface_ptr(),
+                      gamma_control::GammaControlManager::supported_version() as i32,
+                      ptr::null_mut(),
+                      gamma_control::bind
+        );
+    }
+    error!("Created global!");
+    // TODO Doesn't handler get dropped?
+}

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -4,7 +4,9 @@ use std::ptr;
 use wayland_server::Resource;
 use wayland_server::sys::WAYLAND_SERVER_HANDLE;
 use wayland_sys::server::*;
-use self::gamma_control::{GammaHandler, GammaManagerHandler};
+use wayland_sys::common::*;
+use self::gamma_control::{GammaControl, GammaHandler, GammaManagerHandler};
+use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput, WlcView};
 use rustwlc::wayland;
 
 use std::os::raw::c_void;
@@ -13,27 +15,112 @@ use std::ptr::null_mut;
 use std::sync::{Mutex};
 
 // TODO Is this the best way really? Not use anything from the generated file?
+// TODO Move this to gamma_control.rs
+unsafe extern "C" fn gamma_control_send_gamma_size(resource: *mut wl_resource,
+                                                   size: u32) {
+    ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                  wl_resource_post_event,
+                  resource,
+                  0,
+                  size);
+}
 
 #[repr(C)]
 pub struct GammaControlManagerInterface {
-    destroy: extern "C" fn (wl_client: *mut wl_client,
-                            resource: *mut wl_resource),
-    get_gamma_control: extern "C" fn (wl_client: *mut wl_client,
-                                      resource: *mut wl_resource)
+    destroy: unsafe extern "C" fn (client: *mut wl_client,
+                                   resource: *mut wl_resource),
+    get_gamma_control: unsafe extern "C" fn (client: *mut wl_client,
+                                             resource: *mut wl_resource,
+                                             id: u32,
+                                             output: *mut wl_resource)
 }
-extern "C" fn destroy(wl_client: *mut wl_client,
+
+#[repr(C)]
+pub struct GammaControlInterface {
+    destroy: unsafe extern "C" fn (client: *mut wl_client,
+                                   resource: *mut wl_resource),
+    set_gamma: unsafe extern "C" fn (client: *mut wl_client,
+                                     resource: *mut wl_resource,
+                                     red: *mut wl_array,
+                                     green: *mut wl_array,
+                                     blue: *mut wl_array),
+    reset_gamma: unsafe extern "C" fn (client: *mut wl_client,
+                                       resource: *mut wl_resource)
+}
+
+unsafe extern "C" fn set_gamma(client: *mut wl_client,
+                               resource: *mut wl_resource,
+                               red: *mut wl_array,
+                               green: *mut wl_array,
+                               blue: *mut wl_array) {
+    if (*red).size != (*green).size || (*red).size != (*blue).size {
+        // TODO wl_resource_post_error
+        return
+    }
+    let r = (*red).data as *mut u16;
+    let g = (*green).data as *mut u16;
+    let b = (*blue).data as *mut u16;
+    let user_data = ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_get_user_data,
+        resource) as *const _;
+    let output = WlcOutput(wlc_handle_from_wl_output_resource(user_data));
+    // TODO Make this less stupid to check if it's a null index
+    if output.as_view().is_root() {
+        return;
+    }
+    debug!("Setting gamma for output {:?}", output);
+    warn!("Setting gamma for output {:?}", output);
+    error!("Setting gamma for output {:?}", output);
+    // TODO Uncomment when implemented in wlc
+    //wlc_output_set_gamma(output, (*red).size / 16, r, g b)
+
+}
+unsafe extern "C" fn reset_gamma(client: *mut wl_client,
+                                 resource: *mut wl_resource) {
+    // Do nothing
+}
+
+unsafe extern "C" fn destroy(wl_client: *mut wl_client,
                 resource: *mut wl_resource) {
-    warn!("GOT HERE");
-    warn!("GOT HERE");
-    warn!("GOT HERE");
-
+    // TODO wl_destroy_resource
+    unimplemented!()
 }
 
-extern "C" fn get_gamma_control(wl_client: *mut wl_client,
-                                resource: *mut wl_resource) {
-    warn!("GOT HERE2");
-    warn!("GOT HERE2");
-    warn!("GOT HERE2");
+unsafe extern "C" fn get_gamma_control(client: *mut wl_client,
+                                       resource: *mut wl_resource,
+                                       id: u32,
+                                       output: *mut wl_resource) {
+    let manager_resource = ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_create,
+        client,
+        GammaControl::interface_ptr(),
+        GammaControl::supported_version() as i32,
+        id);
+    // check that the output is something we control from wlc
+    warn!("In the setup or whatever");
+    {
+        let output = WlcOutput(wlc_handle_from_wl_output_resource(resource as *const _));
+        // TODO Make this less stupid to check if it's a null index
+        if output.as_view().is_root() {
+            warn!("This is triggering, dis bad?");
+            // TODO ORRRR maybe note whatever
+            //return;
+        }
+    }
+    let mut gamma_control = GAMMA_CONTROL.try_lock().unwrap();
+    let gamma_control_ptr = &mut *gamma_control as *mut _ as *mut c_void;
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_set_implementation,
+        manager_resource,
+        gamma_control_ptr,
+        output as *mut c_void,
+        None
+    );
+    // TODO Uncomment when I add that function to wlc
+    //gamma_control_send_gamma_size(manager_resource, wlc_output_get_gamma_size(output))
 }
 
 
@@ -46,11 +133,21 @@ impl GammaControlManagerInterface {
     }
 }
 
+impl GammaControlInterface {
+    pub fn new() -> Self {
+        GammaControlInterface {
+            destroy: destroy,
+            set_gamma: set_gamma,
+            reset_gamma: reset_gamma
+        }
+    }
+}
+
 lazy_static!(
     static ref GAMMA_CONTROL_MANAGER: Mutex<GammaControlManagerInterface> =
         Mutex::new(GammaControlManagerInterface::new());
-    static ref GAMMA_CONTROL: Mutex<GammaHandler> =
-        Mutex::new(GammaHandler::new());
+    static ref GAMMA_CONTROL: Mutex<GammaControlInterface> =
+        Mutex::new(GammaControlInterface::new());
 );
 
 /// Initializes the appropriate handlers for each wayland protocol

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -3,14 +3,52 @@ pub mod gamma_control;
 use std::ptr;
 use wayland_server::Resource;
 use wayland_server::sys::WAYLAND_SERVER_HANDLE;
+use wayland_sys::server::*;
 use self::gamma_control::{GammaHandler, GammaManagerHandler};
 use rustwlc::wayland;
 
+use std::os::raw::c_void;
+use std::ptr::null_mut;
+
 use std::sync::{Mutex};
 
+// TODO Is this the best way really? Not use anything from the generated file?
+
+#[repr(C)]
+pub struct GammaControlManagerInterface {
+    destroy: extern "C" fn (wl_client: *mut wl_client,
+                            resource: *mut wl_resource),
+    get_gamma_control: extern "C" fn (wl_client: *mut wl_client,
+                                      resource: *mut wl_resource)
+}
+extern "C" fn destroy(wl_client: *mut wl_client,
+                resource: *mut wl_resource) {
+    warn!("GOT HERE");
+    warn!("GOT HERE");
+    warn!("GOT HERE");
+
+}
+
+extern "C" fn get_gamma_control(wl_client: *mut wl_client,
+                                resource: *mut wl_resource) {
+    warn!("GOT HERE2");
+    warn!("GOT HERE2");
+    warn!("GOT HERE2");
+}
+
+
+impl GammaControlManagerInterface {
+    pub fn new() -> Self {
+        GammaControlManagerInterface {
+            destroy: destroy,
+            get_gamma_control: get_gamma_control
+        }
+    }
+}
+
 lazy_static!(
-    static ref GAMMA_CONTROL_MANAGER: Mutex<GammaManagerHandler> =
-        Mutex::new(GammaManagerHandler::new());
+    static ref GAMMA_CONTROL_MANAGER: Mutex<GammaControlManagerInterface> =
+        Mutex::new(GammaControlManagerInterface::new());
     static ref GAMMA_CONTROL: Mutex<GammaHandler> =
         Mutex::new(GammaHandler::new());
 );


### PR DESCRIPTION
This adds a new Wayland protocols module (Fixes #144) and also adds a new folder where all standard protocols will live (`/protocols`).

Adds support for a [patched version of Redshift](https://github.com/giucam/redshift) :tada:. (Fixes #201)