### PR TITLE
Added basic modes to Way Cooler

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -141,3 +141,11 @@ end
 way_cooler.on_terminate = function()
   util.program.terminate_startup_programs()
 end
+
+
+way_cooler.on_pointer_button = function(id, mods, pos, button)
+  print("Hello world")
+  print("id: " .. id)
+  print("x:" .. pos.x .. " y:" .. pos.y)
+  print("button" .. button)
+end

--- a/config/init.lua
+++ b/config/init.lua
@@ -141,11 +141,3 @@ end
 way_cooler.on_terminate = function()
   util.program.terminate_startup_programs()
 end
-
-
-way_cooler.on_pointer_button = function(id, mods, pos, button)
-  print("Hello world")
-  print("id: " .. id)
-  print("x:" .. pos.x .. " y:" .. pos.y)
-  print("button" .. button)
-end

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -125,3 +125,24 @@ commands.__metatable = "Cannot modify"
 
 setmetatable(way_cooler, way_cooler_mt)
 setmetatable(__key_map, { __metatable = "cannot modify" })
+
+
+-- Sets the callbacks to be empty, to suppress warnings
+way_cooler.on_output_created = function(id) end
+way_cooler.on_output_destroyed = function(id) end
+way_cooler.on_output_focused = function(id) end
+way_cooler.on_output_resolution_changed = function(id, old_size, new_size) end
+way_cooler.on_output_render_post = function(id) end
+way_cooler.on_view_moved_to_output = function(id, old_id, new_id) end
+way_cooler.on_view_created = function(id) end
+way_cooler.on_view_focused = function(id) end
+way_cooler.on_view_props_changed = function(id, props) end
+way_cooler.on_view_request_state = function(id, state, toggle) end
+way_cooler.on_view_request_geometry = function(id, geo) end
+way_cooler.on_view_request_move = function(id, point) end
+way_cooler.on_view_request_resize = function(id, edge, point) end
+way_cooler.on_view_pre_render = function(id) end
+way_cooler.on_keyboard_key = function(id, key, mods, state) end
+way_cooler.on_pointer_button = function(id, mods, pos, button) end
+way_cooler.on_pointer_scroll = function(id, mods, axis, height0, height1) end
+way_cooler.on_pointer_motion = function(id, point) end

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -117,11 +117,14 @@ pub extern fn view_request_geometry(view: WlcView, geometry: &Geometry) {
 
 pub extern fn keyboard_key(view: WlcView, time: u32, mods: &KeyboardModifiers,
                            key: u32, state: KeyState) -> bool {
-    if let Ok(mode) = read_current_mode() {
-        mode.on_keyboard_key(view, time, *mods, key, state)
+    // NOTE We read the mode out here, so that if there is a keybinding
+    // that changes the mode we can do that without being blocked!
+    let mode = if let Ok(mode) = read_current_mode() {
+        *mode
     } else {
         return EVENT_PASS_THROUGH
-    }
+    };
+    mode.on_keyboard_key(view, time, *mods, key, state)
 }
 
 pub extern fn pointer_button(view: WlcView, time: u32,

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,49 +1,19 @@
 //! Implementations of the callbacks exposed by wlc.
 //! These functions are the main entry points into Way Cooler from user action.
-#![allow(deprecated)] // keysyms
-
 use rustwlc::handle::{WlcOutput, WlcView};
-use rustwlc::types::{ButtonState, KeyboardModifiers, KeyState, KeyboardLed, ScrollAxis, Size,
-                     Point, Geometry, ResizeEdge, ViewState, ViewPropertyType, PROPERTY_TITLE,
-                     VIEW_MAXIMIZED, VIEW_ACTIVATED, VIEW_RESIZING, VIEW_FULLSCREEN,
-                     MOD_NONE, RESIZE_LEFT, RESIZE_RIGHT, RESIZE_TOP, RESIZE_BOTTOM};
-use rustwlc::input::{pointer, keyboard};
-use rustwlc::render::{read_pixels, wlc_pixel_format};
-use uuid::Uuid;
+use rustwlc::types::*;
 
-use super::keys::{self, KeyPress, KeyEvent};
-use super::layout::{lock_tree, try_lock_tree, try_lock_action, Action, ContainerType,
-                    MovementError, TreeError, FocusError};
-use super::layout::commands::set_performing_action;
-use super::lua::{self, LuaQuery};
+use super::keys;
+use super::layout::{lock_tree, try_lock_tree, TreeError};
+use super::lua;
 
-use ::render::screen_scrape::{read_screen_scrape_lock, scraped_pixels_lock,
-                              sync_scrape};
+use ::modes::{read_current_mode, EVENT_PASS_THROUGH};
 
-use registry::{self};
-
-/// If the event is handled by way-cooler
-const EVENT_BLOCKED: bool = true;
-
-/// If the event should be passed through to clients
-const EVENT_PASS_THROUGH: bool = false;
-
-const LEFT_CLICK: u32 = 0x110;
-const RIGHT_CLICK: u32 = 0x111;
 
 pub extern fn output_created(output: WlcOutput) -> bool {
     trace!("output_created: {:?}: {}", output, output.get_name());
-    if let Ok(mut tree) = try_lock_tree() {
-        let result = tree.add_output(output).and_then(|_|{
-            tree.switch_to_workspace(&"1")
-                .map(|_| tree.layout_active_of(ContainerType::Output))
-        });
-        match result {
-            // If the output exists, we just couldn't add it to the tree because
-            // it's already there. That's OK
-            Ok(_) | Err(TreeError::OutputExists(_)) => true,
-            _ => false
-        }
+    if let Ok(mode) = read_current_mode() {
+        mode.output_created(output)
     } else {
         false
     }
@@ -51,104 +21,37 @@ pub extern fn output_created(output: WlcOutput) -> bool {
 
 pub extern fn output_destroyed(output: WlcOutput) {
     trace!("output_destroyed: {:?}", output);
+    if let Ok(mode) = read_current_mode() {
+        mode.output_destroyed(output)
+    }
 }
 
 pub extern fn output_focus(output: WlcOutput, focused: bool) {
     trace!("output_focus: {:?} focus={}", output, focused);
+    if let Ok(mode) = read_current_mode() {
+        mode.output_focused(output, focused)
+    }
 }
 
 pub extern fn output_resolution(output: WlcOutput,
                                 old_size_ptr: &Size, new_size_ptr: &Size) {
     trace!("output_resolution: {:?} from  {:?} to {:?}",
            output, *old_size_ptr, *new_size_ptr);
-    // Update the resolution of the output and its children
-    let scale = 1;
-    output.set_resolution(*new_size_ptr, scale);
-    if let Ok(mut tree) = try_lock_tree() {
-        tree.layout_active_of(ContainerType::Output)
-            .expect("Could not layout active output");
+    if let Ok(mode) = read_current_mode() {
+        mode.output_resolution(output, *old_size_ptr, *new_size_ptr)
     }
 }
 
 pub extern fn post_render(output: WlcOutput) {
-    let need_to_fetch = read_screen_scrape_lock();
-    if *need_to_fetch {
-        if let Ok(mut scraped_pixels) = scraped_pixels_lock() {
-            let resolution = output.get_resolution()
-                .expect("Output had no resolution");
-            let geo = Geometry {
-                origin: Point { x: 0, y: 0 },
-                size: resolution
-            };
-            let result = read_pixels(wlc_pixel_format::WLC_RGBA8888, geo).1;
-            *scraped_pixels = result;
-            sync_scrape();
-        }
+    if let Ok(mode) = read_current_mode() {
+        mode.output_render_post(output)
     }
 }
 
 pub extern fn view_created(view: WlcView) -> bool {
-    debug!("view_created: {:?}: \"{}\"", view, view.get_title());
-    let lock = registry::clients_read();
-    let client = lock.client(Uuid::nil()).unwrap();
-    let handle = registry::ReadHandle::new(&client);
-    let bar = handle.read("programs".into())
-        .expect("programs category didn't exist")
-        .get("x11_bar".into())
-        .and_then(|data| data.as_string().map(str::to_string));
-    // TODO Move this hack, probably could live somewhere else
-    if let Some(bar_name) = bar {
-        if view.get_title().as_str() == bar_name {
-            view.set_mask(1);
-            view.bring_to_front();
-            if let Ok(mut tree) = try_lock_tree() {
-                for output in WlcOutput::list() {
-                    tree.add_bar(view, output).unwrap_or_else(|_| {
-                        warn!("Could not add bar {:#?} to output {:#?}", view, output);
-                    });
-                }
-                return true;
-            }
-        }
-    }
-    // TODO Remove this hack
-    if view.get_class().as_str() == "Background" {
-        debug!("Setting background: {}", view.get_title());
-        view.send_to_back();
-        view.set_mask(1);
-        let output = view.get_output();
-        let resolution = output.get_resolution()
-            .expect("Couldn't get output resolution");
-        let fullscreen = Geometry {
-            origin: Point { x: 0, y: 0 },
-            size: resolution
-        };
-        view.set_geometry(ResizeEdge::empty(), fullscreen);
-        if let Ok(mut tree) = lock_tree() {
-            let outputs = tree.outputs();
-            return tree.add_background(view, outputs.as_slice()).map(|_| true)
-                .unwrap_or_else(|err| {
-                    error!("Could not add background due to {:?}", err);
-                    true
-                })
-        } else {
-            error!("Could not lock tree");
-        }
-        return false
-    }
-    if let Ok(mut tree) = lock_tree() {
-        let result = tree.add_view(view).and_then(|_| {
-            view.set_state(VIEW_MAXIMIZED, true);
-            match tree.set_active_view(view) {
-                // If blocked by fullscreen, we don't focus on purpose
-                Err(TreeError::Focus(FocusError::BlockedByFullscreen(_, _))) => Ok(()),
-                result => result
-            }
-        });
-        if result.is_err() {
-            warn!("Could not add {:?}. Reason: {:?}", view, result);
-        }
-        result.is_ok()
+    trace!("view_created: {:?}: \"{}\"", view, view.get_title());
+    if let Ok(mode) = read_current_mode() {
+        mode.view_created(view)
     } else {
         false
     }
@@ -156,285 +59,97 @@ pub extern fn view_created(view: WlcView) -> bool {
 
 pub extern fn view_destroyed(view: WlcView) {
     trace!("view_destroyed: {:?}", view);
-    match try_lock_tree() {
-        Ok(mut tree) => {
-            tree.remove_view(view).unwrap_or_else(|err| {
-                match err {
-                    TreeError::ViewNotFound(_) => {},
-                    _ => {
-                        error!("Error in view_destroyed: {:?}", err);
-                    }
-                }});
-        },
-        Err(err) => error!("Could not delete view {:?}, {:?}", view, err)
+    if let Ok(mode) = read_current_mode() {
+        mode.view_destroyed(view)
     }
 }
 
 pub extern fn view_focus(current: WlcView, focused: bool) {
     trace!("view_focus: {:?} {}", current, focused);
-    current.set_state(VIEW_ACTIVATED, focused);
-    if let Ok(mut tree) = try_lock_tree() {
-        match tree.set_active_view(current) {
-            Ok(_) => {},
-            Err(err) => {
-                error!("Could not set {:?} to be active view: {:?}", current, err);
-            }
-        }
+    if let Ok(mode) = read_current_mode() {
+        mode.view_focused(current, focused)
     }
 }
 
 pub extern fn view_props_changed(view: WlcView, prop: ViewPropertyType) {
-    if prop.contains(PROPERTY_TITLE) {
-        if let Ok(mut tree) = try_lock_tree() {
-            match tree.update_title(view) {
-                Ok(_) => {},
-                Err(err) => {
-                    error!("Could not update title for view {:?} because {:#?}",
-                           view, err);
-                }
-            }
-        }
+    trace!("view_props_changed for view {:?}: {:?}", view, prop);
+    if let Ok(mode) = read_current_mode() {
+        mode.view_props_changed(view, prop)
     }
 }
 
 pub extern fn view_move_to_output(current: WlcView,
                                   o1: WlcOutput, o2: WlcOutput) {
     trace!("view_move_to_output: {:?}, {:?}, {:?}", current, o1, o2);
+    if let Ok(mode) = read_current_mode() {
+        mode.view_moved_to_output(current, o1, o2)
+    }
 }
 
 pub extern fn view_request_state(view: WlcView, state: ViewState, toggle: bool) {
     trace!("Setting {:?} to state {:?}", view, state);
-    if state == VIEW_FULLSCREEN {
-        if let Ok(mut tree) = try_lock_tree() {
-            if let Ok(id) = tree.lookup_view(view) {
-                tree.set_fullscreen(id, toggle)
-                    .expect("The ID was related to a non-view, somehow!");
-                match tree.container_in_active_workspace(id) {
-                    Ok(true) => {
-                        tree.layout_active_of(ContainerType::Workspace)
-                            .unwrap_or_else(|err| {
-                                error!("Could not layout active workspace for view {:?}: {:?}",
-                                        view, err)
-                            });
-                    },
-                    Ok(false) => {},
-                    Err(err) => error!("Could not set {:?} fullscreen: {:?}", view, err)
-                }
-            } else {
-                warn!("Could not find view {:?} in tree", view);
-            }
-        }
+    if let Ok(mode) = read_current_mode() {
+        mode.view_request_state(view, state, toggle)
     }
 }
 
-pub extern fn view_request_move(view: WlcView, _dest: &Point) {
-    if let Ok(mut tree) = try_lock_tree() {
-        if let Err(err) = tree.set_active_view(view) {
-            error!("view_request_move error: {:?}", err);
-        }
+pub extern fn view_request_move(view: WlcView, dest: &Point) {
+    trace!("View {:?} request to move to {:?}", view, dest);
+    if let Ok(mode) = read_current_mode() {
+        mode.view_request_move(view, *dest)
     }
 }
 
 pub extern fn view_request_resize(view: WlcView, edge: ResizeEdge, point: &Point) {
-    if let Ok(mut tree) = try_lock_tree() {
-        match try_lock_action() {
-            Ok(guard) => {
-                if guard.is_some() {
-                    if let Ok(id) = tree.lookup_view(view) {
-                        if let Err(err) = tree.resize_container(id, edge, *point) {
-                            error!("Problem: Command returned error: {:#?}", err);
-                        }
-                    }
-                }
-            },
-            _ => {}
-        }
+    trace!("View {:?} request resize w/ edge {:?} to point {:?}",
+           view, edge, point);
+    if let Ok(mode) = read_current_mode() {
+        mode.view_request_resize(view, edge, *point)
     }
-}
-
-pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
-                           key: u32, state: KeyState) -> bool {
-    let empty_mods: KeyboardModifiers = KeyboardModifiers {
-            mods: MOD_NONE,
-            leds: KeyboardLed::empty()
-    };
-    let sym = keyboard::get_keysym_for_key(key, empty_mods);
-    let press = KeyPress::new(mods.mods, sym);
-
-    if state == KeyState::Pressed {
-        if let Some(action) = keys::get(&press) {
-            info!("[key] Found an action for {}, blocking event", press);
-            match action {
-                KeyEvent::Command(func) => {
-                    func();
-                },
-                KeyEvent::Lua => {
-                    match lua::send(LuaQuery::HandleKey(press)) {
-                        Ok(_) => {},
-                        Err(err) => {
-                            // We may want to wait for Lua's reply from
-                            // keypresses; for example if the table is tampered
-                            // with or Lua is restarted or Lua has an error.
-                            // ATM Lua asynchronously logs this but in the future
-                            // an error popup/etc is a good idea.
-                            error!("Error sending keypress: {:?}", err);
-                        }
-                    }
-                }
-            }
-            return EVENT_BLOCKED
-        }
-    }
-
-    return EVENT_PASS_THROUGH
 }
 
 pub extern fn view_request_geometry(view: WlcView, geometry: &Geometry) {
-    if let Ok(mut tree) = try_lock_tree() {
-        tree.update_floating_geometry(view, *geometry).unwrap_or_else(|_| {
-            warn!("Could not find view {:#?} \
-                   in order to update geometry w/ {:#?}",
-                  view, *geometry);
-        });
+    trace!("View {:?} requested geometry {:?}", view, geometry);
+    if let Ok(mode) = read_current_mode() {
+        mode.view_request_geometry(view, *geometry)
     }
 }
 
-pub extern fn pointer_button(view: WlcView, _time: u32,
+pub extern fn keyboard_key(view: WlcView, time: u32, mods: &KeyboardModifiers,
+                           key: u32, state: KeyState) -> bool {
+    if let Ok(mode) = read_current_mode() {
+        mode.on_keyboard_key(view, time, *mods, key, state)
+    } else {
+        return EVENT_PASS_THROUGH
+    }
+}
+
+pub extern fn pointer_button(view: WlcView, time: u32,
                          mods: &KeyboardModifiers, button: u32,
                              state: ButtonState, point: &Point) -> bool {
-    if state == ButtonState::Pressed {
-        let mouse_mod = keys::mouse_modifier();
-        if button == LEFT_CLICK && !view.is_root() {
-            if let Ok(mut tree) = try_lock_tree() {
-                tree.set_active_view(view).unwrap_or_else(|_| {
-                    // still focus on view, even if not in tree.
-                    view.focus();
-                });
-                if mods.mods.contains(mouse_mod) {
-                    let action = Action {
-                        view: view,
-                        grab: *point,
-                        edges: ResizeEdge::empty()
-                    };
-                    set_performing_action(Some(action));
-                }
-            }
-        } else if button == RIGHT_CLICK && !view.is_root() {
-            info!("User right clicked w/ mods \"{:?}\" on {:?}", mods, view);
-            if let Ok(mut tree) = try_lock_tree() {
-                tree.set_active_view(view).ok();
-            }
-            if mods.mods.contains(mouse_mod) {
-                let action = Action {
-                    view: view,
-                    grab: *point,
-                    edges: ResizeEdge::empty()
-                };
-                set_performing_action(Some(action));
-                let geometry = view.get_geometry()
-                    .expect("Could not get geometry of the view");
-                let halfw = geometry.origin.x + geometry.size.w as i32 / 2;
-                let halfh = geometry.origin.y + geometry.size.h as i32 / 2;
-
-                {
-                    let mut action: Action = try_lock_action().ok().and_then(|guard| *guard)
-                        .unwrap_or(Action {
-                            view: view,
-                            grab: *point,
-                            edges: ResizeEdge::empty()
-                        });
-                    let flag_x = if point.x < halfw {
-                        RESIZE_LEFT
-                    } else if point.x > halfw {
-                        RESIZE_RIGHT
-                    } else {
-                        ResizeEdge::empty()
-                    };
-
-                    let flag_y = if point.y < halfh {
-                        RESIZE_TOP
-                    } else if point.y > halfh {
-                        RESIZE_BOTTOM
-                    } else {
-                        ResizeEdge::empty()
-                    };
-
-                    action.edges = flag_x | flag_y;
-                    set_performing_action(Some(action));
-                }
-                view.set_state(VIEW_RESIZING, true);
-                return EVENT_BLOCKED
-            }
-        }
+    if let Ok(mode) = read_current_mode() {
+        mode.on_pointer_button(view, time, *mods, button, state, *point)
     } else {
-        if let Ok(lock) = try_lock_action() {
-            let unknown = format!("unknown ({})", button);
-            info!("User released {:?} mouse button",
-                  match button {
-                      RIGHT_CLICK => "right",
-                      LEFT_CLICK => "left",
-                      _ => unknown.as_str()
-                  });
-            match *lock {
-                Some(action) => {
-                    let view = action.view;
-                    if view.get_state().contains(VIEW_RESIZING) {
-                        view.set_state(VIEW_RESIZING, false);
-                    }
-                },
-                _ => {}
-            }
-        }
-        set_performing_action(None);
+        EVENT_PASS_THROUGH
     }
-    EVENT_PASS_THROUGH
 }
 
-pub extern fn pointer_scroll(_view: WlcView, _time: u32,
-                         _mods_ptr: &KeyboardModifiers, _axis: ScrollAxis,
-                         _heights: [f64; 2]) -> bool {
-    EVENT_PASS_THROUGH
+pub extern fn pointer_scroll(view: WlcView, time: u32,
+                         mods_ptr: &KeyboardModifiers, axis: ScrollAxis,
+                         heights: [f64; 2]) -> bool {
+    if let Ok(mode) = read_current_mode() {
+        mode.on_pointer_scroll(view, time, *mods_ptr, axis, heights)
+    } else {
+        EVENT_PASS_THROUGH
+    }
 }
 
-pub extern fn pointer_motion(view: WlcView, _time: u32, point: &Point) -> bool {
-    let mut result = EVENT_PASS_THROUGH;
-    let mut maybe_action = None;
-    {
-        if let Ok(action_lock) = try_lock_action() {
-            maybe_action = action_lock.clone();
-        }
+pub extern fn pointer_motion(view: WlcView, time: u32, point: &Point) -> bool {
+    if let Ok(mode) = read_current_mode() {
+        mode.on_pointer_motion(view, time, *point)
+    } else {
+        EVENT_PASS_THROUGH
     }
-    match maybe_action {
-        None => result = EVENT_PASS_THROUGH,
-        Some(action) => {
-            if action.edges.bits() != 0 {
-                if let Ok(mut tree) = try_lock_tree() {
-                    if let Ok(active_id) = tree.lookup_view(view) {
-                        match tree.resize_container(active_id, action.edges, *point) {
-                            // Return early here to not set the pointer
-                            Ok(_) => return EVENT_BLOCKED,
-                            Err(err) => warn!("Could not resize: {:#?}", err)
-                        }
-                    }
-                }
-            } else {
-                if let Ok(mut tree) = try_lock_tree() {
-                    match tree.try_drag_active(*point) {
-                        Ok(_) => result = EVENT_BLOCKED,
-                        Err(TreeError::PerformingAction(_)) |
-                        Err(TreeError::Movement(MovementError::NotFloating(_))) =>
-                            result = EVENT_PASS_THROUGH,
-                        Err(err) => {
-                            error!("Error: {:#?}", err);
-                            result = EVENT_PASS_THROUGH
-                        }
-                    }
-                }
-            }
-        }
-    }
-    pointer::set_position(*point);
-    result
 }
 
 pub extern fn compositor_ready() {

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::io::prelude::*;
 use layout::commands as layout_cmds;
+use ::modes::commands as mode_cmds;
 
 use commands::{self, CommandFn};
 use layout::try_lock_tree;
@@ -84,6 +85,7 @@ pub fn register_defaults() {
                            move_to_workspace_9, "9";
                            move_to_workspace_0, "0");
 
+    // Tiling and window controls
     register("horizontal_vertical_switch", Arc::new(layout_cmds::tile_switch));
     register("split_vertical", Arc::new(layout_cmds::split_vertical));
     register("split_horizontal", Arc::new(layout_cmds::split_horizontal));
@@ -99,6 +101,10 @@ pub fn register_defaults() {
     register("close_window", Arc::new(layout_cmds::remove_active));
     register("toggle_float_active", Arc::new(layout_cmds::toggle_float));
     register("toggle_float_focus", Arc::new(layout_cmds::toggle_float_focus));
+
+    // Modes
+    register("default_mode", Arc::new(mode_cmds::set_default_mode));
+    register("custom_mode", Arc::new(mode_cmds::set_custom_mode));
 }
 
 // All of the methods defined should be registered.

--- a/src/convert/json.rs
+++ b/src/convert/json.rs
@@ -1,10 +1,11 @@
 //! Conversion methods for JSON values.
 
+use rustwlc::{Geometry, Point, Size};
 use std::collections::BTreeMap;
 
 use hlua::any::AnyLuaValue;
 use hlua::any::AnyLuaValue::*;
-use rustc_serialize::json::Json;
+use rustc_serialize::json::{Json, ToJson};
 
 /// Converts a Json map into an AnyLuaValue
 pub fn json_to_lua(json: Json) -> AnyLuaValue {
@@ -121,4 +122,28 @@ pub fn lua_object_to_json(obj: Vec<(AnyLuaValue, AnyLuaValue)>)
         return Err(AnyLuaValue::LuaArray(obj))
     }
     Ok(Json::Object(json_obj))
+}
+
+
+pub fn size_to_json(size: Size) -> Json {
+    let mut map = BTreeMap::new();
+    map.insert("w".into(), size.w.to_json());
+    map.insert("h".into(), size.h.to_json());
+    map.to_json()
+}
+
+pub fn point_to_json(point: Point) -> Json {
+    let mut map = BTreeMap::new();
+    map.insert("x".into(), point.x.to_json());
+    map.insert("y".into(), point.y.to_json());
+    map.to_json()
+}
+
+pub fn geometry_to_json(geometry: Geometry) -> Json {
+    let mut map = BTreeMap::new();
+    let origin = point_to_json(geometry.origin);
+    let size = size_to_json(geometry.size);
+    map.insert("origin".into(), origin);
+    map.insert("size".into(), size);
+    map.to_json()
 }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -15,7 +15,7 @@ use ::layout::commands::CommandResult;
 use super::bar::Bar;
 
 /// A handle to either a view or output
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Handle {
     View(WlcView),
     Output(WlcOutput)

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -116,6 +116,8 @@ pub enum TreeError {
     PerformingAction(bool),
     /// Attempted to add an output to the tree, but it already exists.
     OutputExists(WlcOutput),
+    /// Handle was not found
+    HandleNotFound(Handle),
 }
 
 impl LayoutTree {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod layout;
 mod render;
 
 mod wayland;
+mod modes;
 
 use std::env;
 use std::fs::File;

--- a/src/modes/commands.rs
+++ b/src/modes/commands.rs
@@ -1,0 +1,19 @@
+//! Commands to control the modes.
+
+use super::{Modes, Default, CustomLua, write_current_mode};
+
+
+/// Sets the mode to the default (don't execute custom Lua code).
+pub fn set_default_mode() {
+    if let Ok(mut mode) = write_current_mode() {
+        *mode = Modes::Default(Default)
+    }
+}
+
+/// Sets the mode to the Custom Lua mode (execute any custom Lua code that
+/// the user has defined).
+pub fn set_custom_mode() {
+    if let Ok(mut mode) = write_current_mode() {
+        *mode = Modes::CustomLua(CustomLua)
+    }
+}

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -124,7 +124,7 @@ impl Mode for CustomLua {
     fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
         Default.view_props_changed(view, prop);
         if let Some(id) = lookup_handle(view.into()) {
-            send_to_lua(format!("way_coooler.on_view_props_changed(\"{}\", {})",
+            send_to_lua(format!("way_cooler.on_view_props_changed(\"{}\", {})",
                                 id, prop.bits()))
         }
     }
@@ -283,9 +283,7 @@ fn lookup_handle(handle: Handle) -> Option<String> {
 fn send_to_lua<Q: Into<String>>(msg: Q) {
     let msg = msg.into();
     match lua::send(LuaQuery::Execute(msg.clone())) {
-        Ok(result) => {
-            error!("Got back {:?}", result.recv())
-        },
+        Ok(result) => {},
         Err(LuaSendError::Sender(err)) =>
             error!("Error while executing {:?}: {:?}", msg, err),
         Err(LuaSendError::ThreadUninitialized) =>

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -1,15 +1,284 @@
 //! A custom Lua callback mapping, where the default operation is done and
 //! then a custom, user-defined Lua callback is ran.
-use std::collections::BTreeMap;
 use rustwlc::*;
 use rustwlc::Size;
 use ::lua::{self, LuaQuery, LuaSendError};
-use ::layout::{try_lock_tree};
-use rustc_serialize::json::{Json, ToJson};
+use ::layout::{try_lock_tree, Handle};
+use ::convert::json::{size_to_json, point_to_json, geometry_to_json};
+
 use super::default::Default;
 use super::Mode;
 
 pub struct CustomLua;
+
+impl Mode for CustomLua {
+    /// Triggered when an output is connected.
+    /// Sends the id of the created output to Lua.
+    fn output_created(&self, output: WlcOutput) -> bool {
+        let result = Default.output_created(output);
+        if let Some(id) = lookup_handle(output.into()) {
+            send_to_lua(format!("way_cooler.on_output_created(\"{}\")", id));
+        }
+        result
+    }
+
+    /// Triggered when an output is disconnected.
+    /// Sends the id of the destroyed output to Lua.
+    fn output_destroyed(&self, output: WlcOutput) {
+        // Get the output ID before it's destroyed
+        let id = lookup_handle(output.into());
+        Default.output_destroyed(output);
+        if let Some(id) = id {
+            send_to_lua(format!("way_cooler.on_output_destroyed(\"{}\")", id))
+        }
+    }
+
+    /// Triggered when an output loses or gains focus.
+    /// Sends the id of the output, and whether it gained or lost focus.
+    fn output_focused(&self, output: WlcOutput, focused: bool) {
+        Default.output_focused(output, focused);
+        if let Some(id) = lookup_handle(output.into()) {
+            send_to_lua(format!("way_cooler.on_output_focused(\"{}\", {})",
+                                id, focused));
+        }
+    }
+
+    /// Triggered when an output's resolution changes.
+    /// Sends the id of the output, and the old and new size of the output.
+    fn output_resolution(&self, output: WlcOutput,
+                         old_size: Size, new_size: Size) {
+        Default.output_resolution(output, old_size, new_size);
+        if let Some(id) = lookup_handle(output.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_output_resolution_change(\"{}\", {}, {})",
+                id, size_to_lua(old_size), size_to_lua(new_size)));
+        }
+    }
+
+    /// Triggered after the output is rendered.
+    /// Sends the id of the output after it's rendered.
+    fn output_render_post(&self, output: WlcOutput) {
+        Default.output_render_post(output);
+        if let Some(id) = lookup_handle(output.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_output_render_post(\"{}\")", id));
+        }
+    }
+
+    /// Triggered when a view moves outputs.
+    /// Sends the id of the view, the id of the old output, and the id of the
+    /// the new output.
+    fn view_moved_to_output(&self,
+                            view: WlcView,
+                            o1: WlcOutput,
+                            o2: WlcOutput) {
+        Default.view_moved_to_output(view, o1, o2);
+        let (view_id, o1_id, o2_id) = (lookup_handle(view.into()),
+                                       lookup_handle(o1.into()),
+                                       lookup_handle(o2.into()));
+        match (view_id, o1_id, o2_id) {
+            (Some(view_id), Some(o1_id), Some(o2_id)) => {
+                send_to_lua(format!(
+                    "way_cooler.on_view_moved_to_output(\"{}\", \"{}\", \"{}\")",
+                    view_id, o1_id, o2_id))
+            },
+            _ => {}
+        }
+    }
+
+    /// Triggered when a view is created.
+    /// Sends the id of the new view.
+    fn view_created(&self, view: WlcView) -> bool {
+        let result = Default.view_created(view);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_cooler.on_view_created(\"{}\")", id))
+        }
+        result
+    }
+
+    /// Triggered when a view is destroyed.
+    /// Sends the id of the view after its destroyed.
+    fn view_destroyed(&self, view: WlcView) {
+        // Get id before it's destroyed.
+        let id = lookup_handle(view.into());
+        Default.view_destroyed(view);
+        if let Some(id) = id {
+            send_to_lua(format!("way_cooler.on_view_destroyed(\"{}\")", id))
+        }
+    }
+
+    /// Triggered when a view gains or loses focus.
+    /// Sends the id of the view after its focus changes. The focus is true if
+    /// it gained focus, or false if it lost focus.
+    fn view_focused(&self, view: WlcView, focused: bool) {
+        Default.view_focused(view, focused);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_cooler.on_view_focused(\"{}\", {})",
+                                id, focused))
+        }
+    }
+
+    /// Triggered when the properties of a view changes.
+    /// Sends the id of the view that had its properties changed, and the
+    /// changed properties as a bit mask.
+    fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
+        Default.view_props_changed(view, prop);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_coooler.on_view_props_changed(\"{}\", {})",
+                                id, prop.bits()))
+        }
+    }
+
+    /// Triggered when a view has its state change.
+    /// Sends the id of the view, the bit field for the state field,
+    /// and a bool representing how it was toggled.
+    fn view_request_state(&self,
+                          view: WlcView,
+                          state: ViewState,
+                          toggle: bool) {
+        Default.view_request_state(view, state, toggle);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_view_request_state(\"{}\", {}, {})",
+                id, state.bits(), toggle))
+        }
+    }
+
+    /// Triggered when a view requests a different geometry.
+    /// Sends the id of the view, and the new geometry.
+    fn view_request_geometry(&self, view: WlcView, geometry: Geometry) {
+        Default.view_request_geometry(view, geometry);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_view_request_geometry(\"{}\", {})",
+                id, geometry_to_lua(geometry)))
+        }
+    }
+
+    /// Triggered when a view requests to be moved, but not resized.
+    /// Sends the id of the view, and the new destination point.
+    fn view_request_move(&self, view: WlcView, dest: Point) {
+        Default.view_request_move(view, dest);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_cooler.on_view_request_move(\"{}\", {})",
+                id, point_to_lua(dest)))
+        }
+    }
+
+    /// Triggered when a view requests to be resized.
+    /// Sends the id of the view, the bit field of the resize edge,
+    /// and the point where the mouse resized.
+    fn view_request_resize(&self,
+                           view: WlcView,
+                           edge: ResizeEdge,
+                           point: Point) {
+        Default.view_request_resize(view, edge, point);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_view_request_resize(\"{}\", {}, {})",
+                id, edge.bits(), point_to_lua(point)))
+        }
+    }
+
+    /// Triggered just before a view is rendered.
+    /// Used to render the borders.
+    /// Sends the id of the view that will be rendered.
+    fn view_pre_render(&self, view: WlcView) {
+        Default.view_pre_render(view);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_cooler.on_view_pre_render(\"{}\")", id))
+        }
+    }
+
+    /// Triggered when a keyboard key is clicked.
+    /// Sends the id of the view that it was sent to,
+    /// the key that was sent, any modifiers that were sent,
+    /// and the state the key was in (up or down).
+    fn on_keyboard_key(&self,
+                       view: WlcView,
+                       time: u32,
+                       mods: KeyboardModifiers,
+                       key: u32,
+                       state: KeyState) -> bool {
+        let result = Default.on_keyboard_key(view, time, mods, key, state);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_keyboard_key(\"{id}\", {key}, {mods}, {state})",
+                id = id,
+                key = key,
+                mods = mods.mods.bits(),
+                state = state as i32))
+        }
+        result
+    }
+
+    /// Triggered when a user presses a button on the mouse.
+    /// Sends the UUID of the view clicked, any modifiers that were held
+    /// down, where absolutely on the screen it was clicked, and what button
+    /// was used to Lua.
+    fn on_pointer_button(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         button: u32,
+                         state: ButtonState,
+                         point: Point) -> bool {
+        let result = Default.on_pointer_button(view, time, mods, button, state, point);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!("way_cooler.on_pointer_button(\
+                                 \"{view}\", {mods}, {pos}, {button})",
+                                view = id,
+                                mods = mods.mods.bits(),
+                                pos = point_to_lua(point),
+                                button = button))
+        }
+        result
+    }
+
+    /// Triggered when the user scrolls using a mouse.
+    /// Sends the UUID of the view clicked, any modifiers that were held down,
+    /// the axis of the scroll wheel, and both heights.
+    fn on_pointer_scroll(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         axis: ScrollAxis,
+                         heights: [f64; 2]) -> bool {
+        let result = Default.on_pointer_scroll(view, time, mods, axis, heights);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_pointer_scroll(\"{}\", {}, {}, {}, {})",
+                id, mods.mods.bits(), axis as i32, heights[0], heights[1]))
+        }
+        result
+    }
+
+    /// Triggerd when a user moves the mouse.
+    /// Sends the UUID of the view where it was moved over,
+    /// and the absolute point on the screen where it was.
+    fn on_pointer_motion(&self,
+                         view: WlcView,
+                         time: u32,
+                         point: Point) -> bool {
+        let result = Default.on_pointer_motion(view, time, point);
+        if let Some(id) = lookup_handle(view.into()) {
+            send_to_lua(format!(
+                "way_cooler.on_pointer_motion(\"{}\", {})",
+                id, point_to_lua(point)))
+        }
+        result
+    }
+}
+
+/// Looks up the handle in the tree
+fn lookup_handle(handle: Handle) -> Option<String> {
+    if let Ok(tree) = try_lock_tree() {
+        if let Ok(id) = tree.lookup_handle(handle.into()) {
+            return Some(id.hyphenated().to_string())
+        }
+    }
+    None
+}
 
 fn send_to_lua<Q: Into<String>>(msg: Q) {
     let msg = msg.into();
@@ -29,164 +298,14 @@ fn send_to_lua<Q: Into<String>>(msg: Q) {
 }
 
 fn size_to_lua(size: Size) -> String {
-    let mut map = BTreeMap::new();
-    map.insert("w".into(), size.w.to_json());
-    map.insert("h".into(), size.h.to_json());
-    format!("{}", map.to_json()).replace(":", "=").replace("\"", "")
+    format!("{}", size_to_json(size)).replace(":", "=").replace("\"", "")
 }
 
 fn point_to_lua(point: Point) -> String {
-    let mut map = BTreeMap::new();
-    map.insert("x".into(), point.x.to_json());
-    map.insert("y".into(), point.y.to_json());
-    format!("{}", map.to_json()).replace(":", "=").replace("\"", "")
+    format!("{}", point_to_json(point)).replace(":", "=").replace("\"", "")
 }
 
-impl Mode for CustomLua {
-    /// Sends the id of the created output to Lua.
-    fn output_created(&self, output: WlcOutput) -> bool {
-        let result = Default.output_created(output);
-        if let Ok(tree) = try_lock_tree() {
-            if let Ok(id) = tree.lookup_handle(output.into()) {
-                send_to_lua(format!("way_cooler.on_output_created(\"{}\")",
-                                    id.hyphenated().to_string()));
-            }
-        }
-        result
-    }
-
-    /// Sends the id of the destroyed output to Lua.
-    fn output_destroyed(&self, output: WlcOutput) {
-        // Get the output ID before it's destroyed
-        let mut id = None;
-        if let Ok(tree) = try_lock_tree() {
-            id = tree.lookup_handle(output.into()).ok();
-        }
-        Default.output_destroyed(output);
-        if let Some(id) = id {
-            send_to_lua(format!("way_cooler.on_output_destroyed(\"{}\")",
-                                id.hyphenated().to_string()))
-        }
-    }
-
-    /// Sends the id of the output, and whether it gained or lost focus.
-    fn output_focused(&self, output: WlcOutput, focused: bool) {
-        Default.output_focused(output, focused);
-        if let Ok(tree) = try_lock_tree() {
-            if let Ok(id) = tree.lookup_handle(output.into()) {
-                send_to_lua(format!("way_cooler.on_output_focused(\"{}\", {})",
-                                    id.hyphenated().to_string(),
-                                    focused));
-            }
-        }
-    }
-
-    /// Sends the id of the output, and the old and new size of the output.
-    fn output_resolution(&self, output: WlcOutput,
-                         old_size: Size, new_size: Size) {
-        Default.output_resolution(output, old_size, new_size);
-        if let Ok(tree) = try_lock_tree() {
-            if let Ok(id) = tree.lookup_handle(output.into()) {
-                send_to_lua(format!(
-                    "way_cooler.on_output_resolution_change({}, {}, {})",
-                    id.hyphenated().to_string(),
-                    size_to_lua(old_size),
-                    size_to_lua(new_size)));
-            }
-        }
-    }
-
-    fn output_render_post(&self, output: WlcOutput) {
-        Default.output_render_post(output);
-        send_to_lua("way_cooler.on_output_render_post()")
-    }
-    fn view_moved_to_output(&self,
-                            view: WlcView,
-                            o1: WlcOutput,
-                            o2: WlcOutput) {
-        Default.view_moved_to_output(view, o1, o2);
-        send_to_lua("way_cooler.on_view_moved_to_output()")
-    }
-    fn view_created(&self, view: WlcView) -> bool {
-        Default.view_created(view)
-    }
-    fn view_destroyed(&self, view: WlcView) {
-        Default.view_destroyed(view)
-    }
-    fn view_focused(&self, view: WlcView, focused: bool) {
-        Default.view_focused(view, focused)
-    }
-    fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
-        Default.view_props_changed(view, prop)
-    }
-    fn view_request_state(&self,
-                          view: WlcView,
-                          state: ViewState,
-                          toggle: bool) {
-        Default.view_request_state(view, state, toggle)
-    }
-    fn view_request_geometry(&self, view: WlcView, geometry: Geometry) {
-        Default.view_request_geometry(view, geometry)
-    }
-    fn view_request_move(&self, view: WlcView, dest: Point) {
-        Default.view_request_move(view, dest)
-    }
-    fn view_request_resize(&self,
-                           view: WlcView,
-                           edge: ResizeEdge,
-                           point: Point) {
-        Default.view_request_resize(view, edge, point)
-    }
-    fn view_pre_render(&self, view: WlcView) {
-        Default.view_pre_render(view)
-    }
-    fn on_keyboard_key(&self,
-                       view: WlcView,
-                       time: u32,
-                       mods: KeyboardModifiers,
-                       key: u32,
-                       state: KeyState) -> bool {
-        Default.on_keyboard_key(view, time, mods, key, state)
-    }
-
-    /// Sends the UUID of the pointer clicked, any modifiers that were held
-    /// down, where absolutely on the screen it was clicked, and what button
-    /// was used to Lua.
-    fn on_pointer_button(&self,
-                         view: WlcView,
-                         time: u32,
-                         mods: KeyboardModifiers,
-                         button: u32,
-                         state: ButtonState,
-                         point: Point) -> bool {
-        let result = Default.on_pointer_button(view, time, mods, button, state, point);
-        warn!("Sending button thing to Lua!");
-        if let Ok(tree) = try_lock_tree() {
-            if let Ok(id) = tree.lookup_handle(view.into()) {
-                warn!("Ok really sending it!");
-                send_to_lua(format!("way_cooler.on_pointer_button(\
-                                     \"{view}\", {mods}, {pos}, {button})",
-                                    view = id,
-                                    mods = mods.mods.bits(),
-                                    pos = point_to_lua(point),
-                                    button = button))
-            }
-        }
-        result
-    }
-
-    fn on_pointer_scroll(&self,
-                         view: WlcView,
-                         time: u32,
-                         mods: KeyboardModifiers,
-                         axis: ScrollAxis,
-                         heights: [f64; 2]) -> bool {
-        Default.on_pointer_scroll(view, time, mods, axis, heights)
-    }
-    fn on_pointer_motion(&self,
-                         view: WlcView,
-                         time: u32,
-                         point: Point) -> bool {
-        Default.on_pointer_motion(view, time, point)
-    }
+fn geometry_to_lua(geometry: Geometry) -> String {
+    format!("{}", geometry_to_json(geometry))
+        .replace(":", "=").replace("\"", "")
 }

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -1,0 +1,4 @@
+use super::Mode ;
+pub struct CustomLua;
+
+impl Mode for CustomLua {}

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -9,7 +9,15 @@ use ::convert::json::{size_to_json, point_to_json, geometry_to_json};
 use super::default::Default;
 use super::Mode;
 
-pub struct CustomLua;
+pub struct CustomLua {
+    name: String
+}
+
+impl CustomLua {
+    fn new(name: String) -> Self {
+        CustomLua { name: name }
+    }
+}
 
 impl Mode for CustomLua {
     /// Triggered when an output is connected.

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -1,4 +1,192 @@
-use super::Mode ;
+//! A custom Lua callback mapping, where the default operation is done and
+//! then a custom, user-defined Lua callback is ran.
+use std::collections::BTreeMap;
+use rustwlc::*;
+use rustwlc::Size;
+use ::lua::{self, LuaQuery, LuaSendError};
+use ::layout::{try_lock_tree};
+use rustc_serialize::json::{Json, ToJson};
+use super::default::Default;
+use super::Mode;
+
 pub struct CustomLua;
 
-impl Mode for CustomLua {}
+fn send_to_lua<Q: Into<String>>(msg: Q) {
+    let msg = msg.into();
+    match lua::send(LuaQuery::Execute(msg.clone())) {
+        Ok(result) => {
+            error!("Got back {:?}", result.recv())
+        },
+        Err(LuaSendError::Sender(err)) =>
+            error!("Error while executing {:?}: {:?}", msg, err),
+        Err(LuaSendError::ThreadUninitialized) =>
+            error!("Thread was not initilazed yet, could not execute {:?}",
+                   msg),
+        Err(LuaSendError::ThreadClosed) => {
+            error!("Thread closed, could not execute {:?}", msg)
+        }
+    }
+}
+
+fn size_to_lua(size: Size) -> String {
+    let mut map = BTreeMap::new();
+    map.insert("w".into(), size.w.to_json());
+    map.insert("h".into(), size.h.to_json());
+    format!("{}", map.to_json()).replace(":", "=").replace("\"", "")
+}
+
+fn point_to_lua(point: Point) -> String {
+    let mut map = BTreeMap::new();
+    map.insert("x".into(), point.x.to_json());
+    map.insert("y".into(), point.y.to_json());
+    format!("{}", map.to_json()).replace(":", "=").replace("\"", "")
+}
+
+impl Mode for CustomLua {
+    /// Sends the id of the created output to Lua.
+    fn output_created(&self, output: WlcOutput) -> bool {
+        let result = Default.output_created(output);
+        if let Ok(tree) = try_lock_tree() {
+            if let Ok(id) = tree.lookup_handle(output.into()) {
+                send_to_lua(format!("way_cooler.on_output_created(\"{}\")",
+                                    id.hyphenated().to_string()));
+            }
+        }
+        result
+    }
+
+    /// Sends the id of the destroyed output to Lua.
+    fn output_destroyed(&self, output: WlcOutput) {
+        // Get the output ID before it's destroyed
+        let mut id = None;
+        if let Ok(tree) = try_lock_tree() {
+            id = tree.lookup_handle(output.into()).ok();
+        }
+        Default.output_destroyed(output);
+        if let Some(id) = id {
+            send_to_lua(format!("way_cooler.on_output_destroyed(\"{}\")",
+                                id.hyphenated().to_string()))
+        }
+    }
+
+    /// Sends the id of the output, and whether it gained or lost focus.
+    fn output_focused(&self, output: WlcOutput, focused: bool) {
+        Default.output_focused(output, focused);
+        if let Ok(tree) = try_lock_tree() {
+            if let Ok(id) = tree.lookup_handle(output.into()) {
+                send_to_lua(format!("way_cooler.on_output_focused(\"{}\", {})",
+                                    id.hyphenated().to_string(),
+                                    focused));
+            }
+        }
+    }
+
+    /// Sends the id of the output, and the old and new size of the output.
+    fn output_resolution(&self, output: WlcOutput,
+                         old_size: Size, new_size: Size) {
+        Default.output_resolution(output, old_size, new_size);
+        if let Ok(tree) = try_lock_tree() {
+            if let Ok(id) = tree.lookup_handle(output.into()) {
+                send_to_lua(format!(
+                    "way_cooler.on_output_resolution_change({}, {}, {})",
+                    id.hyphenated().to_string(),
+                    size_to_lua(old_size),
+                    size_to_lua(new_size)));
+            }
+        }
+    }
+
+    fn output_render_post(&self, output: WlcOutput) {
+        Default.output_render_post(output);
+        send_to_lua("way_cooler.on_output_render_post()")
+    }
+    fn view_moved_to_output(&self,
+                            view: WlcView,
+                            o1: WlcOutput,
+                            o2: WlcOutput) {
+        Default.view_moved_to_output(view, o1, o2);
+        send_to_lua("way_cooler.on_view_moved_to_output()")
+    }
+    fn view_created(&self, view: WlcView) -> bool {
+        Default.view_created(view)
+    }
+    fn view_destroyed(&self, view: WlcView) {
+        Default.view_destroyed(view)
+    }
+    fn view_focused(&self, view: WlcView, focused: bool) {
+        Default.view_focused(view, focused)
+    }
+    fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
+        Default.view_props_changed(view, prop)
+    }
+    fn view_request_state(&self,
+                          view: WlcView,
+                          state: ViewState,
+                          toggle: bool) {
+        Default.view_request_state(view, state, toggle)
+    }
+    fn view_request_geometry(&self, view: WlcView, geometry: Geometry) {
+        Default.view_request_geometry(view, geometry)
+    }
+    fn view_request_move(&self, view: WlcView, dest: Point) {
+        Default.view_request_move(view, dest)
+    }
+    fn view_request_resize(&self,
+                           view: WlcView,
+                           edge: ResizeEdge,
+                           point: Point) {
+        Default.view_request_resize(view, edge, point)
+    }
+    fn view_pre_render(&self, view: WlcView) {
+        Default.view_pre_render(view)
+    }
+    fn on_keyboard_key(&self,
+                       view: WlcView,
+                       time: u32,
+                       mods: KeyboardModifiers,
+                       key: u32,
+                       state: KeyState) -> bool {
+        Default.on_keyboard_key(view, time, mods, key, state)
+    }
+
+    /// Sends the UUID of the pointer clicked, any modifiers that were held
+    /// down, where absolutely on the screen it was clicked, and what button
+    /// was used to Lua.
+    fn on_pointer_button(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         button: u32,
+                         state: ButtonState,
+                         point: Point) -> bool {
+        let result = Default.on_pointer_button(view, time, mods, button, state, point);
+        warn!("Sending button thing to Lua!");
+        if let Ok(tree) = try_lock_tree() {
+            if let Ok(id) = tree.lookup_handle(view.into()) {
+                warn!("Ok really sending it!");
+                send_to_lua(format!("way_cooler.on_pointer_button(\
+                                     \"{view}\", {mods}, {pos}, {button})",
+                                    view = id,
+                                    mods = mods.mods.bits(),
+                                    pos = point_to_lua(point),
+                                    button = button))
+            }
+        }
+        result
+    }
+
+    fn on_pointer_scroll(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         axis: ScrollAxis,
+                         heights: [f64; 2]) -> bool {
+        Default.on_pointer_scroll(view, time, mods, axis, heights)
+    }
+    fn on_pointer_motion(&self,
+                         view: WlcView,
+                         time: u32,
+                         point: Point) -> bool {
+        Default.on_pointer_motion(view, time, point)
+    }
+}

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -9,15 +9,7 @@ use ::convert::json::{size_to_json, point_to_json, geometry_to_json};
 use super::default::Default;
 use super::Mode;
 
-pub struct CustomLua {
-    name: String
-}
-
-impl CustomLua {
-    fn new(name: String) -> Self {
-        CustomLua { name: name }
-    }
-}
+pub struct CustomLua;
 
 impl Mode for CustomLua {
     /// Triggered when an output is connected.

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -9,6 +9,7 @@ use ::convert::json::{size_to_json, point_to_json, geometry_to_json};
 use super::default::Default;
 use super::Mode;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CustomLua;
 
 impl Mode for CustomLua {
@@ -283,7 +284,7 @@ fn lookup_handle(handle: Handle) -> Option<String> {
 fn send_to_lua<Q: Into<String>>(msg: Q) {
     let msg = msg.into();
     match lua::send(LuaQuery::Execute(msg.clone())) {
-        Ok(result) => {},
+        Ok(_) => {},
         Err(LuaSendError::Sender(err)) =>
             error!("Error while executing {:?}: {:?}", msg, err),
         Err(LuaSendError::ThreadUninitialized) =>

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -18,6 +18,8 @@ use ::render::screen_scrape::{read_screen_scrape_lock, scraped_pixels_lock,
 
 use registry::{self};
 use super::Mode;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Default;
 
 #[allow(unused)]

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -189,7 +189,7 @@ impl Mode for Default {
     fn view_request_state(&self, view: WlcView, state: ViewState, toggle: bool) {
         if state == VIEW_FULLSCREEN {
             if let Ok(mut tree) = try_lock_tree() {
-                if let Ok(id) = tree.lookup_view(view) {
+                if let Ok(id) = tree.lookup_handle(view.into()) {
                     tree.set_fullscreen(id, toggle)
                         .expect("The ID was related to a non-view, somehow!");
                     match tree.container_in_active_workspace(id) {
@@ -223,7 +223,7 @@ impl Mode for Default {
             match try_lock_action() {
                 Ok(guard) => {
                     if guard.is_some() {
-                        if let Ok(id) = tree.lookup_view(view) {
+                        if let Ok(id) = tree.lookup_handle(view.into()) {
                             if let Err(err) = tree.resize_container(id, edge, point) {
                                 error!("Problem: Command returned error: {:#?}", err);
                             }
@@ -392,7 +392,7 @@ impl Mode for Default {
             Some(action) => {
                 if action.edges.bits() != 0 {
                     if let Ok(mut tree) = try_lock_tree() {
-                        if let Ok(active_id) = tree.lookup_view(view) {
+                        if let Ok(active_id) = tree.lookup_handle(view.into()) {
                             match tree.resize_container(active_id, action.edges, point) {
                                 // Return early here to not set the pointer
                                 Ok(_) => return EVENT_BLOCKED,

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -1,6 +1,6 @@
-//! Implementations of the callbacks exposed by wlc.
+//! Implementations of the default callbacks exposed by wlc.
 //! These functions are the main entry points into Way Cooler from user action.
-#![allow(deprecated)] // keysyms
+//! This is the default mode that Way Cooler is in at initilization
 use rustwlc::*;
 use rustwlc::input::{pointer, keyboard};
 use rustwlc::render::{read_pixels, wlc_pixel_format};
@@ -20,9 +20,9 @@ use registry::{self};
 use super::Mode;
 pub struct Default;
 
+#[allow(unused)]
 impl Mode for Default {
-    fn output_created(&mut self, output: WlcOutput) -> bool {
-        trace!("output_created: {:?}: {}", output, output.get_name());
+    fn output_created(&self, output: WlcOutput) -> bool {
         if let Ok(mut tree) = try_lock_tree() {
             let result = tree.add_output(output).and_then(|_|{
                 tree.switch_to_workspace(&"1")
@@ -39,18 +39,16 @@ impl Mode for Default {
         }
     }
 
-     fn output_destroyed(&mut self, output: WlcOutput) {
-        trace!("output_destroyed: {:?}", output);
+    fn output_destroyed(&self, output: WlcOutput) {
+         // TODO Redistribute workspaces of that output.
     }
 
-     fn output_focused(&mut self, output: WlcOutput, focused: bool) {
-        trace!("output_focus: {:?} focus={}", output, focused);
+    fn output_focused(&self, output: WlcOutput, focused: bool) {
+         // TODO Ensure focused on right workspace
     }
 
-     fn output_resolution(&mut self, output: WlcOutput,
+    fn output_resolution(&self, output: WlcOutput,
                                     old_size_ptr: Size, new_size_ptr: Size) {
-        trace!("output_resolution: {:?} from  {:?} to {:?}",
-            output, old_size_ptr, new_size_ptr);
         // Update the resolution of the output and its children
         let scale = 1;
         output.set_resolution(new_size_ptr, scale);
@@ -60,7 +58,7 @@ impl Mode for Default {
         }
     }
 
-     fn output_render_post(&mut self, output: WlcOutput) {
+    fn output_render_post(&self, output: WlcOutput) {
         let need_to_fetch = read_screen_scrape_lock();
         if *need_to_fetch {
             if let Ok(mut scraped_pixels) = scraped_pixels_lock() {
@@ -77,8 +75,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_created(&mut self, view: WlcView) -> bool {
-        debug!("view_created: {:?}: \"{}\"", view, view.get_title());
+    fn view_created(&self, view: WlcView) -> bool {
         let lock = registry::clients_read();
         let client = lock.client(Uuid::nil()).unwrap();
         let handle = registry::ReadHandle::new(&client);
@@ -103,7 +100,7 @@ impl Mode for Default {
         }
         // TODO Remove this hack
         if view.get_class().as_str() == "Background" {
-            debug!("Setting background: {}", view.get_title());
+            trace!("Setting background: {}", view.get_title());
             view.send_to_back();
             view.set_mask(1);
             let output = view.get_output();
@@ -144,8 +141,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_destroyed(&mut self, view: WlcView) {
-        trace!("view_destroyed: {:?}", view);
+    fn view_destroyed(&self, view: WlcView) {
         match try_lock_tree() {
             Ok(mut tree) => {
                 tree.remove_view(view).unwrap_or_else(|err| {
@@ -160,8 +156,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_focused(&mut self, current: WlcView, focused: bool) {
-        trace!("view_focus: {:?} {}", current, focused);
+    fn view_focused(&self, current: WlcView, focused: bool) {
         current.set_state(VIEW_ACTIVATED, focused);
         if let Ok(mut tree) = try_lock_tree() {
             match tree.set_active_view(current) {
@@ -173,7 +168,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_props_changed(&mut self, view: WlcView, prop: ViewPropertyType) {
+    fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
         if prop.contains(PROPERTY_TITLE) {
             if let Ok(mut tree) = try_lock_tree() {
                 match tree.update_title(view) {
@@ -187,8 +182,11 @@ impl Mode for Default {
         }
     }
 
-     fn view_request_state(&mut self, view: WlcView, state: ViewState, toggle: bool) {
-        trace!("Setting {:?} to state {:?}", view, state);
+    fn view_moved_to_output(&self, view: WlcView, o1: WlcOutput, o2: WlcOutput) {
+        // TODO Ensure in correct workspace
+    }
+
+    fn view_request_state(&self, view: WlcView, state: ViewState, toggle: bool) {
         if state == VIEW_FULLSCREEN {
             if let Ok(mut tree) = try_lock_tree() {
                 if let Ok(id) = tree.lookup_view(view) {
@@ -212,7 +210,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_request_move(&mut self, view: WlcView, _dest: Point) {
+    fn view_request_move(&self, view: WlcView, _dest: Point) {
         if let Ok(mut tree) = try_lock_tree() {
             if let Err(err) = tree.set_active_view(view) {
                 error!("view_request_move error: {:?}", err);
@@ -220,7 +218,7 @@ impl Mode for Default {
         }
     }
 
-     fn view_request_resize(&mut self, view: WlcView, edge: ResizeEdge, point: Point) {
+    fn view_request_resize(&self, view: WlcView, edge: ResizeEdge, point: Point) {
         if let Ok(mut tree) = try_lock_tree() {
             match try_lock_action() {
                 Ok(guard) => {
@@ -237,7 +235,7 @@ impl Mode for Default {
         }
     }
 
-     fn on_keyboard_key(&mut self, _view: WlcView, _time: u32, mods: KeyboardModifiers,
+    fn on_keyboard_key(&self, _view: WlcView, _time: u32, mods: KeyboardModifiers,
                             key: u32, state: KeyState) -> bool {
         let empty_mods: KeyboardModifiers = KeyboardModifiers {
                 mods: MOD_NONE,
@@ -274,7 +272,7 @@ impl Mode for Default {
         return EVENT_PASS_THROUGH
     }
 
-     fn view_request_geometry(&mut self, view: WlcView, geometry: Geometry) {
+    fn view_request_geometry(&self, view: WlcView, geometry: Geometry) {
         if let Ok(mut tree) = try_lock_tree() {
             tree.update_floating_geometry(view, geometry).unwrap_or_else(|_| {
                 warn!("Could not find view {:#?} \
@@ -284,7 +282,7 @@ impl Mode for Default {
         }
     }
 
-     fn on_pointer_button(&mut self, view: WlcView, _time: u32,
+    fn on_pointer_button(&self, view: WlcView, _time: u32,
                             mods: KeyboardModifiers, button: u32,
                                 state: ButtonState, point: Point) -> bool {
         if state == ButtonState::Pressed {
@@ -375,13 +373,13 @@ impl Mode for Default {
         EVENT_PASS_THROUGH
     }
 
-     fn on_pointer_scroll(&mut self, _view: WlcView, _time: u32,
+    fn on_pointer_scroll(&self, _view: WlcView, _time: u32,
                             _mods_ptr: KeyboardModifiers, _axis: ScrollAxis,
                             _heights: [f64; 2]) -> bool {
         EVENT_PASS_THROUGH
     }
 
-     fn on_pointer_motion(&mut self, view: WlcView, _time: u32, point: Point) -> bool {
+    fn on_pointer_motion(&self, view: WlcView, _time: u32, point: Point) -> bool {
         let mut result = EVENT_PASS_THROUGH;
         let mut maybe_action = None;
         {
@@ -422,7 +420,7 @@ impl Mode for Default {
         result
     }
 
-     fn view_pre_render(&mut self, view: WlcView) {
+    fn view_pre_render(&self, view: WlcView) {
         if let Ok(mut tree) = lock_tree() {
             tree.render_borders(view).unwrap_or_else(|err| {
                 match err {

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -351,13 +351,6 @@ impl Mode for Default {
             }
         } else {
             if let Ok(lock) = try_lock_action() {
-                let unknown = format!("unknown ({})", button);
-                info!("User released {:?} mouse button",
-                    match button {
-                        RIGHT_CLICK => "right",
-                        LEFT_CLICK => "left",
-                        _ => unknown.as_str()
-                    });
                 match *lock {
                     Some(action) => {
                         let view = action.view;

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -13,112 +13,45 @@
 //! always execute some custom Lua code.
 
 use std::ops::Deref;
-use rustwlc::*;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockResult};
 
+mod mode;
 mod default;
 mod custom_lua;
+pub use self::mode::Mode;
 pub use self::default::Default;
 pub use self::custom_lua::CustomLua;
+
+/// If the event is handled by way-cooler
+pub const EVENT_BLOCKED: bool = true;
+/// If the event should be passed through to clients
+pub const EVENT_PASS_THROUGH: bool = false;
+/// Left click constant, used in `on_pointer_button`
+pub const LEFT_CLICK: u32 = 0x110;
+/// Right click constant, used in `on_pointer_button`
+pub const RIGHT_CLICK: u32 = 0x111;
 
 /// The different modes that Way Cooler can be in
 /// * `Default`: The default mode for Way Cooler, this is the standard mode
 /// that it starts out in
 /// * `CustomLua`: Same as `Default`, except it calls any custom defined
 /// callbacks in the Lua configuration file at the end of the call back.
-
 pub enum Modes {
     Default(Default),
     CustomLua(CustomLua)
 }
 
-/// If the event is handled by way-cooler
-const EVENT_BLOCKED: bool = true;
-/// If the event should be passed through to clients
-const EVENT_PASS_THROUGH: bool = false;
-const LEFT_CLICK: u32 = 0x110;
-const RIGHT_CLICK: u32 = 0x111;
+lazy_static! {
+    static ref CURRENT_MODE: RwLock<Modes> =
+        RwLock::new(Modes::Default(Default));
+}
 
-pub trait Mode {
-    fn output_created(&mut self, output: WlcOutput) -> bool {
-        Default.output_created(output)
-    }
-    fn output_destroyed(&mut self, output: WlcOutput) {
-        Default.output_destroyed(output)
-    }
-    fn output_focused(&mut self, output: WlcOutput, focused: bool) {
-        Default.output_focused(output, focused)
-    }
-    fn output_resolution(&mut self, output: WlcOutput,
-                         old_size: Size, new_size: Size) {
-        Default.output_resolution(output, old_size, new_size)
-    }
-    fn output_render_post(&mut self, output: WlcOutput) {
-        Default.output_render_post(output)
-    }
-    fn view_created(&mut self, view: WlcView) -> bool {
-        Default.view_created(view)
-    }
-    fn view_destroyed(&mut self, view: WlcView) {
-        Default.view_destroyed(view)
-    }
-    fn view_focused(&mut self, view: WlcView, focused: bool) {
-        Default.view_focused(view, focused)
-    }
-    fn view_props_changed(&mut self, view: WlcView, prop: ViewPropertyType) {
-        Default.view_props_changed(view, prop)
-    }
-    fn view_request_state(&mut self,
-                          view: WlcView,
-                          state: ViewState,
-                          toggle: bool) {
-        Default.view_request_state(view, state, toggle)
-    }
-    fn view_request_geometry(&mut self, view: WlcView, geometry: Geometry) {
-        Default.view_request_geometry(view, geometry)
-    }
-    fn view_request_move(&mut self, view: WlcView, dest: Point) {
-        Default.view_request_move(view, dest)
-    }
-    fn view_request_resize(&mut self,
-                           view: WlcView,
-                           edge: ResizeEdge,
-                           point: Point) {
-        Default.view_request_resize(view, edge, point)
-    }
-    fn view_pre_render(&mut self, view: WlcView) {
-        Default.view_pre_render(view)
-    }
-    fn on_keyboard_key(&mut self,
-                       view: WlcView,
-                       time: u32,
-                       mods: KeyboardModifiers,
-                       key: u32,
-                       state: KeyState) -> bool {
-        Default.on_keyboard_key(view, time, mods, key, state)
-    }
-    fn on_pointer_button(&mut self,
-                         view: WlcView,
-                         time: u32,
-                         mods: KeyboardModifiers,
-                         button: u32,
-                         state: ButtonState,
-                         point: Point) -> bool {
-        Default.on_pointer_button(view, time, mods, button, state, point)
-    }
-    fn on_pointer_scroll(&mut self,
-                         view: WlcView,
-                         time: u32,
-                         mods: KeyboardModifiers,
-                         axis: ScrollAxis,
-                         heights: [f64; 2]) -> bool {
-        Default.on_pointer_scroll(view, time, mods, axis, heights)
-    }
-    fn on_pointer_motion(&mut self,
-                         view: WlcView,
-                         time: u32,
-                         point: Point) -> bool {
-        Default.on_pointer_motion(view, time, point)
-    }
+pub fn write_current_mode<'a>() -> TryLockResult<RwLockWriteGuard<'a, Modes>> {
+    CURRENT_MODE.try_write()
+}
+
+pub fn read_current_mode<'a>() -> TryLockResult<RwLockReadGuard<'a, Modes>> {
+    CURRENT_MODE.try_read()
 }
 
 impl Deref for Modes {

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -43,7 +43,7 @@ pub enum Modes {
 
 lazy_static! {
     static ref CURRENT_MODE: RwLock<Modes> =
-        RwLock::new(Modes::CustomLua(CustomLua));
+        RwLock::new(Modes::Default(Default));
 }
 
 pub fn write_current_mode<'a>() -> TryLockResult<RwLockWriteGuard<'a, Modes>> {

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -18,6 +18,7 @@ use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockResult};
 mod mode;
 mod default;
 mod custom_lua;
+pub mod commands;
 pub use self::mode::Mode;
 pub use self::default::Default;
 pub use self::custom_lua::CustomLua;
@@ -36,6 +37,7 @@ pub const RIGHT_CLICK: u32 = 0x111;
 /// that it starts out in
 /// * `CustomLua`: Same as `Default`, except it calls any custom defined
 /// callbacks in the Lua configuration file at the end of the call back.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Modes {
     Default(Default),
     CustomLua(CustomLua)

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -43,7 +43,7 @@ pub enum Modes {
 
 lazy_static! {
     static ref CURRENT_MODE: RwLock<Modes> =
-        RwLock::new(Modes::Default(Default));
+        RwLock::new(Modes::CustomLua(CustomLua));
 }
 
 pub fn write_current_mode<'a>() -> TryLockResult<RwLockWriteGuard<'a, Modes>> {

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -1,0 +1,133 @@
+//! Way Cooler exists in one of several different "Modes"
+//! The current mode defines what Way Cooler does in each callback.
+//!
+//! The central use of this is to define different commands that the user can
+//! run.
+//!
+//! For example, when the lock screen mode is active the user can't do anything
+//! other than send input to the lock screen program.
+//!
+//! We also allow users to define their own custom modes, which allows them to
+//! hook into the callbacks from Lua. In the `CustomLua` mode, callbacks do
+//! the same thing as they do in the `Default` mode, but at the end of will
+//! always execute some custom Lua code.
+
+use std::ops::Deref;
+use rustwlc::*;
+
+mod default;
+mod custom_lua;
+pub use self::default::Default;
+pub use self::custom_lua::CustomLua;
+
+/// The different modes that Way Cooler can be in
+/// * `Default`: The default mode for Way Cooler, this is the standard mode
+/// that it starts out in
+/// * `CustomLua`: Same as `Default`, except it calls any custom defined
+/// callbacks in the Lua configuration file at the end of the call back.
+
+pub enum Modes {
+    Default(Default),
+    CustomLua(CustomLua)
+}
+
+/// If the event is handled by way-cooler
+const EVENT_BLOCKED: bool = true;
+/// If the event should be passed through to clients
+const EVENT_PASS_THROUGH: bool = false;
+const LEFT_CLICK: u32 = 0x110;
+const RIGHT_CLICK: u32 = 0x111;
+
+pub trait Mode {
+    fn output_created(&mut self, output: WlcOutput) -> bool {
+        Default.output_created(output)
+    }
+    fn output_destroyed(&mut self, output: WlcOutput) {
+        Default.output_destroyed(output)
+    }
+    fn output_focused(&mut self, output: WlcOutput, focused: bool) {
+        Default.output_focused(output, focused)
+    }
+    fn output_resolution(&mut self, output: WlcOutput,
+                         old_size: Size, new_size: Size) {
+        Default.output_resolution(output, old_size, new_size)
+    }
+    fn output_render_post(&mut self, output: WlcOutput) {
+        Default.output_render_post(output)
+    }
+    fn view_created(&mut self, view: WlcView) -> bool {
+        Default.view_created(view)
+    }
+    fn view_destroyed(&mut self, view: WlcView) {
+        Default.view_destroyed(view)
+    }
+    fn view_focused(&mut self, view: WlcView, focused: bool) {
+        Default.view_focused(view, focused)
+    }
+    fn view_props_changed(&mut self, view: WlcView, prop: ViewPropertyType) {
+        Default.view_props_changed(view, prop)
+    }
+    fn view_request_state(&mut self,
+                          view: WlcView,
+                          state: ViewState,
+                          toggle: bool) {
+        Default.view_request_state(view, state, toggle)
+    }
+    fn view_request_geometry(&mut self, view: WlcView, geometry: Geometry) {
+        Default.view_request_geometry(view, geometry)
+    }
+    fn view_request_move(&mut self, view: WlcView, dest: Point) {
+        Default.view_request_move(view, dest)
+    }
+    fn view_request_resize(&mut self,
+                           view: WlcView,
+                           edge: ResizeEdge,
+                           point: Point) {
+        Default.view_request_resize(view, edge, point)
+    }
+    fn view_pre_render(&mut self, view: WlcView) {
+        Default.view_pre_render(view)
+    }
+    fn on_keyboard_key(&mut self,
+                       view: WlcView,
+                       time: u32,
+                       mods: KeyboardModifiers,
+                       key: u32,
+                       state: KeyState) -> bool {
+        Default.on_keyboard_key(view, time, mods, key, state)
+    }
+    fn on_pointer_button(&mut self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         button: u32,
+                         state: ButtonState,
+                         point: Point) -> bool {
+        Default.on_pointer_button(view, time, mods, button, state, point)
+    }
+    fn on_pointer_scroll(&mut self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         axis: ScrollAxis,
+                         heights: [f64; 2]) -> bool {
+        Default.on_pointer_scroll(view, time, mods, axis, heights)
+    }
+    fn on_pointer_motion(&mut self,
+                         view: WlcView,
+                         time: u32,
+                         point: Point) -> bool {
+        Default.on_pointer_motion(view, time, point)
+    }
+}
+
+impl Deref for Modes {
+    type Target = Mode;
+
+    fn deref(&self) -> &(Mode + 'static) {
+        match *self {
+            Modes::Default(ref mode) => mode as &Mode,
+            Modes::CustomLua(ref mode) => mode as &Mode
+        }
+    }
+}

--- a/src/modes/mode.rs
+++ b/src/modes/mode.rs
@@ -1,0 +1,96 @@
+//! The trait that should be implemented for every variant in the `Modes`
+//! enum. These define what to do on each wlc callback.
+//!
+//! If any are left unspecified, they execute the `Default` operation.
+use rustwlc::*;
+use super::default::Default;
+
+
+pub trait Mode {
+    fn output_created(&self, output: WlcOutput) -> bool {
+        Default.output_created(output)
+    }
+    fn output_destroyed(&self, output: WlcOutput) {
+        Default.output_destroyed(output)
+    }
+    fn output_focused(&self, output: WlcOutput, focused: bool) {
+        Default.output_focused(output, focused)
+    }
+    fn output_resolution(&self, output: WlcOutput,
+                         old_size: Size, new_size: Size) {
+        Default.output_resolution(output, old_size, new_size)
+    }
+    fn output_render_post(&self, output: WlcOutput) {
+        Default.output_render_post(output)
+    }
+    fn view_moved_to_output(&self,
+                            view: WlcView,
+                            o1: WlcOutput,
+                            o2: WlcOutput) {
+        Default.view_moved_to_output(view, o1, o2)
+    }
+    fn view_created(&self, view: WlcView) -> bool {
+        Default.view_created(view)
+    }
+    fn view_destroyed(&self, view: WlcView) {
+        Default.view_destroyed(view)
+    }
+    fn view_focused(&self, view: WlcView, focused: bool) {
+        Default.view_focused(view, focused)
+    }
+    fn view_props_changed(&self, view: WlcView, prop: ViewPropertyType) {
+        Default.view_props_changed(view, prop)
+    }
+    fn view_request_state(&self,
+                          view: WlcView,
+                          state: ViewState,
+                          toggle: bool) {
+        Default.view_request_state(view, state, toggle)
+    }
+    fn view_request_geometry(&self, view: WlcView, geometry: Geometry) {
+        Default.view_request_geometry(view, geometry)
+    }
+    fn view_request_move(&self, view: WlcView, dest: Point) {
+        Default.view_request_move(view, dest)
+    }
+    fn view_request_resize(&self,
+                           view: WlcView,
+                           edge: ResizeEdge,
+                           point: Point) {
+        Default.view_request_resize(view, edge, point)
+    }
+    fn view_pre_render(&self, view: WlcView) {
+        Default.view_pre_render(view)
+    }
+    fn on_keyboard_key(&self,
+                       view: WlcView,
+                       time: u32,
+                       mods: KeyboardModifiers,
+                       key: u32,
+                       state: KeyState) -> bool {
+        Default.on_keyboard_key(view, time, mods, key, state)
+    }
+    fn on_pointer_button(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         button: u32,
+                         state: ButtonState,
+                         point: Point) -> bool {
+        Default.on_pointer_button(view, time, mods, button, state, point)
+    }
+    fn on_pointer_scroll(&self,
+                         view: WlcView,
+                         time: u32,
+                         mods: KeyboardModifiers,
+                         axis: ScrollAxis,
+                         heights: [f64; 2]) -> bool {
+        Default.on_pointer_scroll(view, time, mods, axis, heights)
+    }
+    fn on_pointer_motion(&self,
+                         view: WlcView,
+                         time: u32,
+                         point: Point) -> bool {
+        Default.on_pointer_motion(view, time, point)
+    }
+}


### PR DESCRIPTION
Way Cooler now has the concept of "modes". :tada:

Modes influence how the window manager reacts when the user does different operations, primarily by built-in modes currently but also with a rudimentary custom mode option where the user can define what happens when certain events happen in the Lua file. This could eventually help influence the current keybindings, the way windows are tiled on the screen, or even what's rendered on the screen.

One of the most immediate use cases for this is a simple way to implement a lock screen for Way Cooler without pepppering everything with annoying if statements. 

The main thing this PR adds from the user side however is rudimentary user-defined modes. Eventually, we want the user to be able to make named modes, where they can change the keybindings, what windows can be created, and other such fun things. 

For now, there is only two modes: `Default`, which is Way Cooler exactly as it was before, and `Custom`. 

In `Custom` mode Way Cooler does the same operations it's always done, but now it calls special Lua callbacks on the completion of those tasks with relevant information.

For example, from Lua it's now possible to listen to all view creations and, for example, do something special when your editor is spawned for the first time (maybe spawn a music player, or a browser).

Right now, the support is very basic. Eventually the keys declaration in particular will change drastically, where you can define keys to be used in either the "default" mode or any custom named modes you want.

This PR was kept simple, for one because it changed a lot of code, but also because we want to minimize the amount of configuration breakage between 0.5.2 and 0.6.

Unblocks #279 and #286
Fixes #287 