### PR TITLE
Center dialog race condition hotfix

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -675,7 +675,7 @@ impl Tree {
         let container = self.0.lookup_view_mut(view)?;
         if container.floating() {
             // If we didn't request it to be at 0,0, don't move
-            // WORKAROUND This is a workaround where certain popups
+            // FIXME WORKAROUND This is a workaround where certain popups
             // (I'm looking at you, Firefox save), will request it to be at 0,0
             // but with the correct size. This causes a race condition,
             // where sometimes we get to update the origin first and sometimes

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -685,7 +685,7 @@ impl Tree {
             // so it's only updated from Way Cooler's side.
             let effective_geo = container.get_geometry()
                 .expect("Updated a container that wasn't a view!");
-            if effective_geometry.origin != geometry.origin {
+            if effective_geo.origin != geometry.origin {
                 // And it's trying to put it in the top left.
                 if geometry.origin == Point::new(0, 0) {
                     let output = view.get_output();


### PR DESCRIPTION
This fixes a bug where certain apps (e.g Firefox using XWayland) would send updates to change their popup geometry to something unsatisfying (such as at origin point 0,0) after the surface has already been created.

This causes a data race to occur (at the protocol level, this is something that Rust *cannot* protect us against), where sometimes Way Cooler gets to it in time to e.g center the popup correctly and other times it would be too early and the app will reposition it (incorrectly) for us.

This adds a check when a geometry is updated to not move it to 0,0 unless the request came from Way Cooler.

Thanks for @platipo for pointing out this bug (that I have also noticed) and making me dig into why it was happening.