### PR TITLE
Remove clones on Size and Geometry, fixes #224

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -550,18 +550,18 @@ impl LayoutTree {
               RemainF: Fn(Geometry, Geometry) -> Size,
               PointF:  Fn(Size, Geometry) -> Point
     {
-        let mut sub_geometry = geometry.clone();
+        let mut sub_geometry = geometry;
         for (index, child_ix) in children.iter().enumerate() {
             let child_size = self.tree[*child_ix].get_geometry()
                 .expect("Child had no geometry").size;
-            let new_size = new_size_f(child_size, sub_geometry.clone());
+            let new_size = new_size_f(child_size, sub_geometry);
             sub_geometry = Geometry {
                 origin: sub_geometry.origin.clone(),
-                size: new_size.clone()
+                size: new_size
             };
             // If last child, then just give it the remaining height
             if index == children.len() - 1 {
-                let new_size = remaining_size_f(sub_geometry.clone(),
+                let new_size = remaining_size_f(sub_geometry,
                                                 self.tree[node_ix].get_geometry()
                                                 .expect("Container had no geometry"));
                 sub_geometry = Geometry {
@@ -569,10 +569,10 @@ impl LayoutTree {
                     size: new_size
                 };
             }
-            self.layout_helper(*child_ix, sub_geometry.clone(), fullscreen_apps);
+            self.layout_helper(*child_ix, sub_geometry, fullscreen_apps);
 
             // Next sub container needs to start where this one ends
-            let new_point = new_point_f(new_size.clone(), sub_geometry.clone());
+            let new_point = new_point_f(new_size, sub_geometry);
             sub_geometry = Geometry {
                 // lambda to calculate new point, given a new size
                 // which is calculated in the function

--- a/src/layout/actions/resize.rs
+++ b/src/layout/actions/resize.rs
@@ -113,7 +113,7 @@ impl LayoutTree {
 /// the current position of the pointer, and the previous place the pointer was at.
 fn calculate_resize(geo: Geometry, edge: ResizeEdge,
                     cur_pointer: Point, prev_pointer: Point) -> Geometry {
-    let mut new_geo = geo.clone();
+    let mut new_geo = geo;
     let dx = cur_pointer.x - prev_pointer.x;
     let dy = cur_pointer.y - prev_pointer.y;
     if edge.contains(RESIZE_LEFT) {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -837,7 +837,7 @@ mod tests {
         let root_ix = tree.root_ix();
         let fake_size = Size { h: 800, w: 600 };
         let fake_geometry = Geometry {
-            size: fake_size.clone(),
+            size: fake_size,
             origin: Point { x: 0, y: 0 }
         };
 
@@ -846,7 +846,7 @@ mod tests {
                                                 Container::new_workspace("1".to_string(),
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                 Container::new_container(fake_geometry.clone(),
+                                                 Container::new_container(fake_geometry,
                                                                           fake_output,
                                                                           None),
                                                  false);
@@ -854,7 +854,7 @@ mod tests {
                                                 Container::new_workspace("2".to_string(),
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
-                                                 Container::new_container(fake_geometry.clone(),
+                                                 Container::new_container(fake_geometry,
                                                                           fake_output,
                                                                           None),
                                                  false);
@@ -863,7 +863,7 @@ mod tests {
                                                 Container::new_view(fake_view_1.clone(), None), false);
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
-                                               Container::new_container(fake_geometry.clone(),
+                                               Container::new_container(fake_geometry,
                                                                         fake_output,
                                                                         None),
                                                false);

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -924,7 +924,7 @@ pub mod tests {
         let root_ix = tree.root_ix();
         let fake_size = Size { h: 800, w: 600 };
         let fake_geometry = Geometry {
-            size: fake_size.clone(),
+            size: fake_size,
             origin: Point { x: 0, y: 0 }
         };
 
@@ -933,7 +933,7 @@ pub mod tests {
                                                 Container::new_workspace("1".to_string(),
                                                                    fake_geometry), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                 Container::new_container(fake_geometry.clone(),
+                                                 Container::new_container(fake_geometry,
                                                                           fake_output,
                                                                           None),
                                                  false);
@@ -941,7 +941,7 @@ pub mod tests {
                                                 Container::new_workspace("2".to_string(),
                                                                      fake_geometry), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
-                                                 Container::new_container(fake_geometry.clone(),
+                                                 Container::new_container(fake_geometry,
                                                                           fake_output,
                                                                           None),
                                                  false);
@@ -950,7 +950,7 @@ pub mod tests {
                                                 Container::new_view(fake_view_1.clone(), None), false);
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
-                                               Container::new_container(fake_geometry.clone(),
+                                               Container::new_container(fake_geometry,
                                                                         fake_output,
                                                                         None),
                                                false);


### PR DESCRIPTION
This should remove all .clone() calls for Size and Geometry.