### PR TITLE
Nested border hotfix

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -414,7 +414,14 @@ impl LayoutTree {
                 return Ok(())
             }
             if self.tree.grounded_children(parent_ix).len() == 1 {
-                self.set_layout(parent_ix, new_layout);
+                // NOTE Do _NOT_ use set_layout,
+                // the normalization causes the issue described in #344
+                match self.tree[parent_ix] {
+                    Container::Container { ref mut layout , ..} => {
+                        *layout = new_layout
+                    },
+                    _ => unreachable!()
+                }
                 return Ok(())
             }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -77,17 +77,20 @@ pub fn tile_switch() {
 
 pub fn split_vertical() {
     if let Ok(mut tree) = try_lock_tree() {
+        debug!("Layout.SplitVertical()");
         tree.0.toggle_active_layout(Layout::Vertical).ok();
     }
 }
 
 pub fn split_horizontal() {
+    debug!("Layout.SplitHorizontal()");
     if let Ok(mut tree) = try_lock_tree() {
         tree.0.toggle_active_layout(Layout::Horizontal).ok();
     }
 }
 
 pub fn tile_tabbed() {
+    debug!("Layout.SplitTabbed()");
     if let Ok(mut tree) = try_lock_tree() {
         tree.0.set_active_layout(Layout::Tabbed).unwrap_or_else(|err| {
             warn!("Could not tile as tabbed: {:?}", err);
@@ -97,6 +100,7 @@ pub fn tile_tabbed() {
 
 pub fn tile_stacked() {
     if let Ok(mut tree) = try_lock_tree() {
+        debug!("Layout.SplitStacked()");
         tree.0.set_active_layout(Layout::Stacked).unwrap_or_else(|err| {
             warn!("Could not tile as stacked: {:?}", err);
         })


### PR DESCRIPTION
Fixes #344.

Adds more logging for user input (namely switching tiling and making sub-containers).