### PR TITLE
Fixed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you find bugs or have questions about the code, please [submit an issue] or [
 [wayland]: https://wayland.freedesktop.org/
 [Lua]: https://lua.org/
 [wlc]: https://github.com/Cloudef/wlc
-[i3]: i3wm.org
+[i3]: https://i3wm.org
 [D-Bus]: https://www.freedesktop.org/wiki/Software/dbus/
 [awesome]: https://awesomewm.org/
 [polybar]: https://github.com/jaagr/polybar


### PR DESCRIPTION
Made the link to the i3wm website in the description link properly.

Before it wouldn't link to the website, but attempt to link to a nonexistent page at https://github.com/way-cooler/way-cooler/blob/master/i3wm.org