### PR TITLE
Added unbinding keys and allowing key passthrough.

### DIFF
--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -54,6 +54,7 @@ commands.on_terminate = function() end
 local use_key = ", use the `way_cooler.key` method to create a keybinding"
 -- Converts a list of modifiers to a string
 local function keymods_to_string(mods, key)
+    mods = {table.unpack(mods)}
     table.insert(mods, key)
     return table.concat(mods, ',')
 end

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -91,15 +91,12 @@ commands.register_key = function(key)
     end
 end
 
--- unregisters a keybinding
-commands.unregister_key = function(key)
-  assert(key.mods, "keybinding missing modifiers" .. use_key)
-  assert(key.key, "keybinding missing key" .. use_key)
-  assert(type(key.mods) == 'table',
-         "keybinding modifiers: expected table" .. use_key)
-  assert(type(key.key) == 'string',
-         "keybinding key: expected string" .. use_key)
-  rust.unregister_lua_key(keymods_to_string(key.mods, key.key))
+-- unregisters a keybinding (e.g mods + key).
+-- This is the same arguments as the first two to key(...).
+commands.unregister_key = function(mods, key)
+  assert(type(mods) == 'table', "modifiers: expected table")
+  assert(type(key) == 'string', "key: expected string")
+  rust.unregister_lua_key(keymods_to_string(mods, key))
 end
 
 -- Bind a key to use in conjunction with the mouse for certain commands (resize, move floating)

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -67,7 +67,7 @@ end
 -- Register a keybinding
 commands.register_key = function(key)
     assert(key.mods, "keybinding missing modifiers" .. use_key)
-    assert(key.key, "keybinding missing modifiers" .. use_key)
+    assert(key.key, "keybinding missing key" .. use_key)
     assert(key.action, "keybinding missing action" .. use_key)
     assert(key.loop ~= nil, "keybinding missing repeat" .. use_key)
     assert(key.passthrough ~= nil, "keybinding missing passthrough" .. use_key)
@@ -89,6 +89,17 @@ commands.register_key = function(key)
     else
         error("keybinding action: expected string or a function"..use_key, 2)
     end
+end
+
+-- unregisters a keybinding
+commands.unregister_key = function(key)
+  assert(key.mods, "keybinding missing modifiers" .. use_key)
+  assert(key.key, "keybinding missing key" .. use_key)
+  assert(type(key.mods) == 'table',
+         "keybinding modifiers: expected table" .. use_key)
+  assert(type(key.key) == 'string',
+         "keybinding key: expected string" .. use_key)
+  rust.unregister_lua_key(keymods_to_string(key.mods, key.key))
 end
 
 -- Bind a key to use in conjunction with the mouse for certain commands (resize, move floating)

--- a/src/keys/action.rs
+++ b/src/keys/action.rs
@@ -1,0 +1,20 @@
+use std::fmt::{Debug, Formatter};
+use std::fmt::Result as FmtResult;
+use super::KeyEvent;
+
+/// An action performed by the key binding.
+/// Contains the event that is performed (e.g what Lua or Rust function
+/// to call), and meta data around the action such as whether to include
+/// passthrough to the client or not.
+#[derive(Clone)]
+pub struct Action {
+    pub event: KeyEvent,
+    pub passthrough: bool
+}
+
+impl Debug for Action {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Event: {:?}, passthrough: {:?} ",
+               self.event, self.passthrough)
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -89,6 +89,13 @@ pub fn register(key: KeyPress, event: KeyEvent, passthrough: bool)
     bindings.insert(key, action)
 }
 
+/// Unregisters a key mapping
+pub fn unregister(key: &KeyPress) -> Option<Action> {
+    let mut bindings = BINDINGS.write()
+        .expect("Keybindings/unregister: unable to lock keybindings");
+    bindings.remove(key)
+}
+
 /// Registers a modifier to be used with mouse commands
 pub fn register_mouse_modifier(modifier: KeyMod) {
     let mut key_mod = MOUSE_MODIFIER.write()

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -114,7 +114,6 @@ fn register_lua_key(mods: String, _repeat: bool, passthrough: bool)
 ///
 /// If a key wasn't registered, a proper error string is raised.
 fn unregister_lua_key(mods: String) -> Result<String, String> {
-    error!("Got {:#?}", mods);
     keypress_from_string(&mods).and_then(|press| {
         if let Some(action) = keys::unregister(&press) {
             trace!("Removed keybinding \"{}\" for {:?}", press, action);

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -249,8 +249,10 @@ impl Mode for Default {
         let press = KeyPress::new(mods.mods, sym);
 
         if state == KeyState::Pressed {
-            if let Some(action) = keys::get(&press) {
+            if let Some(key) = keys::get(&press) {
                 info!("[key] Found an action for {}, blocking event", press);
+                let action = key.event;
+                let passthrough = key.passthrough;
                 match action {
                     KeyEvent::Command(func) => {
                         func();
@@ -269,7 +271,7 @@ impl Mode for Default {
                         }
                     }
                 }
-                return EVENT_BLOCKED
+                return !passthrough
             }
         }
 


### PR DESCRIPTION
This should fix #342.

In order to register a key for passthrough, note that you need **two** `true` statements after declaring a key. E.g:
```lua
-- enables passthrough to the mod+shift+h keybinding
key({ mod, "Shift" }, "h", function () print("Hello world!") end, true, true)
```

This is because there is a currently unused variable there (loop) and I did not want to break backwards compatibility in case I use that. In the future this might change, but because this is being added in a minor version bump I will not make this a breaking change (even if it wouldn't actually break anything).

@z33ky Can you please test this to ensure that it works for your use case? I'll take the next couple of days to run it on my own system (to ensure no regressions) and to review the code.

This PR also fixes a bug where the adding a key would mutate the original keybinding table that was passed in, meaning subsequent calls to it would be invalid.