### PR TITLE
Parent borders are not drawn if child is floating

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -689,12 +689,19 @@ impl Tree {
         let node_ix = try!(self.lookup_handle(view.into()).ok()
                       .and_then(|id| self.0.tree.lookup_id(id))
                       .ok_or_else(||TreeError::ViewNotFound(view)));
+        let floating = {
+            let container = &mut self.0.tree[node_ix];
+            container.render_borders();
+            container.floating()
+        };
         self.0.tree[node_ix].render_borders();
         // Render parent container too, if applicable.
         let mut parent_ix = self.0.tree.parent_of(node_ix)?;
-        while self.0.tree[parent_ix].get_type() != ContainerType::Workspace {
-            self.0.tree[parent_ix].render_borders();
-            parent_ix = self.0.tree.parent_of(parent_ix)?
+        if ! floating {
+            while self.0.tree[parent_ix].get_type() != ContainerType::Workspace {
+                self.0.tree[parent_ix].render_borders();
+                parent_ix = self.0.tree.parent_of(parent_ix)?
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This fixes the bug where e.g dmenu would cause root container borders to appear when there were no other windows on the screen.