### PR TITLE
IPC RemoveView hotfix

### DIFF
--- a/docs/d-bus/FullScreen.md
+++ b/docs/d-bus/FullScreen.md
@@ -18,8 +18,11 @@ If a container is toggled to be in a state it is already in then no error is ret
 ## Examples
 ```python
 from pydbus import SessionBus
+from time import sleep
 bus = SessionBus()
 layout = bus.get(bus_name='org.way-cooler', object_path='/org/way_cooler/Layout')
 active_id = layout.ActiveContainerId()
-layout.FullScreen(active_id)
+layout.FullScreen(active_id, True)
+sleep(1)
+layout.FullScreen(active_id, False)
 ```

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -457,8 +457,11 @@ impl Tree {
     /// `view_destroyed` callback, as it's possible the view from that callback is invalid.
     pub fn remove_view_by_id(&mut self, id: Uuid) -> CommandResult {
         debug!("Layout.CloseView(\"{}\")", id);
-        match try!(self.0.lookup(id)).get_handle()? {
-            Handle::View(view) => self.remove_view(view),
+        match self.0.lookup(id)?.get_handle()? {
+            Handle::View(view) => {
+                view.close();
+                Ok(())
+            },
             Handle::Output(_) =>
                 Err(TreeError::UuidNotAssociatedWith(ContainerType::View))
         }


### PR DESCRIPTION
* Fixes `Layout.CloseView` in D-Bus. It was not requesting a close of the handle properly, and instead just removing it from the layout tree.
* Fixed and expanded the example in the `Layout.FullScreen` documentation.