### PR TITLE
Floating container border bug hotfix

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -1,11 +1,5 @@
 //! Commands from the user to manipulate the tree
 
-use super::{try_lock_tree, lock_tree, try_lock_action};
-use super::{Action, ActionErr, Bar, Container, ContainerType,
-            Direction, Handle, Layout, TreeError};
-use super::Tree;
-use ::registry;
-
 use uuid::Uuid;
 use rustwlc::{Point, Size, Geometry, ResizeEdge, WlcView, WlcOutput, ViewType,
               VIEW_BIT_UNMANAGED};

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -630,7 +630,7 @@ impl Tree {
         if container.floating() {
             container.set_geometry(ResizeEdge::empty(), geometry);
             container.resize_borders(geometry);
-            container.draw_borders();
+            container.draw_borders()?;
             Ok(())
         } else {
             let uuid = container.get_id();

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -625,10 +625,12 @@ impl Tree {
     /// Updates the geometry of the view from an external request
     /// (such a request can come from the view itself)
     pub fn update_floating_geometry(&mut self, view: WlcView,
-                           geometry: Geometry) -> CommandResult {
+                                    geometry: Geometry) -> CommandResult {
         let container = self.0.lookup_view_mut(view)?;
         if container.floating() {
             container.set_geometry(ResizeEdge::empty(), geometry);
+            container.resize_borders(geometry);
+            container.draw_borders();
             Ok(())
         } else {
             let uuid = container.get_id();

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -135,6 +135,12 @@ impl From<GraphError> for TreeError {
     }
 }
 
+impl From<ResizeErr> for TreeError {
+    fn from(err: ResizeErr) -> TreeError {
+        TreeError::Resize(err)
+    }
+}
+
 impl LayoutTree {
     /// Drops every node in the tree, essentially invalidating it
     pub fn destroy_tree(&mut self) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -7,6 +7,8 @@ mod unit_tests;
 
 pub use self::actions::movement::MovementError;
 pub use self::actions::focus::FocusError;
+pub use self::actions::resize::ResizeErr;
+pub use self::core::GraphError;
 
 pub use self::core::action::{Action, ActionErr};
 pub use self::core::container::{Container, ContainerType, Handle, Layout};


### PR DESCRIPTION
Fixed bug where some programs that, when floating, would automatically move their contents but the borders around the view would not update properly. 

For example, this happens with Steam.