### PR TITLE
Scrape active screen

### DIFF
--- a/src/ipc/interfaces/screen.rs
+++ b/src/ipc/interfaces/screen.rs
@@ -2,6 +2,8 @@ use dbus::arg::{Array};
 use dbus::tree::MethodErr;
 use dbus::MessageItem;
 
+use ::rustwlc::WlcOutput;
+use ::layout::Handle;
 use ::ipc::utils::{parse_uuid, lock_tree_dbus};
 use ::ipc::{DBusFactory, DBusObjPath};
 use ::render::screen_scrape::{write_screen_scrape_lock, read_screen_scrape_lock,
@@ -21,6 +23,14 @@ pub fn setup(f: &mut DBusFactory) -> DBusObjPath {
                             .append((MessageItem::Array(outputs, "s".into())))
                     ])
                 }).outarg::<Array<String, Vec<String>>, _>("success")
+            )
+            .add_m(
+                f.method("ActiveScreen", (), |m| {
+                    let tree = lock_tree_dbus()?;
+                    let id = tree.lookup_handle(Handle::Output(WlcOutput::focused()))
+                        .map_err(|err| MethodErr::failed(&format!("{:?}", err)))?.to_string();
+                    Ok(vec![m.msg.method_return().append((MessageItem::Str(id)))])
+                }).outarg::<String, _>("success")
             )
             .add_m(
                 // TODO Make this take in a:

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -62,6 +62,9 @@ impl Mode for Default {
     }
 
     fn output_render_post(&mut self, output: WlcOutput) {
+        if WlcOutput::focused() != output {
+            return
+        }
         let need_to_fetch = read_screen_scrape_lock();
         if *need_to_fetch {
             if let Ok(mut scraped_pixels) = scraped_pixels_lock() {

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -62,11 +62,11 @@ impl Mode for Default {
     }
 
     fn output_render_post(&mut self, output: WlcOutput) {
-        if WlcOutput::focused() != output {
-            return
-        }
         let need_to_fetch = read_screen_scrape_lock();
         if *need_to_fetch {
+            if WlcOutput::focused() != output {
+                return
+            }
             if let Ok(mut scraped_pixels) = scraped_pixels_lock() {
                 let resolution = output.get_resolution()
                     .expect("Output had no resolution");


### PR DESCRIPTION
Adds a new screen endpoint to get the UUID of the active output.

Also ensures only scrapes the pixels of the active output.

Fixes #349 