### PR TITLE
Multi head output fixes

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -324,14 +324,10 @@ impl LayoutTree {
     /// Sets all the nodes under and at the node index to the given
     /// visibilty setting
     pub fn set_container_visibility(&mut self, node_ix: NodeIndex, val: bool) {
-        let container_c;
-        {
-            let container = &mut self.tree[node_ix];
-            container_c = container.get_type();
-            container.set_visibility(val);
-        }
-        match container_c {
-            ContainerType::View => {},
+        match self.tree[node_ix].get_type() {
+            ContainerType::View => {
+                self.tree[node_ix].set_visibility(val);
+            },
             _ => {
                 for child_ix in self.tree.children_of(node_ix) {
                     self.set_container_visibility(child_ix, val);

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -263,11 +263,10 @@ impl LayoutTree {
                 self.get_active_container(), name);
             self.tree.move_node(active_ix, next_work_root_ix);
 
+            // If different outputs, show it on the new output.
             let cur_output_ix = self.tree.parent_of(curr_work_ix)
                 .expect("Couldn't get parent of current work index");
-            let next_is_vis = self.tree.on_path(next_work_root_ix);
-            // If different outputs, show it on the new output if workspace is vis.
-            if new_output_ix != cur_output_ix && next_is_vis {
+            if new_output_ix != cur_output_ix {
                 self.container_visibilty_wrapper(new_output_ix, true);
             }
 

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -263,10 +263,11 @@ impl LayoutTree {
                 self.get_active_container(), name);
             self.tree.move_node(active_ix, next_work_root_ix);
 
-            // If different outputs, show it on the new output.
             let cur_output_ix = self.tree.parent_of(curr_work_ix)
                 .expect("Couldn't get parent of current work index");
-            if new_output_ix != cur_output_ix {
+            let next_is_vis = self.tree.on_path(next_work_root_ix);
+            // If different outputs, show it on the new output if workspace is vis.
+            if new_output_ix != cur_output_ix && next_is_vis {
                 self.container_visibilty_wrapper(new_output_ix, true);
             }
 

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -263,6 +263,13 @@ impl LayoutTree {
                 self.get_active_container(), name);
             self.tree.move_node(active_ix, next_work_root_ix);
 
+            // If different outputs, show it on the new output.
+            let cur_output_ix = self.tree.parent_of(curr_work_ix)
+                .expect("Couldn't get parent of current work index");
+            if new_output_ix != cur_output_ix {
+                self.container_visibilty_wrapper(new_output_ix, true);
+            }
+
             // If it's a fullscreen app, then update the fullscreen lists
             self.transfer_fullscreen(curr_work_ix, next_work_ix, id);
 

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -227,11 +227,14 @@ impl LayoutTree {
                     fn set_output_recurse(this: &mut LayoutTree,
                                           node_ix: NodeIndex,
                                           output_handle: WlcOutput) {
-                        match this.tree[node_ix] {
-                            Container::View { handle, .. } => {
-                                handle.set_output(output_handle);
+                        match this.tree[node_ix].get_type() {
+                            ContainerType::View => {
+                                this.tree[node_ix].update_border_output(output_handle)
+                                    .expect("Could not update border output for view");
                             },
-                            Container::Container { .. } => {
+                            ContainerType::Container => {
+                                this.tree[node_ix].update_border_output(output_handle)
+                                    .expect("Could not update border output for view");
                                 for child_ix in this.tree.children_of(node_ix) {
                                     set_output_recurse(this, child_ix, output_handle)
                                 }

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -231,10 +231,26 @@ impl LayoutTree {
                             ContainerType::View => {
                                 this.tree[node_ix].update_border_output(output_handle)
                                     .expect("Could not update border output for view");
+                                // TODO this is duplicated in other places,
+                                // abstract into a function somewhere (not here)
+                                {
+                                    // Update the border colors
+                                    let container = &mut this.tree[node_ix];
+                                    container.clear_border_color()
+                                        .expect("Could not clear old active border color");
+                                    container.draw_borders().expect("Could not draw borders");
+                                }
                             },
                             ContainerType::Container => {
                                 this.tree[node_ix].update_border_output(output_handle)
                                     .expect("Could not update border output for view");
+                                {
+                                    // Update the border colors
+                                    let container = &mut this.tree[node_ix];
+                                    container.clear_border_color()
+                                        .expect("Could not clear old active border color");
+                                    container.draw_borders().expect("Could not draw borders");
+                                }
                                 for child_ix in this.tree.children_of(node_ix) {
                                     set_output_recurse(this, child_ix, output_handle)
                                 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -361,8 +361,8 @@ impl Tree {
     /// Binds a view to be the background for the given outputs.
     ///
     /// If there was a previous background, it is removed and deallocated.
-    pub fn add_background(&mut self, view: WlcView, outputs: &[Uuid]) -> CommandResult {
-        self.0.attach_background(view, outputs)
+    pub fn add_background(&mut self, view: WlcView, output: Uuid) -> CommandResult {
+        self.0.attach_background(view, output)
     }
 
     /// Adds a Workspace to the tree. Never fails

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -327,6 +327,16 @@ impl Borders {
         self.output
     }
 
+    /// Changes the output that this border resides in.
+    /// This will automatically re-trigger a reallocation
+    /// so that it renders correctly.
+    pub fn set_output(mut self, output: WlcOutput) -> Option<Self> {
+        self.output = output;
+        // Force copy
+        let geo = self.geometry;
+        self.reallocate_buffer(geo)
+    }
+
     pub fn title(&self) -> &str {
         self.title.as_str()
     }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -708,6 +708,33 @@ impl Container {
         }
     }
 
+    /// Sets the new output that the border should render on.
+    pub fn update_border_output(&mut self, output: WlcOutput)
+                                -> Result<(), ContainerErr> {
+        let c_type = self.get_type();
+        match *self {
+            Container::View { handle, ref mut borders, .. }  => {
+                handle.set_output(output);
+                if let Some(borders_) = borders.take() {
+                    *borders = borders_.set_output(output);
+                }
+                Ok(())
+            }
+            Container::Container { ref mut borders, .. } => {
+                if let Some(borders_) = borders.take() {
+                    *borders = borders_.set_output(output);
+                }
+                Ok(())
+            },
+            _ => {
+                Err(ContainerErr::BadOperationOn(c_type,
+                                                 "Can only call \
+                                                  update_border_update on \
+                                                  View/Container".into()))?
+            }
+        }
+    }
+
     /// Gets the title for a wlc handle.
     /// Tries to get the title, then defers to class if blank,
     /// and finally to the app_id if that is blank as well.

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -114,8 +114,8 @@ impl Mode for Default {
             };
             view.set_geometry(ResizeEdge::empty(), fullscreen);
             if let Ok(mut tree) = lock_tree() {
-                let outputs = tree.outputs();
-                return tree.add_background(view, outputs.as_slice()).map(|_| true)
+                let output = tree.outputs()[0];
+                return tree.add_background(view, output).map(|_| true)
                     .unwrap_or_else(|err| {
                         warn!("Could not add background due to {:?}", err);
                         true


### PR DESCRIPTION
Fixes a few issues/regressions with multi-head output:
* Borders will no longer be improperly sized when moving a container to a different output
* Containers will now be visible in their new output once they have been moved
* Backgrounds will not resize to try to fit on a background that they don't fit on