### PR TITLE
Tabbed stacked hotfix

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -234,22 +234,24 @@ impl LayoutTree {
                         }
                         // Set everything invisible,
                         // set floating and focused view to be visible.
-                        self.set_container_visibility(node_ix, false);
                         let mut children = self.tree
                             .children_of_by_active(node_ix);
-                        let mut seen = false;
+                        let mut seen = None;
                         for child_ix in &children {
                             if self.tree[*child_ix].floating() {
                                 self.set_container_visibility(*child_ix, true);
                                 continue
                             }
-                            if !seen {
-                                seen = true;
-                                self.layout_helper(*child_ix,
-                                                   geometry,
-                                                   fullscreen_apps);
-                                self.set_container_visibility(*child_ix, true);
+                            if seen.is_none() {
+                                seen = Some(*child_ix);
                             }
+                            self.layout_helper(*child_ix,
+                                               geometry,
+                                               fullscreen_apps);
+                        }
+                        self.set_container_visibility(node_ix, false);
+                        if let Some(child_ix) = seen {
+                            self.set_container_visibility(child_ix, true);
                         }
                         children.push(node_ix);
                         // TODO Propogate error

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -565,12 +565,9 @@ impl Tree {
     pub fn move_focus(&mut self, dir: Direction) -> CommandResult {
         debug!("Layout.FocusDir(\"{}\")", dir);
         self.0.move_focus(dir)?;
-        let layout = self.0.active_layout()?;
         // NOTE Since tiling is somewhat expensive,
         // this can be a bottleneck that can be possibly optimized.
-        if layout == Layout::Tabbed || layout == Layout::Stacked {
-            self.0.layout_active_of(ContainerType::Container);
-        }
+        self.0.layout_active_of(ContainerType::Workspace);
         Ok(())
     }
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -347,16 +347,6 @@ impl LayoutTree {
         }
     }
 
-    pub fn active_layout(&self) -> Result<Layout, TreeError> {
-        let mut node_ix = self.active_container
-            .ok_or(TreeError::NoActiveContainer)?;
-        if self.tree[node_ix].get_type() == ContainerType::View {
-            node_ix = self.tree.parent_of(node_ix)
-                .expect("Node had no parent");
-        }
-        self.tree[node_ix].get_layout().map_err(TreeError::Container)
-    }
-
     /// Add a new view container with the given WlcView to the active container
     pub fn add_view(&mut self, view: WlcView) -> Result<&Container, TreeError> {
         if let Some(mut active_ix) = self.active_container {


### PR DESCRIPTION
Fixes #313, and another bug which I will describe here:

When having a Tabbed/Stacked with a sub container that was just changed to Tabbed/Stacked, it would not tile the other containers, so that when you switched to the inner Tabbed/Stacked by cycling the outer Tabbed/Stacked it wouldn't update them properly and they would display themselves in a weird place (generally where they would have been before they were changed to Tabbed/Stacked). This PR fixes that bug as well.