### PR TITLE
Add config directory to Lua's package.path

### DIFF
--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -130,7 +130,13 @@ pub fn init() {
     let (use_config, maybe_init_file) = init_path::get_config();
     if use_config {
         match maybe_init_file {
-            Ok(init_file) => {
+            Ok((init_dir, init_file)) => {
+                if init_dir.components().next().is_some() {
+                    // Add the config directory to the package path.
+                    let mut package: hlua::LuaTable<_> = lua.get("package").expect("package not defined in Lua");
+                    let paths: String = package.get("path").expect("package.path not defined in Lua");
+                    package.set("path", paths + ";" + init_dir.join("?.lua").to_str().expect("init_dir not a valid UTF-8 string"));
+                }
                 let _: () = lua.execute_from_reader(init_file)
                     .map(|r| { info!("Read init.lua successfully"); r })
                     .or_else(|err| {


### PR DESCRIPTION
This way, `init.lua` can `require()` additional scripts in the same directory.
A consequence of this is that the `WAY_COOLER_INIT_FILE` environment variable can also influence the `package.path`.

I have a version checking that accessing `package.path` succeeds [here](1bf3521a520b73905a4b2d5b8adc53f42ae407a4), whereas this PR just uses `unwrap()`. Since `package.path` should be set by the Lua interpreter I think we can just assume it exists though.