### PR TITLE
Tabbed/stacked layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ and is not backwards compatible with existing X11 tools, we wanted to put our st
 
 ## Current Features
 - i3-style tiling
-  * Horizontal/vertical layouts
+  * Horizontal/Vertical layouts
+  * Tabbed/Stacked layouts
   * Nest containers with different layouts
   * Floating windows per workspace
 - Client application support via the D-Bus IPC
@@ -43,14 +44,13 @@ and is not backwards compatible with existing X11 tools, we wanted to put our st
   * Lua is the configuration format, allowing the user to enhance their window manager in any way they want.
   * Utilities library included to aid communicating with Way Cooler
 - X programs supported through XWayland
-- Borders around windows
-- Gaps between windows
+- Borders around containers
+- Gaps between containers
 - Basic X11 bar support (e.g [lemonbar][], [polybar][])
 - Screen grabber / screen shot taker
 
 ## Planned Features
 
-- i3 tabbed/stacked tiling
 - Notification support
 - Lock screen
 - Tiling window through configurable Lua scripts (awesome-style)

--- a/config/init.lua
+++ b/config/init.lua
@@ -100,6 +100,8 @@ local keys = {
   key({ mod }, "h", "split_horizontal"),
   key({ mod }, "v", "split_vertical"),
   key({ mod }, "e", "horizontal_vertical_switch"),
+  key({ mod }, "s", "tile_stacked"),
+  key({ mod }, "w", "tile_tabbed"),
   key({ mod }, "f", "fullscreen_toggle"),
   key({ mod, "Shift" }, "q", "close_window"),
   key({ mod, "Shift" }, "space", "toggle_float_active"),

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -89,6 +89,8 @@ pub fn register_defaults() {
     register("horizontal_vertical_switch", Arc::new(layout_cmds::tile_switch));
     register("split_vertical", Arc::new(layout_cmds::split_vertical));
     register("split_horizontal", Arc::new(layout_cmds::split_horizontal));
+    register("tile_tabbed", Arc::new(layout_cmds::tile_tabbed));
+    register("tile_stacked", Arc::new(layout_cmds::tile_stacked));
     register("fullscreen_toggle", Arc::new(layout_cmds::fullscreen_toggle));
     register("focus_left", Arc::new(layout_cmds::focus_left));
     register("focus_right", Arc::new(layout_cmds::focus_right));

--- a/src/ipc/layout.rs
+++ b/src/ipc/layout.rs
@@ -55,7 +55,9 @@ dbus_interface! {
         // for now this is _ok_, but we are swallowing an potential Tree lock error here.
         match axis {
             Layout::Horizontal => layout_cmd::split_horizontal(),
-            Layout::Vertical => layout_cmd::split_vertical()
+            Layout::Vertical => layout_cmd::split_vertical(),
+            Layout::Tabbed => layout_cmd::tile_tabbed(),
+            Layout::Stacked => layout_cmd::tile_stacked()
         }
         Ok(true)
     }

--- a/src/layout/actions/borders.rs
+++ b/src/layout/actions/borders.rs
@@ -1,0 +1,58 @@
+use std::cmp;
+
+use petgraph::graph::NodeIndex;
+use rustwlc::{WlcView, Geometry, Point, Size, ResizeEdge};
+
+use super::super::{LayoutTree, TreeError};
+use super::super::commands::CommandResult;
+use super::super::core::container::{self, Container, ContainerType, ContainerErr,
+                                    Layout, Handle};
+use ::layout::core::borders::Borders;
+use ::render::Renderable;
+use ::debug_enabled;
+use uuid::Uuid;
+
+
+/// The mode the borders can be in. This affects the color primarily.
+pub enum Mode {
+    /// Borders are active, this means they are focused.
+    Active,
+    /// Borders are inactive, this means they are not focused.
+    Inactive
+}
+
+impl LayoutTree {
+    /// Sets the borders for the given node to active.
+    /// Automatically sets the borders for the ancestor borders as well.
+    pub fn set_borders(&mut self, mut node_ix: NodeIndex, focus: Mode)
+                              -> CommandResult {
+        match self.tree[node_ix] {
+            Container::Root(id) |
+            Container::Output {id, .. } |
+            Container::Workspace {id, .. } =>
+                return Err(
+                    TreeError::UuidWrongType(id,
+                                             vec![ContainerType::View,
+                                                  ContainerType::Container])),
+            _ => {}
+        }
+        while self.tree[node_ix].get_type() != ContainerType::Workspace {
+            match focus {
+                Mode::Active =>
+                    if !self.tree.on_path(node_ix) { break },
+                Mode::Inactive =>
+                    if self.tree.on_path(node_ix)  { break }
+            }
+            {
+                let container = &mut self.tree[node_ix];
+                match focus {
+                    Mode::Active => container.active_border_color()?,
+                    Mode::Inactive => container.clear_border_color()?
+                }
+                container.draw_borders()?;
+            }
+            node_ix = self.tree.parent_of(node_ix)?;
+        }
+        Ok(())
+    }
+}

--- a/src/layout/actions/borders.rs
+++ b/src/layout/actions/borders.rs
@@ -1,17 +1,8 @@
-use std::cmp;
-
 use petgraph::graph::NodeIndex;
-use rustwlc::{WlcView, Geometry, Point, Size, ResizeEdge};
 
 use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
-use super::super::core::container::{self, Container, ContainerType, ContainerErr,
-                                    Layout, Handle};
-use ::layout::core::borders::Borders;
-use ::render::Renderable;
-use ::debug_enabled;
-use uuid::Uuid;
-
+use super::super::core::container::{Container, ContainerType};
 
 /// The mode the borders can be in. This affects the color primarily.
 pub enum Mode {

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -87,8 +87,12 @@ impl LayoutTree {
                 match (layout, direction) {
                     (Layout::Horizontal, Direction::Left) |
                     (Layout::Horizontal, Direction::Right) |
+                    (Layout::Tabbed, Direction::Left) |
+                    (Layout::Tabbed, Direction::Right) |
                     (Layout::Vertical, Direction::Up) |
-                    (Layout::Vertical, Direction::Down) => {
+                    (Layout::Vertical, Direction::Down) |
+                    (Layout::Stacked,  Direction::Up) |
+                    (Layout::Stacked,  Direction::Down) => {
                         let siblings = self.tree.children_of(parent_ix);
                         let cur_index = siblings.iter().position(|node| {
                             *node == node_ix

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -312,6 +312,25 @@ impl LayoutTree {
             Ok(())
         }
     }
+
+    /// Sets all the nodes under and at the node index to the given
+    /// visibilty setting
+    pub fn set_container_visibility(&mut self, node_ix: NodeIndex, val: bool) {
+        let container_c;
+        {
+            let container = &mut self.tree[node_ix];
+            container_c = container.get_type();
+            container.set_visibility(val);
+        }
+        match container_c {
+            ContainerType::View => {},
+            _ => {
+                for child_ix in self.tree.children_of(node_ix) {
+                    self.set_container_visibility(child_ix, val);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -792,7 +792,21 @@ impl LayoutTree {
                     geometry.size.h = geometry.size.h.saturating_sub(title_size);
                     handle.set_geometry(ResizeEdge::empty(), geometry);
                 },
-                Container::Container { .. } => {/*recurse*/},
+                Container::Container { ref mut geometry, ref borders, .. } => {
+                    if borders.is_some() {
+                        let thickness = Borders::thickness();
+                        if thickness == 0 {
+                            return Ok(())
+                        }
+                        let edge_thickness = (thickness / 2) as i32;
+                        let title_size = Borders::title_bar_size();
+                        geometry.origin.x += edge_thickness;
+                        geometry.origin.y += edge_thickness;
+                        geometry.origin.y += (title_size / 2) as i32;
+                        geometry.size.h = geometry.size.h
+                            .saturating_sub(thickness);
+                    }
+                },
                 ref container => {
                     error!("Attempted to add borders to non-view/container");
                     error!("Found {:#?}", container);

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -231,11 +231,9 @@ impl LayoutTree {
                             return;
                         }
                         children.push(node_ix);
-                        let c_geometry = self.tree[node_ix].get_geometry()
-                            .expect("Container had no geometry");
                         if let Some(visible_child) = self.tree.next_active_node(node_ix) {
                             self.layout_helper(visible_child,
-                                               c_geometry,
+                                               geometry,
                                                fullscreen_apps);
                             let workspace_ix = self.tree.ancestor_of_type(
                                 node_ix, ContainerType::Workspace)

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -237,10 +237,16 @@ impl LayoutTree {
                             self.layout_helper(visible_child,
                                                c_geometry,
                                                fullscreen_apps);
-                            // set all the children invisible
-                            self.set_container_visibility(node_ix, false);
-                            // set the focused child to be visible
-                            self.set_container_visibility(visible_child, true);
+                            let workspace_ix = self.tree.ancestor_of_type(
+                                node_ix, ContainerType::Workspace)
+                                .expect("Node did not have a workspace as an ancestor");
+                            // Set visibilty if on active workspace
+                            if self.tree.on_path(workspace_ix) {
+                                // set all the children invisible
+                                self.set_container_visibility(node_ix, false);
+                                // set the focused child to be visible
+                                self.set_container_visibility(visible_child, true);
+                            }
                         }
                         // TODO Propogate error
                         self.draw_borders_rec(children).ok();

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -538,7 +538,8 @@ impl LayoutTree {
         for (index, child_ix) in children.iter().enumerate() {
             let child_size: Size;
             {
-                let child = &self.tree[*child_ix];
+                let child = &mut self.tree[*child_ix];
+                child.set_visibility(true);
                 child_size = child.get_geometry()
                     .expect("Child had no geometry").size;
             }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -170,9 +170,6 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children.as_slice(),
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
-                            for child_ix in &children {
-                                self.tree[*child_ix].set_visibility(true);
-                            }
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to horizontal container");
                             // TODO Propogate error
@@ -222,9 +219,6 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children.as_slice(),
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
-                            for child_ix in &children {
-                                self.tree[*child_ix].set_visibility(true);
-                            }
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to vertical container");
                             // TODO Propogate error
@@ -502,12 +496,11 @@ impl LayoutTree {
                 let parent_id = try!(self.parent_of(id)).get_id();
                 return self.toggle_cardinal_tiling(parent_id)
             }
-            let container = &mut self.tree[node_ix];
-            let new_layout = match container.get_layout()? {
+            let new_layout = match self.tree[node_ix].get_layout()? {
                 Layout::Horizontal => Layout::Vertical,
                 _ => Layout::Horizontal
             };
-            container.set_layout(new_layout)?;
+            self.set_layout(node_ix, new_layout)
         }
         self.validate();
         Ok(())
@@ -579,6 +572,11 @@ impl LayoutTree {
             ref container => {
                 warn!("Can not set layout on non-container {:#?}", container);
                 return;
+            }
+        }
+        if new_layout == Layout::Vertical || new_layout == Layout::Horizontal {
+            for child_ix in self.tree.children_of(node_ix) {
+                self.tree[child_ix].set_visibility(true);
             }
         }
     }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -414,12 +414,7 @@ impl LayoutTree {
                 Handle::Output(handle) => handle,
                 _ => unreachable!()
             };
-            let borders = Borders::new(active_geometry, output)
-                // TODO This will change when we get proper tabbed/stacked borders
-                .map(|mut b| {
-                    b.title = format!("{:?} container", new_layout);
-                    b
-                });
+            let borders = Borders::new(active_geometry, output);
             let mut new_container = Container::new_container(active_geometry,
                                                              borders);
             new_container.set_layout(new_layout).ok();

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -131,7 +131,7 @@ impl LayoutTree {
                         let children = self.tree.grounded_children(node_ix);
                         let children_len = children.len();
                         let mut scale = LayoutTree::calculate_scale(children.iter().map(|child_ix| {
-                            let c_geometry = self.tree[*child_ix].get_actual_geometry()
+                            let c_geometry = self.tree[*child_ix].get_geometry()
                                 .expect("Child had no geometry");
                             c_geometry.size.w as f32
                         }).collect(), geometry.size.w as f32);
@@ -180,7 +180,7 @@ impl LayoutTree {
                         let children = self.tree.grounded_children(node_ix);
                         let children_len = children.len();
                         let mut scale = LayoutTree::calculate_scale(children.iter().map(|child_ix| {
-                            let c_geometry = self.tree[*child_ix].get_actual_geometry()
+                            let c_geometry = self.tree[*child_ix].get_geometry()
                                 .expect("Child had no geometry");
                             c_geometry.size.h as f32
                         }).collect(), geometry.size.h as f32);
@@ -796,7 +796,6 @@ impl LayoutTree {
                     let thickness = Borders::thickness();
                     let edge_thickness = thickness / 2;
                     let title_size = Borders::title_bar_size();
-
                     geometry.origin.y += edge_thickness as i32;
                     geometry.origin.y += (title_size / 2) as i32;
                     geometry.size.h = geometry.size.h.saturating_sub(edge_thickness);
@@ -822,17 +821,17 @@ impl LayoutTree {
             .expect("Container had no geometry");
         match *container {
             Container::View { handle, .. } => {
-                let borders = Borders::thickness();
-                if borders == 0 {
+                let thickness = Borders::thickness();
+                if thickness == 0 {
                     return Ok(())
                 }
-                let edge_thickness = (borders / 2) as i32;
+                let edge_thickness = (thickness / 2) as i32;
                 let title_size = Borders::title_bar_size();
                 geometry.origin.x += edge_thickness;
                 geometry.origin.y += edge_thickness;
                 geometry.origin.y += title_size as i32;
-                geometry.size.w = geometry.size.w.saturating_sub(borders);
-                geometry.size.h = geometry.size.h.saturating_sub(borders);
+                geometry.size.w = geometry.size.w.saturating_sub(thickness);
+                geometry.size.h = geometry.size.h.saturating_sub(thickness);
                 geometry.size.h = geometry.size.h.saturating_sub(title_size);
                 handle.set_geometry(ResizeEdge::empty(), geometry);
             },

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -417,7 +417,14 @@ impl LayoutTree {
                 _ => unreachable!()
             };
             let borders = Borders::new(active_geometry, output);
+            let output_c = self.tree.ancestor_of_type(active_ix,
+                                                      ContainerType::Output)?;
+            let output_handle = match self.tree[output_c].get_handle()? {
+                Handle::Output(output) => output,
+                _ => unreachable!()
+            };
             let mut new_container = Container::new_container(active_geometry,
+                                                             output_handle,
                                                              borders);
             new_container.set_layout(new_layout).ok();
             self.add_container(new_container, active_ix)?;

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -575,8 +575,11 @@ impl LayoutTree {
             }
         }
         if new_layout == Layout::Vertical || new_layout == Layout::Horizontal {
-            for child_ix in self.tree.children_of(node_ix) {
-                self.tree[child_ix].set_visibility(true);
+            let workspace_ix = self.tree.ancestor_of_type(
+                node_ix, ContainerType::Workspace)
+                .expect("Node did not have a workspace as an ancestor");
+            if self.tree.on_path(workspace_ix) {
+                self.set_container_visibility(node_ix, true)
             }
         }
     }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -791,7 +791,9 @@ impl LayoutTree {
 
         match *container {
             Container::Container { ref mut apparent_geometry,
+                                   geometry: ref mut actual_geometry,
                                    ref borders, .. } => {
+                *actual_geometry = geometry;
                 if borders.is_some() {
                     let thickness = Borders::thickness();
                     let edge_thickness = thickness / 2;

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -181,6 +181,7 @@ impl LayoutTree {
                         }
                     }
                     Layout::Vertical => {
+                        self.tree[node_ix].draw_borders();
                         let children = self.tree.grounded_children(node_ix);
                         let children_len = children.len();
                         let mut scale = LayoutTree::calculate_scale(children.iter().map(|child_ix| {
@@ -235,8 +236,13 @@ impl LayoutTree {
                         if children.len() == 0 {
                             return;
                         }
-                        let c_geometry = self.tree[node_ix].get_geometry()
-                            .expect("Container had no geometry");
+                        let c_geometry;
+                        {
+                            let container = &mut self.tree[node_ix];
+                            container.draw_borders();
+                            c_geometry = container.get_geometry()
+                                .expect("Container had no geometry");
+                        }
                         if let Some(visible_child) = self.tree.next_active_node(node_ix) {
                             self.layout_helper(visible_child,
                                             c_geometry,
@@ -680,7 +686,7 @@ impl LayoutTree {
                     handle.set_geometry(ResizeEdge::empty(), output_geometry);
                     handle.bring_to_front();
                     let views = handle.get_output().get_views();
-                    // TODO It would be nice to not have to iterate vier
+                    // TODO It would be nice to not have to iterate over
                     // all the views just to do this.
                     for view in views {
                         // make sure children render above fullscreen parent

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -231,11 +231,8 @@ impl LayoutTree {
                             return;
                         }
                         children.push(node_ix);
-                        let c_geometry = match self.tree[node_ix] {
-                            Container::Container { apparent_geometry, .. } =>
-                                apparent_geometry,
-                            _ => unreachable!()
-                        };
+                        let c_geometry = self.tree[node_ix].get_geometry()
+                            .expect("Container had no geometry");
                         if let Some(visible_child) = self.tree.next_active_node(node_ix) {
                             self.layout_helper(visible_child,
                                                c_geometry,

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -247,6 +247,8 @@ impl LayoutTree {
                             }
                         }
                         // TODO Propogate error
+                        self.add_gaps(node_ix)
+                            .expect("Couldn't add gaps to tabbed/stacked container");
                         self.draw_borders_rec(children).ok();
                     },
                 }
@@ -736,8 +738,10 @@ impl LayoutTree {
                             Layout::Vertical => {
                                 geometry.size.h = geometry.size.h.saturating_sub(gap / 2)
                             },
-                            // TODO Gaps for tabbed/stacked
-                            _ => {}
+                            _ => {
+                                // Nothing special for the last container,
+                                // since only one is visible at a time
+                            }
                         }
                     }
                     match layout {
@@ -750,9 +754,8 @@ impl LayoutTree {
                             geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
                         },
                         Layout::Tabbed | Layout::Stacked => {
-                            /* Should not be gaps within a stacked / tabbed,
-                             * because only one view is visible at a time.
-                             */
+                            geometry.size.w = geometry.size.w.saturating_sub(gap);
+                            geometry.size.h = geometry.size.h.saturating_sub(gap)
                         }
                     }
                     handle.set_geometry(ResizeEdge::empty(), geometry);

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -7,6 +7,7 @@ use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
 use super::super::core::container::{Container, ContainerType, ContainerErr,
                                     Layout, Handle};
+use super::borders;
 use ::layout::core::borders::Borders;
 use ::render::Renderable;
 use ::debug_enabled;
@@ -850,18 +851,8 @@ impl LayoutTree {
             let children = self.tree.children_of(parent_ix);
             let index = children.iter().position(|&node_ix| node_ix == child_ix)
                 .map(|num| (num + 1).to_string());
-            let container;
             if Some(child_ix) != self.active_container {
-                // TODO Just unpaint conditonally all up the tree
-                // This should be the same for the parent drawing below
-                // in the else case
-                if !self.tree.on_path(parent_ix) {
-                    let parent_container = &mut self.tree[parent_ix];
-                    parent_container.clear_border_color()?;
-                    parent_container.draw_borders()?;
-                }
-                container = &mut self.tree[child_ix];
-                container.clear_border_color()?;
+                self.set_borders(child_ix, borders::Mode::Inactive)?;
             } else {
                 match self.tree[parent_ix] {
                     Container::Container { layout, ref mut borders, .. } => {
@@ -877,19 +868,11 @@ impl LayoutTree {
                     },
                     _ => {}
                 }
-                {
-                    let parent_container = &mut self.tree[parent_ix];
-                    parent_container.active_border_color()?;
-                    parent_container.draw_borders()?;
-                }
-                container = &mut self.tree[child_ix];
-                container.active_border_color()?;
+                self.set_borders(child_ix, borders::Mode::Active)?;
             }
-            container.draw_borders()?;
         }
         Ok(())
     }
-
 }
 
 #[cfg(test)]

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -835,7 +835,7 @@ impl LayoutTree {
                 .expect("Node had no parent");
             let container;
             if Some(child_ix) != self.active_container {
-                {
+                if !self.tree.on_path(parent_ix) {
                     let parent_container = &mut self.tree[parent_ix];
                     parent_container.clear_border_color()?;
                     parent_container.draw_borders()?;

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -245,14 +245,12 @@ impl LayoutTree {
                         }
                         if let Some(visible_child) = self.tree.next_active_node(node_ix) {
                             self.layout_helper(visible_child,
-                                            c_geometry,
-                                            fullscreen_apps);
-                            let mut iter = children.iter();
-                            iter.next();
-                            for child_ix in iter {
-                                self.tree[*child_ix].set_visibility(false);
-                            }
-                            self.tree[visible_child].set_visibility(true);
+                                               c_geometry,
+                                               fullscreen_apps);
+                            // set all the children invisible
+                            self.set_container_visibility(node_ix, false);
+                            // set the focused child to be visible
+                            self.set_container_visibility(visible_child, true);
                         }
                         self.draw_borders_rec(children);
                     },

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -114,7 +114,8 @@ impl LayoutTree {
                 // place floating children above everything else
                 let root_ix = self.tree.children_of(node_ix)[0];
                 for child_ix in self.tree.floating_children(root_ix) {
-                    self.place_floating(child_ix, fullscreen_apps);
+                    // TODO Propogate error
+                    self.place_floating(child_ix, fullscreen_apps).ok();
                 }
             },
             ContainerType::Container => {
@@ -177,7 +178,8 @@ impl LayoutTree {
                                               fullscreen_apps);
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to horizontal container");
-                            self.draw_borders_rec(children);
+                            // TODO Propogate error
+                            self.draw_borders_rec(children).ok();
                         }
                     }
                     Layout::Vertical => {
@@ -225,7 +227,8 @@ impl LayoutTree {
                                               fullscreen_apps);
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to vertical container");
-                            self.draw_borders_rec(children);
+                            // TODO Propogate error
+                            self.draw_borders_rec(children).ok();
                         }
                     },
                     Layout::Tabbed | Layout::Stacked => {
@@ -245,7 +248,8 @@ impl LayoutTree {
                             // set the focused child to be visible
                             self.set_container_visibility(visible_child, true);
                         }
-                        self.draw_borders_rec(children);
+                        // TODO Propogate error
+                        self.draw_borders_rec(children).ok();
                     },
                 }
             }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -535,13 +535,8 @@ impl LayoutTree {
     {
         let mut sub_geometry = geometry.clone();
         for (index, child_ix) in children.iter().enumerate() {
-            let child_size: Size;
-            {
-                let child = &mut self.tree[*child_ix];
-                child.set_visibility(true);
-                child_size = child.get_geometry()
-                    .expect("Child had no geometry").size;
-            }
+            let child_size = self.tree[*child_ix].get_geometry()
+                .expect("Child had no geometry").size;
             let new_size = new_size_f(child_size, sub_geometry.clone());
             sub_geometry = Geometry {
                 origin: sub_geometry.origin.clone(),

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -475,8 +475,9 @@ impl LayoutTree {
         self.tree[node_ix].set_layout(new_layout)
             .map_err(TreeError::Container)?;
         self.validate();
-        let parent_ix = self.tree.parent_of(node_ix)?;
-        self.layout(parent_ix);
+        let workspace_ix = self.tree.ancestor_of_type(node_ix,
+                                                      ContainerType::Workspace)?;
+        self.layout(workspace_ix);
         Ok(())
     }
 

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -171,6 +171,9 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children.as_slice(),
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
+                            for child_ix in &children {
+                                self.tree[*child_ix].set_visibility(true);
+                            }
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to horizontal container");
                             // TODO Propogate error
@@ -220,6 +223,9 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children.as_slice(),
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
+                            for child_ix in &children {
+                                self.tree[*child_ix].set_visibility(true);
+                            }
                             self.add_gaps(node_ix)
                                 .expect("Couldn't add gaps to vertical container");
                             // TODO Propogate error

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -791,7 +791,8 @@ impl LayoutTree {
                                    ref borders, .. } => {
                 *actual_geometry = geometry;
                 if borders.is_some() {
-                    let thickness = Borders::thickness();
+                    let gap = Borders::gap_size();
+                    let thickness = Borders::thickness() + gap;
                     let edge_thickness = thickness / 2;
                     let title_size = Borders::title_bar_size();
                     geometry.origin.y += edge_thickness as i32;

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -231,8 +231,11 @@ impl LayoutTree {
                             return;
                         }
                         children.push(node_ix);
-                        let c_geometry = self.tree[node_ix].get_geometry()
-                            .expect("Container had no geometry");
+                        let c_geometry = match self.tree[node_ix] {
+                            Container::Container { apparent_geometry, .. } =>
+                                apparent_geometry,
+                            _ => unreachable!()
+                        };
                         if let Some(visible_child) = self.tree.next_active_node(node_ix) {
                             self.layout_helper(visible_child,
                                                c_geometry,

--- a/src/layout/actions/mod.rs
+++ b/src/layout/actions/mod.rs
@@ -5,3 +5,4 @@ pub mod workspace;
 pub mod resize;
 pub mod pointer;
 pub mod background;
+pub mod borders;

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -151,7 +151,8 @@ impl LayoutTree {
                          .map_err(|err| MovementError::Tree(
                              Box::new(TreeError::PetGraph(err)))));
                     match self.tree[node_ix].get_handle()? {
-                        Handle::View(view) => self.normalize_view(view),
+                        Handle::View(view) => self.normalize_view(view)
+                            .map_err(|err| MovementError::Tree(Box::new(err)))?,
                         _ => unreachable!()
                     }
                 },
@@ -232,7 +233,9 @@ impl LayoutTree {
         }.map_err(|err| MovementError::Tree(Box::new(TreeError::PetGraph(err)))));
         match self.tree[node_to_move] {
             Container::View { handle, .. } => {
-                self.normalize_view(handle);
+                self.normalize_view(handle)
+                    .map_err(|err| MovementError::Tree(
+                    Box::new(err)))?;
                 Ok(parent_ix)
             },
             _ => {

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -60,6 +60,10 @@ impl LayoutTree {
                 match (layout, direction) {
                     (Layout::Horizontal, Direction::Left) |
                     (Layout::Horizontal, Direction::Right) |
+                    (Layout::Tabbed, Direction::Left) |
+                    (Layout::Tabbed, Direction::Right) |
+                    (Layout::Stacked, Direction::Up) |
+                    (Layout::Stacked, Direction::Down) |
                     (Layout::Vertical, Direction::Up) |
                     (Layout::Vertical, Direction::Down) => {
                         if let Some(ancestor_ix) = move_ancestor {

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -259,7 +259,7 @@ impl LayoutTree {
                 return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View)))
             }
         }
-        container.draw_borders();
+        container.draw_borders()?;
         Ok(())
     }
 }

--- a/src/layout/actions/resize.rs
+++ b/src/layout/actions/resize.rs
@@ -34,7 +34,7 @@ impl LayoutTree {
             let new_geo = calculate_resize(geo, edge, pointer, action.grab);
             container.set_geometry(edge, new_geo);
             container.resize_borders(new_geo);
-            container.draw_borders();
+            container.draw_borders()?;
         }
         action.grab = self.grab_at_corner(id, edge)
             .expect("Could not update pointer position");

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -2,7 +2,7 @@ use rustwlc::WlcOutput;
 use petgraph::graph::NodeIndex;
 use uuid::Uuid;
 use super::super::LayoutTree;
-use super::super::core::container::{Container, ContainerType, Layout};
+use super::super::core::container::{Container, ContainerType, Layout, Handle};
 use ::debug_enabled;
 
 // TODO This module needs to be updated like the other modules...
@@ -33,10 +33,15 @@ impl LayoutTree {
             .expect("init_workspace: invalid output").get_geometry()
             .expect("init_workspace: no geometry for output");
         let worksp = Container::new_workspace(name.to_string(), geometry);
+        let output_handle = match self.tree[output_ix].get_handle() {
+            Ok(Handle::Output(output)) => output,
+            Err(err) => panic!("Could not get handle from output: {:#?}", err),
+            _ => unreachable!()
+        };
 
         trace!("Adding workspace {:?}", worksp);
         let worksp_ix = self.tree.add_child(output_ix, worksp, false);
-        let container = Container::new_container(geometry, None);
+        let container = Container::new_container(geometry, output_handle, None);
         let container_ix = self.tree.add_child(worksp_ix, container, false);
         self.tree.set_ancestor_paths_active(container_ix);
         self.validate();

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -151,6 +151,7 @@ impl LayoutTree {
                 self.set_active_node(active_ix)
                     .expect("Could not set new active node");
                 self.tree.set_ancestor_paths_active(active_ix);
+                self.layout(workspace_ix);
                 self.validate();
                 self.validate_path();
                 return;
@@ -179,6 +180,7 @@ impl LayoutTree {
         }
         trace!("Focusing on next container");
         self.focus_on_next_container(workspace_ix);
+        self.layout(workspace_ix);
         self.validate();
         self.validate_path();
     }

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -98,14 +98,14 @@ impl LayoutTree {
         // Only set the old one to be invisible if new and old share output.
         if new_worksp_parent_ix == old_worksp_parent_ix {
             // Set the old one to invisible
-            self.tree.set_family_visible(old_worksp_ix, false);
+            self.set_container_visibility(old_worksp_ix, false);
         } else {
             // Set all views on the target output to be invisible,
             // to clear the old workspace visibilty out.
-            self.tree.set_family_visible(new_worksp_parent_ix, false);
+            self.set_container_visibility(new_worksp_parent_ix, false);
         }
         // Set the new one to visible
-        self.tree.set_family_visible(workspace_ix, true);
+        self.set_container_visibility(workspace_ix, true);
         // Focus on the new output
         match self.tree[new_worksp_parent_ix] {
             Container::Output { handle, .. } => {
@@ -203,7 +203,7 @@ impl LayoutTree {
                 trace!("Attempted to move a view to the same workspace {}!", name);
                 return;
             }
-            self.tree.set_family_visible(curr_work_ix, false);
+            self.set_container_visibility(curr_work_ix, false);
             let new_output_ix = self.tree.parent_of(next_work_ix)
                 .expect("Target workspace had no parent");
             match self.tree[new_output_ix] {
@@ -268,7 +268,7 @@ impl LayoutTree {
                 self.focus_on_next_container(curr_work_ix);
             }
 
-            self.tree.set_family_visible(curr_work_ix, true);
+            self.set_container_visibility(curr_work_ix, true);
 
             if !self.tree[active_ix].floating() {
                 self.normalize_container(active_ix);

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -89,7 +89,7 @@ impl LayoutTree {
             let container = &mut self.tree[active_ix];
             container.clear_border_color()
                 .expect("Could not clear old active border color");
-            container.draw_borders();
+            container.draw_borders().expect("Could not draw borders");
         }
         let old_worksp_parent_ix = self.tree.parent_of(old_worksp_ix)
             .expect("Old workspace had no parent");

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -300,8 +300,7 @@ impl LayoutTree {
     }
 
     /// Wrapper around `set_container_visibility`, so that tabbed/stacked
-    /// is handled correctly. Might need to generalize this else where.
-    /// For now, just used in workspace switching.
+    /// is handled correctly (i.e, it's visibilty checks are skipped).
     fn container_visibilty_wrapper(&mut self, node_ix: NodeIndex, val: bool) {
         let mut set = false;
         match self.tree[node_ix] {

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -203,6 +203,7 @@ impl LayoutTree {
                 trace!("Attempted to move a view to the same workspace {}!", name);
                 return;
             }
+            self.set_container_visibility(curr_work_ix, false);
             let new_output_ix = self.tree.parent_of(next_work_ix)
                 .expect("Target workspace had no parent");
             match self.tree[new_output_ix] {
@@ -266,7 +267,7 @@ impl LayoutTree {
             else {
                 self.focus_on_next_container(curr_work_ix);
             }
-
+            self.container_visibilty_wrapper(curr_work_ix, true);
             if !self.tree[active_ix].floating() {
                 self.normalize_container(active_ix);
             }

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -276,7 +276,7 @@ impl LayoutTree {
             }
             self.container_visibilty_wrapper(curr_work_ix, true);
             if !self.tree[active_ix].floating() {
-                self.normalize_container(active_ix);
+                self.normalize_container(active_ix).ok();
             }
         }
         let root_ix = self.tree.root_ix();

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -36,8 +36,8 @@ impl LayoutTree {
 
         trace!("Adding workspace {:?}", worksp);
         let worksp_ix = self.tree.add_child(output_ix, worksp, false);
-        let container_ix = self.tree.add_child(worksp_ix,
-                                               Container::new_container(geometry), false);
+        let container = Container::new_container(geometry, None);
+        let container_ix = self.tree.add_child(worksp_ix, container, false);
         self.tree.set_ancestor_paths_active(container_ix);
         self.validate();
         container_ix

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -615,9 +615,11 @@ impl Tree {
                       .ok_or_else(||TreeError::ViewNotFound(view)));
         self.0.tree[node_ix].render_borders();
         // Render parent container too, if applicable.
-        let parent_ix = self.0.tree.parent_of(node_ix)
-            .expect("Node had no parent");
-        self.0.tree[parent_ix].render_borders();
+        let mut parent_ix = self.0.tree.parent_of(node_ix)?;
+        while self.0.tree[parent_ix].get_type() != ContainerType::Workspace {
+            self.0.tree[parent_ix].render_borders();
+            parent_ix = self.0.tree.parent_of(parent_ix)?
+        }
         Ok(())
     }
 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -603,10 +603,13 @@ impl Tree {
 
     /// Renders the borders for the view.
     pub fn render_borders(&mut self, view: WlcView) -> CommandResult {
-        let id = try!(self.lookup_handle(view.into())
-                      .map_err(|_|TreeError::ViewNotFound(view)));
-        let container = try!(self.0.lookup_mut(id));
-        container.render_borders();
+        let node_ix = try!(self.lookup_view(view).ok()
+                      .and_then(|id| self.0.tree.lookup_id(id))
+                      .ok_or_else(||TreeError::ViewNotFound(view)));
+        self.0.tree[node_ix].render_borders();
+        let parent_ix = self.0.tree.parent_of(node_ix)
+            .expect("Node had no parent");
+        self.0.tree[parent_ix].render_borders();
         Ok(())
     }
 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -82,6 +82,22 @@ pub fn split_horizontal() {
     }
 }
 
+pub fn tile_tabbed() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.0.set_active_layout(Layout::Tabbed).unwrap_or_else(|err| {
+            warn!("Could not tile as tabbed: {:?}", err);
+        })
+    }
+}
+
+pub fn tile_stacked() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.0.set_active_layout(Layout::Stacked).unwrap_or_else(|err| {
+            warn!("Could not tile as stacked: {:?}", err);
+        })
+    }
+}
+
 pub fn fullscreen_toggle() {
     if let Ok(mut tree) = try_lock_tree() {
         if let Some(id) = tree.active_id() {
@@ -494,6 +510,7 @@ impl Tree {
 
     pub fn move_focus(&mut self, dir: Direction) -> CommandResult {
         try!(self.0.move_focus(dir));
+        self.0.layout_active_of(ContainerType::Workspace);
         Ok(())
     }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -603,7 +603,7 @@ impl Tree {
 
     /// Renders the borders for the view.
     pub fn render_borders(&mut self, view: WlcView) -> CommandResult {
-        let node_ix = try!(self.lookup_view(view).ok()
+        let node_ix = try!(self.lookup_handle(view.into()).ok()
                       .and_then(|id| self.0.tree.lookup_id(id))
                       .ok_or_else(||TreeError::ViewNotFound(view)));
         self.0.tree[node_ix].render_borders();

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -378,10 +378,10 @@ impl Tree {
         if view.get_type() != ViewType::empty() || has_parent ||
             view.get_type().intersects(VIEW_BIT_UNMANAGED)
         {
-            try!(tree.add_floating_view(view, None));
+            tree.add_floating_view(view, None)?;
         } else {
-            try!(tree.add_view(view));
-            tree.normalize_view(view);
+            tree.add_view(view)?;
+            tree.normalize_view(view)?;
         }
         tree.layout_active_of(ContainerType::Workspace);
         Ok(())

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -431,7 +431,7 @@ impl Tree {
                       .map_err(|_|TreeError::ViewNotFound(view)));
         let container = try!(self.0.lookup_mut(id));
         container.set_name(Container::get_title(view));
-        container.draw_borders();
+        container.draw_borders()?;
         Ok(())
     }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -248,8 +248,8 @@ impl Tree {
 
     /// Determines if the container is in the currently active workspace.
     pub fn container_in_active_workspace(&self, id: Uuid) -> Result<bool, TreeError> {
-        let view = match try!(self.0.lookup(id)).get_handle() {
-            Some(Handle::View(view)) => view,
+        let view = match try!(self.0.lookup(id)).get_handle()? {
+            Handle::View(view) => view,
             _ => return Err(TreeError::UuidNotAssociatedWith(ContainerType::View))
         };
         if let Some(active_workspace) = self.0.active_ix_of(ContainerType::Workspace) {
@@ -329,9 +329,10 @@ impl Tree {
     }
 
     pub fn output_resolution(&self, id: Uuid) -> Result<Size, TreeError> {
-        let output = match try!(self.0.lookup(id)).get_handle() {
-            Some(Handle::Output(output)) => output,
-            _ => return Err(TreeError::UuidNotAssociatedWith(ContainerType::Output))
+        let output = match try!(self.0.lookup(id)).get_handle()? {
+            Handle::Output(output) => output,
+            _ => return Err(TreeError::UuidNotAssociatedWith(
+                ContainerType::Output))
         };
         Ok(output.get_resolution().expect("Output had no resolution"))
     }
@@ -418,11 +419,10 @@ impl Tree {
     /// This WILL close the view, and should never be called from the
     /// `view_destroyed` callback, as it's possible the view from that callback is invalid.
     pub fn remove_view_by_id(&mut self, id: Uuid) -> CommandResult {
-        match try!(self.0.lookup(id)).get_handle() {
-            Some(Handle::View(view)) => return self.remove_view(view),
-            Some(Handle::Output(_)) | None => {
+        match try!(self.0.lookup(id)).get_handle()? {
+            Handle::View(view) => self.remove_view(view),
+            Handle::Output(_) =>
                 Err(TreeError::UuidNotAssociatedWith(ContainerType::View))
-            }
         }
     }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -516,7 +516,7 @@ impl Tree {
         // NOTE Since tiling is somewhat expensive,
         // this can be a bottleneck that can be possibly optimized.
         if layout == Layout::Tabbed || layout == Layout::Stacked {
-            self.0.layout_active_of(ContainerType::Workspace);
+            self.0.layout_active_of(ContainerType::Container);
         }
         Ok(())
     }

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -106,7 +106,8 @@ impl Renderable for Borders {
         geometry.size.w += thickness;
         geometry.size.h += thickness;
         geometry.size.h += title_size;
-        let output_res = self.output.get_resolution().unwrap();
+        let output_res = self.output.get_resolution()
+            .expect("Could not get output's resolution");
 
         // Need to do geometry check here, because it's possible we'll allocate
         // a buffer that is the right size to hold the data, but ultimately

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -106,6 +106,31 @@ impl Renderable for Borders {
         geometry.size.w += thickness;
         geometry.size.h += thickness;
         geometry.size.h += title_size;
+        let output_res = self.output.get_resolution().unwrap();
+
+        // TODO Do I need this check?
+        if geometry.origin.x + geometry.size.w as i32 > output_res.w as i32 {
+            let offset = (geometry.origin.x + geometry.size.w as i32) - output_res.w as i32;
+            geometry.origin.x -= offset as i32;
+        }
+        if geometry.origin.y + geometry.size.h as i32 > output_res.h as i32 {
+            let offset = (geometry.origin.y + geometry.size.h as i32) - output_res.h as i32;
+            geometry.origin.y -= offset as i32;
+        }
+        if geometry.origin.x < 0 {
+            geometry.origin.x = 0;
+        }
+        if geometry.origin.y < 0 {
+            geometry.origin.y = 0;
+        }
+        if geometry.size.w > output_res.w {
+            geometry.size.w = output_res.w;
+        }
+        if geometry.size.h > output_res.h {
+            geometry.size.h = output_res.h;
+        }
+        // END TODO
+
         let Size { w, h } = geometry.size;
         if w == self.geometry.size.w && h == self.geometry.size.h {
             return Some(self);

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -108,7 +108,9 @@ impl Renderable for Borders {
         geometry.size.h += title_size;
         let output_res = self.output.get_resolution().unwrap();
 
-        // TODO Do I need this check?
+        // Need to do geometry check here, because it's possible we'll allocate
+        // a buffer that is the right size to hold the data, but ultimately
+        // will be too big to be rendered, which will cause an ugly wrap-around
         if geometry.origin.x + geometry.size.w as i32 > output_res.w as i32 {
             let offset = (geometry.origin.x + geometry.size.w as i32) - output_res.w as i32;
             geometry.origin.x -= offset as i32;
@@ -129,7 +131,6 @@ impl Renderable for Borders {
         if geometry.size.h > output_res.h {
             geometry.size.h = output_res.h;
         }
-        // END TODO
 
         let Size { w, h } = geometry.size;
         if w == self.geometry.size.w && h == self.geometry.size.h {

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -330,6 +330,10 @@ impl Borders {
     pub fn title(&self) -> &str {
         self.title.as_str()
     }
+
+    pub fn set_title(&mut self, title: String) {
+        self.title = title;
+    }
 }
 
 impl PartialEq for Borders {

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -1,5 +1,4 @@
 use std::iter;
-use std::fmt::{self, Debug};
 use std::cmp::{Eq, PartialEq};
 use rustwlc::{Geometry, Size, WlcOutput};
 use rustwlc::render::{calculate_stride};
@@ -12,7 +11,7 @@ use ::render::{Color, Renderable};
 /// The borders of a container.
 ///
 /// This type just deals with rendering,
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Borders {
     /// The title displayed in the title border.
     pub title: String,
@@ -303,14 +302,6 @@ impl Borders {
 
     pub fn title(&self) -> &str {
         self.title.as_str()
-    }
-}
-
-impl Debug for Borders {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Borders")
-            .field("geometry", &self.geometry as &Debug)
-            .finish()
     }
 }
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -16,9 +16,62 @@ impl ContainerDraw {
             base
         }
     }
+
+    fn draw_title_bar(mut self,
+                      mut x: f64,
+                      _y: f64,
+                      mut w: f64,
+                      _h: f64,
+                      border_geometry: Geometry,
+                      output_res: Size) -> Result<Self, DrawErr<Borders>> {
+        let title_size = Borders::title_bar_size() as f64;
+        let title_color = self.base.inner().title_background_color();
+        let title_font_color = self.base.inner().title_font_color();
+        let title: String = self.inner().title().into();
+        if x < 0.0 {
+            w += x;
+        }
+        let mut title_x = Borders::thickness() as f64;
+        let mut title_y = title_size - 5.0;
+        x = 0.0;
+        let mut y = 0.0;
+        if border_geometry.origin.x + border_geometry.size.w as i32 > output_res.w as i32 {
+            let offset = (border_geometry.origin.x + border_geometry.size.w as i32)
+                - output_res.w as i32;
+            x += offset as f64;
+            title_x += offset as f64;
+        }
+        if border_geometry.origin.y + border_geometry.size.h as i32 > output_res.h as i32 {
+            let offset = (border_geometry.origin.y + border_geometry.size.h as i32)
+                - output_res.h as i32;
+            y += offset as f64;
+            title_y += offset as f64;
+        }
+        // Draw background of title bar
+        self.base.set_color_source(title_color);
+        warn!("Drawing rect;\nx: {}, y: {}, w: {}, h: {}",
+              x, y, w, title_size);
+        error!("Drawing at geo: {:#?}", border_geometry);
+        error!("MAX: {:#?}", output_res);
+        self.base.rectangle(x, y, w, title_size);
+        self.base = try!(self.base.check_cairo());
+        self.base.fill();
+        self.base = try!(self.base.check_cairo());
+
+        // Draw title text
+        self.base.move_to(title_x, title_y);
+        self.base = try!(self.base.check_cairo());
+        self.base.set_color_source(title_font_color);
+        self.base = try!(self.base.check_cairo());
+        self.base.show_text(title.as_str());
+        self.base = try!(self.base.check_cairo());
+        Ok(self)
+    }
 }
 
 impl Drawable<Borders> for ContainerDraw {
+
+
     // Draw the title bar around the container
     fn draw(mut self, container_g: Geometry) -> Result<Borders, DrawErr<Borders>> {
         let mut border_g = container_g;
@@ -26,50 +79,37 @@ impl Drawable<Borders> for ContainerDraw {
         let title_size = Borders::title_bar_size();
         let edge_thickness = thickness / 2;
         let title_color = self.base.inner().title_background_color();
+        let title_font_color = self.base.inner().title_font_color();
         let title: String = self.inner().title().into();
         let output_res = self.inner().get_output().get_resolution()
             .expect("Could not gett focused output's resolution");
 
         border_g.origin.x -= edge_thickness as i32;
+        border_g.origin.y -= edge_thickness as i32;
+        border_g.origin.y -= title_size as i32;
         border_g.size.w += thickness;
-        let mut title_x = thickness;
-        let mut title_y = title_size - 5;
-
-        // If off the screen to the left or right, adjust.
+        border_g.size.h = thickness;
         if border_g.origin.x < 0 {
-            border_g.size.w += border_g.origin.x as u32;
-        } else if border_g.origin.x + border_g.size.w as i32 > output_res.w as i32 {
-            let offset = border_g.origin.x + border_g.size.w as i32 - output_res.w as i32;
-            border_g.origin.x += offset;
-            title_x += offset as u32;
+            border_g.origin.x = 0;
         }
-        // If over the top, adjust.
-        // TODO Handle bottom as well, for title bars on the bottom of container.
-        if border_g.origin.y + border_g.size.h as i32 > output_res.h as i32 {
-            let offset = border_g.origin.y + border_g.size.h as i32 - output_res.h as i32;
-            border_g.origin.y += offset;
-            title_y += offset as u32;
+        if border_g.size.w > output_res.w {
+            border_g.size.w = output_res.w;
         }
 
-        // Draw background of title bar
-        self.base.set_source_rgb(1.0, 0.0, 0.0);
-        self.base.set_color_source(title_color);
-        self.base.rectangle(border_g.origin.x as f64,
-                            border_g.origin.y as f64,
-                            border_g.size.w as f64,
-                            title_size as f64);
-        self.base = try!(self.base.check_cairo());
-        self.base.fill();
-        self.base = try!(self.base.check_cairo());
+        self.base.set_source_rgba(0.0, 0.0, 0.0, 0.0);
+        self.base.paint();
+        let color = self.base.inner().color();
+        self.base.set_color_source(color);
 
-        // Draw title text
-        self.base.move_to(title_x as f64, title_y as f64);
-        self.base = try!(self.base.check_cairo());
-        self.base.set_color_source(title_color);
-        self.base = try!(self.base.check_cairo());
-        self.base.show_text(title.as_str());
-        self.base = try!(self.base.check_cairo());
-
+        let Size { w, h } = border_g.size;
+        let Point { x, y } = border_g.origin;
+        let (mut x, mut y, mut w, mut h) = (x as f64,
+                                            y as f64,
+                                            w as f64,
+                                            h as f64);
+        let edge_thickness = edge_thickness as f64;
+        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?;
+        error!("Returning GEO: {:#?}", border_g);
         Ok(self.base.finish(border_g))
     }
 }

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -35,18 +35,7 @@ impl ContainerDraw {
         let mut title_y = title_size - 5.0;
         x = 0.0;
         let mut y = 0.0;
-        if border_geometry.origin.x + border_geometry.size.w as i32 > output_res.w as i32 {
-            let offset = (border_geometry.origin.x + border_geometry.size.w as i32)
-                - output_res.w as i32;
-            x += offset as f64;
-            title_x += offset as f64;
-        }
-        if border_geometry.origin.y + border_geometry.size.h as i32 > output_res.h as i32 {
-            let offset = (border_geometry.origin.y + border_geometry.size.h as i32)
-                - output_res.h as i32;
-            y += offset as f64;
-            title_y += offset as f64;
-        }
+
         // Draw background of title bar
         self.base.set_source_rgb(1.0, 0.0, 0.0);
         self.base.set_color_source(title_color);
@@ -67,8 +56,6 @@ impl ContainerDraw {
 }
 
 impl Drawable<Borders> for ContainerDraw {
-
-
     // Draw the title bar around the container
     fn draw(mut self, container_g: Geometry) -> Result<Borders, DrawErr<Borders>> {
         let mut border_g = container_g;
@@ -99,9 +86,8 @@ impl Drawable<Borders> for ContainerDraw {
                                             w as f64,
                                             h as f64);
         let edge_thickness = edge_thickness as f64;
-        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?
-        ;
-        error!("Returning GEO: {:#?}", border_g);
+        warn!("output: {:#?}", output_res);
+        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?;
         Ok(self.base.finish(border_g))
     }
 }

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -1,5 +1,5 @@
 use std::ops::{Deref, DerefMut};
-use rustwlc::{Geometry, Size, Point};
+use rustwlc::Geometry;
 use super::super::borders::Borders;
 use ::render::{BaseDraw, Drawable, DrawErr};
 
@@ -19,11 +19,7 @@ impl ContainerDraw {
 
     fn draw_title_bar(mut self,
                       mut x: f64,
-                      _y: f64,
-                      mut w: f64,
-                      _h: f64,
-                      border_geometry: Geometry,
-                      output_res: Size) -> Result<Self, DrawErr<Borders>> {
+                      mut w: f64,) -> Result<Self, DrawErr<Borders>> {
         let title_size = Borders::title_bar_size() as f64;
         let title_color = self.base.inner().title_background_color();
         let title_font_color = self.base.inner().title_font_color();
@@ -31,15 +27,14 @@ impl ContainerDraw {
         if x < 0.0 {
             w += x;
         }
-        let mut title_x = Borders::thickness() as f64;
-        let mut title_y = title_size - 5.0;
+        let title_x = Borders::thickness() as f64;
+        let title_y = title_size - 5.0;
         x = 0.0;
-        let mut y = 0.0;
 
         // Draw background of title bar
         self.base.set_source_rgb(1.0, 0.0, 0.0);
         self.base.set_color_source(title_color);
-        self.base.rectangle(x, y, w, title_size);
+        self.base.rectangle(x, 0.0, w, title_size);
         self.base = try!(self.base.check_cairo());
         self.base.fill();
         self.base = try!(self.base.check_cairo());
@@ -62,11 +57,6 @@ impl Drawable<Borders> for ContainerDraw {
         let thickness = Borders::thickness();
         let title_size = Borders::title_bar_size();
         let edge_thickness = thickness / 2;
-        let title_color = self.base.inner().title_background_color();
-        let title_font_color = self.base.inner().title_font_color();
-        let title: String = self.inner().title().into();
-        let output_res = self.inner().get_output().get_resolution()
-            .expect("Could not get focused output's resolution");
 
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
@@ -79,15 +69,9 @@ impl Drawable<Borders> for ContainerDraw {
         let color = self.base.inner().color();
         self.base.set_color_source(color);
 
-        let Size { w, h } = border_g.size;
-        let Point { x, y } = border_g.origin;
-        let (mut x, mut y, mut w, mut h) = (x as f64,
-                                            y as f64,
-                                            w as f64,
-                                            h as f64);
-        let edge_thickness = edge_thickness as f64;
-        warn!("output: {:#?}", output_res);
-        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?;
+        let (x, w) = (border_g.origin.x as f64,
+                      border_g.size.w as f64);
+        self = self.draw_title_bar(x, w)?;
         Ok(self.base.finish(border_g))
     }
 }

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -48,11 +48,8 @@ impl ContainerDraw {
             title_y += offset as f64;
         }
         // Draw background of title bar
+        self.base.set_source_rgb(1.0, 0.0, 0.0);
         self.base.set_color_source(title_color);
-        warn!("Drawing rect;\nx: {}, y: {}, w: {}, h: {}",
-              x, y, w, title_size);
-        error!("Drawing at geo: {:#?}", border_geometry);
-        error!("MAX: {:#?}", output_res);
         self.base.rectangle(x, y, w, title_size);
         self.base = try!(self.base.check_cairo());
         self.base.fill();
@@ -82,19 +79,13 @@ impl Drawable<Borders> for ContainerDraw {
         let title_font_color = self.base.inner().title_font_color();
         let title: String = self.inner().title().into();
         let output_res = self.inner().get_output().get_resolution()
-            .expect("Could not gett focused output's resolution");
+            .expect("Could not get focused output's resolution");
 
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
         border_g.origin.y -= title_size as i32;
         border_g.size.w += thickness;
         border_g.size.h = thickness;
-        if border_g.origin.x < 0 {
-            border_g.origin.x = 0;
-        }
-        if border_g.size.w > output_res.w {
-            border_g.size.w = output_res.w;
-        }
 
         self.base.set_source_rgba(0.0, 0.0, 0.0, 0.0);
         self.base.paint();
@@ -108,7 +99,8 @@ impl Drawable<Borders> for ContainerDraw {
                                             w as f64,
                                             h as f64);
         let edge_thickness = edge_thickness as f64;
-        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?;
+        self = self.draw_title_bar(x, y, w, edge_thickness, border_g, output_res)?
+        ;
         error!("Returning GEO: {:#?}", border_g);
         Ok(self.base.finish(border_g))
     }

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -60,7 +60,9 @@ impl Drawable<Borders> for ContainerDraw {
 
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
-        border_g.origin.y -= title_size as i32;
+        border_g.origin.y -= (title_size / 2) as i32;
+        // TODO Remove this line
+        // HOWEVER, it bugs out in simple tests, fix that!
         border_g.size.w += thickness;
         border_g.size.h = thickness;
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -61,8 +61,6 @@ impl Drawable<Borders> for ContainerDraw {
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
         border_g.origin.y -= (title_size / 2) as i32;
-        // TODO Remove this line
-        // HOWEVER, it bugs out in simple tests, fix that!
         border_g.size.w += thickness;
         border_g.size.h = thickness;
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -20,6 +20,7 @@ impl ContainerDraw {
     fn draw_title_bar(mut self,
                       mut x: f64,
                       mut w: f64,) -> Result<Self, DrawErr<Borders>> {
+        let gap = Borders::gap_size() as f64;
         let title_size = Borders::title_bar_size() as f64;
         let title_color = self.base.inner().title_background_color();
         let title_font_color = self.base.inner().title_font_color();
@@ -27,9 +28,10 @@ impl ContainerDraw {
         if x < 0.0 {
             w += x;
         }
-        let title_x = Borders::thickness() as f64;
+        let title_x = Borders::thickness() as f64 + gap / 2.0;
         let title_y = title_size - 5.0;
-        x = 0.0;
+        x = gap / 2.0;
+        w -= gap;
 
         // Draw background of title bar
         self.base.set_source_rgb(1.0, 0.0, 0.0);

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -1,0 +1,89 @@
+use std::ops::{Deref, DerefMut};
+use rustwlc::{Geometry, Size, Point};
+use super::super::borders::Borders;
+use ::render::{BaseDraw, Drawable, DrawErr};
+
+/// Draws the borders around the container.
+/// The only borders that are drawn are for the title bars, as the individual
+/// edge borders are handled by the child views.
+pub struct ContainerDraw {
+    base: BaseDraw<Borders>,
+}
+
+impl ContainerDraw {
+    pub fn new(base: BaseDraw<Borders>) -> Self {
+        ContainerDraw {
+            base
+        }
+    }
+}
+
+impl Drawable<Borders> for ContainerDraw {
+    // Draw the title bar around the container
+    fn draw(mut self, container_g: Geometry) -> Result<Borders, DrawErr<Borders>> {
+        let mut border_g = container_g;
+        let thickness = Borders::thickness();
+        let title_size = Borders::title_bar_size();
+        let edge_thickness = thickness / 2;
+        let title_color = self.base.inner().title_background_color();
+        let title: String = self.inner().title().into();
+        let output_res = self.inner().get_output().get_resolution()
+            .expect("Could not gett focused output's resolution");
+
+        border_g.origin.x -= edge_thickness as i32;
+        border_g.size.w += thickness;
+        let mut title_x = thickness;
+        let mut title_y = title_size - 5;
+
+        // If off the screen to the left or right, adjust.
+        if border_g.origin.x < 0 {
+            border_g.size.w += border_g.origin.x as u32;
+        } else if border_g.origin.x + border_g.size.w as i32 > output_res.w as i32 {
+            let offset = border_g.origin.x + border_g.size.w as i32 - output_res.w as i32;
+            border_g.origin.x += offset;
+            title_x += offset as u32;
+        }
+        // If over the top, adjust.
+        // TODO Handle bottom as well, for title bars on the bottom of container.
+        if border_g.origin.y + border_g.size.h as i32 > output_res.h as i32 {
+            let offset = border_g.origin.y + border_g.size.h as i32 - output_res.h as i32;
+            border_g.origin.y += offset;
+            title_y += offset as u32;
+        }
+
+        // Draw background of title bar
+        self.base.set_source_rgb(1.0, 0.0, 0.0);
+        self.base.set_color_source(title_color);
+        self.base.rectangle(border_g.origin.x as f64,
+                            border_g.origin.y as f64,
+                            border_g.size.w as f64,
+                            title_size as f64);
+        self.base = try!(self.base.check_cairo());
+        self.base.fill();
+        self.base = try!(self.base.check_cairo());
+
+        // Draw title text
+        self.base.move_to(title_x as f64, title_y as f64);
+        self.base = try!(self.base.check_cairo());
+        self.base.set_color_source(title_color);
+        self.base = try!(self.base.check_cairo());
+        self.base.show_text(title.as_str());
+        self.base = try!(self.base.check_cairo());
+
+        Ok(self.base.finish(border_g))
+    }
+}
+
+impl Deref for ContainerDraw {
+    type Target = BaseDraw<Borders>;
+
+    fn deref(&self) -> &BaseDraw<Borders> {
+        &self.base
+    }
+}
+
+impl DerefMut for ContainerDraw {
+    fn deref_mut(&mut self) -> &mut BaseDraw<Borders> {
+        &mut self.base
+    }
+}

--- a/src/layout/core/borders/mod.rs
+++ b/src/layout/core/borders/mod.rs
@@ -1,6 +1,8 @@
 mod borders;
 mod borders_draw;
+mod container_draw;
 
 pub use self::borders::{Borders};
 pub use self::borders_draw::{BordersDraw};
+pub use self::container_draw::{ContainerDraw};
 

--- a/src/layout/core/borders/mod.rs
+++ b/src/layout/core/borders/mod.rs
@@ -1,8 +1,8 @@
 mod borders;
-mod borders_draw;
+mod view_draw;
 mod container_draw;
 
 pub use self::borders::{Borders};
-pub use self::borders_draw::{BordersDraw};
+pub use self::view_draw::{ViewDraw};
 pub use self::container_draw::{ContainerDraw};
 

--- a/src/layout/core/borders/view_draw.rs
+++ b/src/layout/core/borders/view_draw.rs
@@ -5,13 +5,13 @@ use ::render::{BaseDraw, Drawable, DrawErr};
 
 /// Draws the borders around windows.
 /// They are all of the same size, including the top.
-pub struct BordersDraw {
+pub struct ViewDraw {
     base: BaseDraw<Borders>
 }
 
-impl BordersDraw {
+impl ViewDraw {
     pub fn new(base: BaseDraw<Borders>) -> Self {
-        BordersDraw {
+        ViewDraw {
             base: base
         }
     }
@@ -202,7 +202,7 @@ impl BordersDraw {
     }
 }
 
-impl Drawable<Borders> for BordersDraw {
+impl Drawable<Borders> for ViewDraw {
     fn draw(mut self, view_g: Geometry) -> Result<Borders, DrawErr<Borders>> {
         let mut border_g = view_g;
         let thickness = Borders::thickness();
@@ -241,7 +241,7 @@ impl Drawable<Borders> for BordersDraw {
     }
 }
 
-impl Deref for BordersDraw {
+impl Deref for ViewDraw {
     type Target = BaseDraw<Borders>;
 
     fn deref(&self) -> &BaseDraw<Borders> {
@@ -249,7 +249,7 @@ impl Deref for BordersDraw {
     }
 }
 
-impl DerefMut for BordersDraw {
+impl DerefMut for ViewDraw {
     fn deref_mut(&mut self) -> &mut BaseDraw<Borders> {
         &mut self.base
     }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -196,7 +196,7 @@ impl Container {
             floating: false,
             effective_geometry: geometry,
             id: Uuid::new_v4(),
-            borders: borders
+            borders: None//borders
         }
     }
 
@@ -540,8 +540,6 @@ impl Container {
         // border, but for now this will do.
         match *self {
             Container::View { ref mut borders, handle, .. } => {
-                // TODO remove
-                return;
                 if let Some(mut borders_) = borders.take() {
                     let geometry = handle.get_geometry()
                         .expect("View had no geometry");
@@ -556,8 +554,10 @@ impl Container {
                         .draw(geometry).ok();
                 }
             },
-            Container::Container { ref mut borders, geometry, .. } => {
+            Container::Container { ref mut borders, mut geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
+                    // TODO Remove?
+                    geometry.size.w -= 2;
                     if borders_.geometry != geometry {
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;
@@ -581,6 +581,7 @@ impl Container {
     pub fn resize_borders(&mut self, geo: Geometry) {
         match *self {
             Container::View { handle, ref mut borders, ..}  => {
+                return;
                 if let Some(borders_) = borders.take() {
                     *borders = borders_.reallocate_buffer(geo)
                 } else {

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -272,9 +272,8 @@ impl Container {
                     size: resolution
                 })
             },
-            Container::Workspace { geometry, .. } => Some(geometry),
-            Container::Container { apparent_geometry, .. } =>
-                Some(apparent_geometry),
+            Container::Workspace { geometry, .. } |
+            Container::Container { geometry, .. } => Some(geometry),
             Container::View { effective_geometry, .. } => {
                 Some(effective_geometry)
             },

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -594,7 +594,7 @@ impl Container {
                         // side border that is never drawn. And thus it
                         // over-draws.
                         let thickness = Borders::thickness() as i32;
-                        geometry.origin.x += thickness;
+                        geometry.origin.x += thickness / 2;
                         geometry.size.w = geometry.size.w.saturating_sub(thickness as u32);
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -596,6 +596,7 @@ impl Container {
 
                     borders_.title = match layout {
                         Layout::Tabbed | Layout::Stacked => {
+                            // Already filled in from `layout.rs`
                             borders_.title
                         },
                         _ => format!("{:?} container", layout)

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -583,9 +583,18 @@ impl Container {
                 }
                 Ok(())
             },
-            Container::Container { ref mut borders,
+            Container::Container { layout,
+                                   ref mut borders,
                                    apparent_geometry: mut geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
+                    // update the title of the borders
+
+                    borders_.title = match layout {
+                        Layout::Tabbed | Layout::Stacked => {
+                            borders_.title
+                        },
+                        _ => format!("{:?} container", layout)
+                    };
                     if borders_.geometry != geometry {
                         // NOTE This is a hack to work around how borders work...
                         // This fixes a bug where the title border extends too

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -73,7 +73,9 @@ impl ContainerType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Layout {
     Horizontal,
-    Vertical
+    Vertical,
+    Tabbed,
+    Stacked
 }
 
 /// Represents an item in the container tree.

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -548,7 +548,14 @@ impl Container {
         }
     }
 
-    pub fn draw_borders(&mut self) {
+    /// Draws the borders around the container.
+    ///
+    /// If the type of the container is not `Container` or `View`, then an
+    /// error is returned.
+    ///
+    /// If there are no borders associated with the `Container`/`View`,
+    /// then argument returns `Ok` but nothing is done.
+    pub fn draw_borders(&mut self) -> Result<(), ContainerErr> {
         // TODO Eventually, we should use an enum to choose which way to draw the
         // border, but for now this will do.
         match *self {
@@ -560,12 +567,13 @@ impl Container {
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;
                         } else {
-                            return
+                            return Ok(())
                         }
                     }
                     *borders = BordersDraw::new(borders_.enable_cairo().unwrap())
                         .draw(geometry).ok();
                 }
+                Ok(())
             },
             Container::Container { ref mut borders, geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
@@ -573,14 +581,16 @@ impl Container {
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;
                         } else {
-                            return
+                            return Ok(())
                         }
                     }
                     *borders = ContainerDraw::new(borders_.enable_cairo().unwrap())
                         .draw(geometry).ok();
                 }
+                Ok(())
             },
-            _ => panic!("Tried to render a non-view / non-container")
+            ref other => Err(ContainerErr::BadOperationOn(
+                other.get_type(), "Tried to render a non-view/container".into()))
         }
     }
 

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -574,9 +574,17 @@ impl Container {
                 }
                 Ok(())
             },
-            Container::Container { ref mut borders, geometry, .. } => {
+            Container::Container { ref mut borders, mut geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
                     if borders_.geometry != geometry {
+                        // NOTE This is a hack to work around how borders work...
+                        // This fixes a bug where the title border extends too
+                        // far to the left, because it allocates space for a
+                        // side border that is never drawn. And thus it
+                        // over-draws.
+                        let thickness = Borders::thickness() as i32;
+                        geometry.origin.x += thickness;
+                        geometry.size.w = geometry.size.w.saturating_sub(thickness as u32);
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;
                         } else {

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -335,6 +335,16 @@ impl Container {
         }
     }
 
+    pub fn get_layout(&self) -> Result<Layout, ContainerErr> {
+        match *self {
+            Container::Container { layout, .. } => Ok(layout),
+            ref other => Err(ContainerErr::BadOperationOn(
+                other.get_type(),
+                "Only containers have a layout!".into()
+            ))
+        }
+    }
+
     pub fn get_id(&self) -> Uuid {
         match *self {
             Container::Root(id) | Container::Output { id, .. } |
@@ -557,7 +567,7 @@ impl Container {
                         .draw(geometry).ok();
                 }
             },
-            Container::Container { ref mut borders, mut geometry, .. } => {
+            Container::Container { ref mut borders, geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
                     if borders_.geometry != geometry {
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
@@ -582,7 +592,6 @@ impl Container {
     pub fn resize_borders(&mut self, geo: Geometry) {
         match *self {
             Container::View { handle, ref mut borders, ..}  => {
-                return;
                 if let Some(borders_) = borders.take() {
                     *borders = borders_.reallocate_buffer(geo)
                 } else {

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -175,7 +175,16 @@ impl Container {
             fullscreen: false,
             geometry: geometry,
             id: Uuid::new_v4(),
-            borders: None
+            // TODO FIXME
+            // Pass this in, don't create it here
+            borders: unsafe {
+                Borders::new(geometry,
+                                  WlcView::dummy(1).as_output())
+                    .map(|mut b| {
+                        b.title = "Hello world!".into();
+                        b
+                    })
+            }
         }
     }
 

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -8,7 +8,7 @@ use rustwlc::handle::{WlcView, WlcOutput};
 use rustwlc::{Geometry, ResizeEdge, Point, Size,
               VIEW_FULLSCREEN, VIEW_BIT_MODAL};
 
-use super::borders::{Borders, BordersDraw, ContainerDraw};
+use super::borders::{Borders, ViewDraw, ContainerDraw};
 use super::tree::TreeError;
 use ::render::{Renderable, Drawable};
 use ::layout::commands::CommandResult;
@@ -583,7 +583,7 @@ impl Container {
                             return Ok(())
                         }
                     }
-                    *borders = BordersDraw::new(borders_.enable_cairo().unwrap())
+                    *borders = ViewDraw::new(borders_.enable_cairo().unwrap())
                         .draw(geometry).ok();
                 }
                 Ok(())

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -48,11 +48,11 @@ pub enum ContainerType {
     View
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContainerErr {
     /// A bad operation on the container type.
     /// The human readable string provides more context.
-    BadOperationOn(ContainerType, &'static str)
+    BadOperationOn(ContainerType, String)
 }
 
 impl ContainerType {
@@ -322,14 +322,17 @@ impl Container {
         }
     }
 
-    pub fn set_layout(&mut self, new_layout: Layout) -> Result<(), String>{
+    pub fn set_layout(&mut self, new_layout: Layout) -> Result<(), ContainerErr>{
         match *self {
-            Container::Container { ref mut layout, .. } => *layout = new_layout,
-            ref other => return Err(
+            Container::Container { ref mut layout, .. } => {
+                *layout = new_layout;
+                Ok(())
+            },
+            ref other => Err(ContainerErr::BadOperationOn(
+                other.get_type(),
                 format!("Can only set the layout of a container, not {:?}",
-                        other))
+                        other)))
         }
-        Ok(())
     }
 
     pub fn get_id(&self) -> Uuid {
@@ -623,7 +626,7 @@ impl Container {
             },
             _ => Err(TreeError::Container(
                 ContainerErr::BadOperationOn(c_type,
-                                               "active_border_color")))
+                                               "active_border_color".into())))
         }
     }
 
@@ -644,7 +647,7 @@ impl Container {
             },
             _ => Err(TreeError::Container(
                 ContainerErr::BadOperationOn(c_type,
-                                             "active_border_color")))
+                                             "active_border_color".into())))
         }
     }
 

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -196,7 +196,7 @@ impl Container {
             floating: false,
             effective_geometry: geometry,
             id: Uuid::new_v4(),
-            borders: None//borders
+            borders: borders
         }
     }
 
@@ -556,8 +556,6 @@ impl Container {
             },
             Container::Container { ref mut borders, mut geometry, .. } => {
                 if let Some(mut borders_) = borders.take() {
-                    // TODO Remove?
-                    geometry.size.w -= 2;
                     if borders_.geometry != geometry {
                         if let Some(new_borders) = borders_.reallocate_buffer(geometry) {
                             borders_ = new_borders;

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -107,6 +107,24 @@ impl InnerTree {
         result
     }
 
+    /// Determines if the node is on the active path.
+    pub fn on_path(&self, node_ix: NodeIndex) -> bool {
+        let mut next_ix = Some(self.root);
+        while let Some(cur_ix) = next_ix {
+            let maybe_edge = self.graph.edges(cur_ix)
+                .find(|e| e.weight().is_active());
+            if let Some(edge) = maybe_edge {
+                if edge.target() == node_ix {
+                    return true
+                }
+                next_ix = Some(edge.target());
+            } else {
+                next_ix = None;
+            }
+        }
+        return false
+    }
+
     /// Gets the immediant child of the node that is active.
     /// If there is no active child (e.g, there are no childern),
     /// then `None` is returned.

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -848,13 +848,16 @@ mod tests {
                                                 Container::new_workspace("1".to_string(),
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                 Container::new_container(fake_geometry.clone(), None),
+                                                 Container::new_container(fake_geometry.clone(),
+                                                                          fake_output,
+                                                                          None),
                                                  false);
         let workspace_2_ix = tree.add_child(output_ix,
                                                 Container::new_workspace("2".to_string(),
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
                                                  Container::new_container(fake_geometry.clone(),
+                                                                          fake_output,
                                                                           None),
                                                  false);
         /* Workspace 1 containers */
@@ -863,6 +866,7 @@ mod tests {
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
                                                Container::new_container(fake_geometry.clone(),
+                                                                        fake_output,
                                                                         None),
                                                false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -584,7 +584,7 @@ impl InnerTree {
     }
 
     /// Collects all children of a node, sorted by active number.
-    fn children_of_by_active(&self, node_ix: NodeIndex) -> Vec<NodeIndex> {
+    pub fn children_of_by_active(&self, node_ix: NodeIndex) -> Vec<NodeIndex> {
         let mut edges = self.graph.edges(node_ix).collect::<Vec<_>>();
         edges.sort_by_key(|e| e.weight().active);
         edges.into_iter().map(|e| e.target()).collect()

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -107,6 +107,14 @@ impl InnerTree {
         result
     }
 
+    /// Gets the immediant child of the node that is active.
+    /// If there is no active child (e.g, there are no childern),
+    /// then `None` is returned.
+    pub fn next_active_node(&self, node_ix: NodeIndex) -> Option<NodeIndex> {
+        self.graph.edges(node_ix).find(|e| e.weight().is_active())
+            .map(|edge| edge.target())
+    }
+
     /// Follows the active path beneath the node until it ends.
     /// Returns the last node in the chain.
     pub fn follow_path(&self, node_ix: NodeIndex) -> NodeIndex {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -769,15 +769,6 @@ impl InnerTree {
         nodes
     }
 
-    /// Sets the node and its children's visibility
-    pub fn set_family_visible(&mut self, node_ix: NodeIndex, visible: bool) {
-        trace!("Setting {:?} to {}", node_ix, if visible {"visible"} else {"invisible"});
-        self.get_mut(node_ix).map(|c| c.set_visibility(visible));
-        for child in self.children_of(node_ix) {
-            self.set_family_visible(child, visible);
-        }
-    }
-
     /// Modifies the ancestor paths so that the only complete path from the root
     /// goes to this node.
     ///

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -201,7 +201,7 @@ impl InnerTree {
     pub fn add_child(&mut self, parent_ix: NodeIndex, val: Container, active: bool) -> NodeIndex {
         let id = val.get_id();
         let maybe_view = match val.get_handle() {
-            Some(Handle::View(view)) => Some(view),
+            Ok(Handle::View(view)) => Some(view),
             _ => None
         };
         let child_ix = self.graph.add_node(val);
@@ -839,18 +839,23 @@ mod tests {
                                                 Container::new_workspace("1".to_string(),
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                                 Container::new_container(fake_geometry.clone(), None),
+                                                 false);
         let workspace_2_ix = tree.add_child(output_ix,
                                                 Container::new_workspace("2".to_string(),
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                                 Container::new_container(fake_geometry.clone(),
+                                                                          None),
+                                                 false);
         /* Workspace 1 containers */
         let wkspc_1_view = tree.add_child(root_container_1_ix,
                                                 Container::new_view(fake_view_1.clone(), None), false);
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                               Container::new_container(fake_geometry.clone(),
+                                                                        None),
+                                               false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone(), None), false);
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -228,8 +228,17 @@ impl LayoutTree {
         if !self.tree[node_ix].floating() {
             self.tree.set_ancestor_paths_active(node_ix);
         }
-        if let Some(old_active) = old_active {
-            self.set_borders(old_active, borders::Mode::Inactive)?;
+        if let Some(old_active_ix) = old_active {
+            match self.tree[node_ix] {
+                Container::View { handle, .. } => {
+                    let parent = handle.get_parent();
+                    let parent_node = self.tree.lookup_view(parent);
+                    if parent_node != old_active {
+                        self.set_borders(old_active_ix, borders::Mode::Inactive)?;
+                    }
+                },
+                _ => {}
+            }
         }
         self.set_borders(node_ix, borders::Mode::Active)?;
         Ok(())

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -321,6 +321,16 @@ impl LayoutTree {
         }
     }
 
+    pub fn active_layout(&self) -> Result<Layout, TreeError> {
+        let mut node_ix = self.active_container
+            .ok_or(TreeError::NoActiveContainer)?;
+        if self.tree[node_ix].get_type() == ContainerType::View {
+            node_ix = self.tree.parent_of(node_ix)
+                .expect("Node had no parent");
+        }
+        self.tree[node_ix].get_layout().map_err(TreeError::Container)
+    }
+
     /// Add a new view container with the given WlcView to the active container
     pub fn add_view(&mut self, view: WlcView) -> Result<&Container, TreeError> {
         if let Some(mut active_ix) = self.active_container {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -120,6 +120,18 @@ pub enum TreeError {
     HandleNotFound(Handle),
 }
 
+impl From<ContainerErr> for TreeError {
+    fn from(err: ContainerErr) -> TreeError {
+        TreeError::Container(err)
+    }
+}
+
+impl From<GraphError> for TreeError {
+    fn from(err: GraphError) -> TreeError {
+        TreeError::PetGraph(err)
+    }
+}
+
 impl LayoutTree {
     /// Drops every node in the tree, essentially invalidating it
     pub fn destroy_tree(&mut self) {
@@ -214,7 +226,7 @@ impl LayoutTree {
             if parent_node != self.active_container {
                 active_c.clear_border_color()
                     .expect("Could not clear border color");
-                active_c.draw_borders();
+                active_c.draw_borders()?;
             }
         }
         self.tree[node_ix].active_border_color()
@@ -235,7 +247,7 @@ impl LayoutTree {
         if !self.tree[node_ix].floating() {
             self.tree.set_ancestor_paths_active(node_ix);
         }
-        self.tree[node_ix].draw_borders();
+        self.tree[node_ix].draw_borders()?;
         Ok(())
     }
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -925,6 +925,7 @@ pub mod tests {
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
                                                  Container::new_container(fake_geometry.clone(),
+                                                                          fake_output,
                                                                           None),
                                                  false);
         let workspace_2_ix = tree.add_child(output_ix,
@@ -932,6 +933,7 @@ pub mod tests {
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
                                                  Container::new_container(fake_geometry.clone(),
+                                                                          fake_output,
                                                                           None),
                                                  false);
         /* Workspace 1 containers */
@@ -940,12 +942,17 @@ pub mod tests {
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
                                                Container::new_container(fake_geometry.clone(),
+                                                                        fake_output,
                                                                         None),
                                                false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,
-                                                Container::new_view(fake_view_1.clone(), None), true);
+                                                Container::new_view(fake_view_1.clone(),
+                                                                    None),
+                                                true);
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
-                                                Container::new_view(fake_view_1.clone(), None), false);
+                                                Container::new_view(fake_view_1.clone(),
+                                                                    None),
+                                                false);
         let mut layout_tree = LayoutTree {
             tree: tree,
             active_container: None
@@ -1227,7 +1234,9 @@ pub mod tests {
             origin: Point { x: 0, y: 0},
             size: Size { w: 0, h: 0}
         };
-        let new_container = Container::new_container(geometry, None);
+        let new_container = Container::new_container(geometry,
+                                                     WlcView::root().as_output(),
+                                                     None);
         tree.add_container(new_container, active_ix).unwrap();
         let new_active_ix = tree.active_container.unwrap();
         // The view moved, since it was placed in the new container

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -222,15 +222,25 @@ impl LayoutTree {
                 .unwrap_or("not set".into()),
                 node_ix.index());
         if let Some(active_ix) = self.active_container {
-            let active_c = &mut self.tree[active_ix];
             if parent_node != self.active_container {
-                active_c.clear_border_color()
-                    .expect("Could not clear border color");
-                active_c.draw_borders()?;
+                {
+                    let active_c = &mut self.tree[active_ix];
+                    active_c.clear_border_color()?;
+                    active_c.draw_borders()?;
+                }
+                let parent_ix = self.tree.parent_of(active_ix)?;
+                let parent_c = &mut self.tree[parent_ix];
+                parent_c.clear_border_color()
+                    .map(|_| parent_c.draw_borders()).ok();
             }
         }
-        self.tree[node_ix].active_border_color()
-            .expect("Could set active border color");
+        self.tree[node_ix].active_border_color()?;
+        {
+            let parent_ix = self.tree.parent_of(node_ix)?;
+            let parent_c = &mut self.tree[parent_ix];
+            parent_c.active_border_color()
+                .map(|_| parent_c.draw_borders()).ok();
+        }
         self.active_container = Some(node_ix);
         let c_type; let id;
         {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -931,18 +931,24 @@ pub mod tests {
                                                 Container::new_workspace("1".to_string(),
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                                 Container::new_container(fake_geometry.clone(),
+                                                                          None),
+                                                 false);
         let workspace_2_ix = tree.add_child(output_ix,
                                                 Container::new_workspace("2".to_string(),
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                                 Container::new_container(fake_geometry.clone(),
+                                                                          None),
+                                                 false);
         /* Workspace 1 containers */
         let wkspc_1_view = tree.add_child(root_container_1_ix,
                                                 Container::new_view(fake_view_1.clone(), None), false);
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
-                                                Container::new_container(fake_geometry.clone()), false);
+                                               Container::new_container(fake_geometry.clone(),
+                                                                        None),
+                                               false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone(), None), true);
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
@@ -1228,7 +1234,7 @@ pub mod tests {
             origin: Point { x: 0, y: 0},
             size: Size { w: 0, h: 0}
         };
-        let new_container = Container::new_container(geometry);
+        let new_container = Container::new_container(geometry, None);
         tree.add_container(new_container, active_ix).unwrap();
         let new_active_ix = tree.active_container.unwrap();
         // The view moved, since it was placed in the new container

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -201,18 +201,7 @@ impl LayoutTree {
                     .unwrap_or("not set".into()),
                   node_ix.index());
         }
-        let id;
-        let mut parent_node = None;
-        {
-            let container = &self.tree[node_ix];
-            id = container.get_id();
-            match *container {
-                Container::View { handle, .. } => {
-                    parent_node = self.tree.lookup_view(handle.get_parent());
-                },
-                _ => {}
-            };
-        }
+        let id = self.tree[node_ix].get_id();
         if let Some(fullscreen_id) = try!(self.in_fullscreen_workspace(id)) {
             if fullscreen_id != id {
                 return Err(TreeError::Focus(FocusError::BlockedByFullscreen(id, fullscreen_id)))

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -78,6 +78,8 @@ impl Direction {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TreeError {
+    /// The container was floating, and that was unexpected.
+    ContainerWasFloating(NodeIndex),
     /// A Node can not be found in the tree with this Node Handle.
     NodeNotFound(Uuid),
     /// The node was removed from the tree already.

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -1211,7 +1211,7 @@ pub mod tests {
             // should still be focused on the previous container.
             // though the active index might be different
             let active_ix = tree.active_container.unwrap();
-            assert_eq!(active_container, tree.tree[active_ix]);
+            assert_eq!(active_container.get_id(), tree.tree[active_ix].get_id());
             let new_parent = tree.tree[tree.tree.parent_of(active_ix).unwrap()]
                 .clone();
             let new_layout = match new_parent {

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -59,8 +59,6 @@ impl<T: Renderable> BaseDraw<T> {
 
     /// Finishes drawing on the border, yielding `Renderable`.
     pub fn finish(mut self, border_g: Geometry) -> T {
-        //TODO Why not this again?
-        //self.reallocate_buffer(border_g);
         self.inner.set_geometry(border_g);
         self.inner
     }

--- a/src/render/renderable.rs
+++ b/src/render/renderable.rs
@@ -60,7 +60,7 @@ pub trait Renderable {
     /// Renders the data buffer at the internal geometry.
     ///
     /// Automatically ensures that the buffer does not clip the sides
-    fn render(&mut self) where Self: ::std::fmt::Debug {
+    fn render(&mut self) {
         let output_res = self.get_output().get_resolution()
             .expect("Output had no resolution");
         let mut geometry = self.get_geometry();
@@ -92,6 +92,7 @@ pub trait Renderable {
             return
         }
         warn!("FINAL rendering at {:#?}", geometry);
+        error!("output_res: {:#?}", output_res);
         write_pixels(wlc_pixel_format::WLC_RGBA8888, geometry, &buffer);
     }
 }

--- a/src/render/renderable.rs
+++ b/src/render/renderable.rs
@@ -60,7 +60,7 @@ pub trait Renderable {
     /// Renders the data buffer at the internal geometry.
     ///
     /// Automatically ensures that the buffer does not clip the sides
-    fn render(&mut self) {
+    fn render(&mut self) where Self: ::std::fmt::Debug {
         let output_res = self.get_output().get_resolution()
             .expect("Output had no resolution");
         let mut geometry = self.get_geometry();
@@ -71,6 +71,7 @@ pub trait Renderable {
         // If the buffer would clip the side, keep it within the bounds
         // This is done because wlc wraps if it goes beyond, which we don't
         // want for the borders.
+        debug!("Rendering at {:#?}", geometry);
         if geometry.origin.x + geometry.size.w as i32 > output_res.w as i32 {
             let offset = (geometry.origin.x + geometry.size.w as i32) - output_res.w as i32;
             geometry.origin.x -= offset as i32;
@@ -90,6 +91,7 @@ pub trait Renderable {
             warn!("Buffer to big to draw! Not drawing");
             return
         }
+        warn!("FINAL rendering at {:#?}", geometry);
         write_pixels(wlc_pixel_format::WLC_RGBA8888, geometry, &buffer);
     }
 }

--- a/src/render/renderable.rs
+++ b/src/render/renderable.rs
@@ -71,7 +71,6 @@ pub trait Renderable {
         // If the buffer would clip the side, keep it within the bounds
         // This is done because wlc wraps if it goes beyond, which we don't
         // want for the borders.
-        debug!("Rendering at {:#?}", geometry);
         if geometry.origin.x + geometry.size.w as i32 > output_res.w as i32 {
             let offset = (geometry.origin.x + geometry.size.w as i32) - output_res.w as i32;
             geometry.origin.x -= offset as i32;
@@ -91,8 +90,6 @@ pub trait Renderable {
             warn!("Buffer to big to draw! Not drawing");
             return
         }
-        warn!("FINAL rendering at {:#?}", geometry);
-        error!("output_res: {:#?}", output_res);
         write_pixels(wlc_pixel_format::WLC_RGBA8888, geometry, &buffer);
     }
 }


### PR DESCRIPTION
Added Tabbed and Stacked layouts to Way Cooler 🎉. This PR also adds title bars to containers, which take on the same properties as the normal borders (e.g, the same Lua options control the color, size, etc. This might change in the future).

To control the command to switch to tabbed/stacked tiling, the Lua commands `tile_stacked` and `tile_tabbed` have been added. By default, they are bound to `mod+s` and `mod+w` respectively.

There still needs to be work done to them, that will come later:
1) ~The tiling is a little too aggressive for containers now~ **Fixed!**
2) Tabbed/Stacked title bars are not very descriptive about what they contain. They only display how many containers they contain, and which index you are on (e.g `(3/5)`).

This PR also fixes a rare graphical bug with borders, where they would not display correctly.

**This is the last major i3 feature that I have planned to add.** 
More might be added in the future, and they will definitely be polished going forward. 

However, going forward more work will be done for client programs (e.g, expanding the use case of the Lua configuration and D-Bus clients) and fleshing out of the complete desktop experience (notifications, an official status bar, documentation, etc.).

Fixes #163 