### PR TITLE
Virt manager hotfixes

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -414,14 +414,7 @@ impl LayoutTree {
                 return Ok(())
             }
             if self.tree.grounded_children(parent_ix).len() == 1 {
-                // NOTE Do _NOT_ use set_layout,
-                // the normalization causes the issue described in #344
-                match self.tree[parent_ix] {
-                    Container::Container { ref mut layout , ..} => {
-                        *layout = new_layout
-                    },
-                    _ => unreachable!()
-                }
+                self.set_layout(parent_ix, new_layout);
                 return Ok(())
             }
 

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -414,7 +414,14 @@ impl LayoutTree {
                 return Ok(())
             }
             if self.tree.grounded_children(parent_ix).len() == 1 {
-                self.set_layout(parent_ix, new_layout);
+                // NOTE Do _NOT_ use set_layout,
+                // the normalization causes the issue described in #344
+                match self.tree[parent_ix] {
+                    Container::Container { ref mut layout , ..} => {
+                        *layout = new_layout
+                    },
+                    _ => unreachable!()
+                }
                 return Ok(())
             }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -422,7 +422,7 @@ impl Tree {
         let view_bit = view.get_type();
         trace!("Adding view: {:?}\n w/ bit: {:?}\n has parent: {:?}\n\
                 title: {:?}\n class: {:?}\n appid: {:?}",
-               view, view_bit, has_parent,
+               view, view_bit.bits(), has_parent,
                view.get_title(), view.get_class(), view.get_app_id());
         if view_bit.intersects(VIEW_BIT_UNMANAGED) {
             tree.add_floating_view(view, None)?;

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -433,12 +433,21 @@ impl Tree {
                         .expect("View had no geometry");
                     let borders = Borders::new(geo, output);
                     tree.add_floating_view(view, borders)?;
+                    view.focus();
                 },
                 VIEW_BIT_POPUP => {
                     tree.add_floating_view(view, None)?;
                 },
-                _ => {
-                    tree.add_floating_view(view, None)?;
+                v => {
+                    if v == ViewType::empty() {
+                        let geo = view.get_geometry()
+                            .expect("View had no geometry");
+                        let borders = Borders::new(geo, output);
+                        tree.add_floating_view(view, borders)?;
+                        view.focus();
+                    } else {
+                        tree.add_floating_view(view, None)?;
+                    }
                 }
             }
         } else if view_bit != ViewType::empty() {

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -13,7 +13,7 @@ use ::registry;
 
 use uuid::Uuid;
 use rustwlc::{Point, Size, Geometry, ResizeEdge, WlcView, WlcOutput, ViewType,
-              VIEW_BIT_UNMANAGED};
+              VIEW_BIT_UNMANAGED, VIEW_BIT_MODAL, VIEW_BIT_POPUP};
 use rustwlc::input::pointer;
 use rustc_serialize::json::{Json, ToJson};
 
@@ -427,12 +427,19 @@ impl Tree {
         if view_bit.intersects(VIEW_BIT_UNMANAGED) {
             tree.add_floating_view(view, None)?;
         } else if has_parent {
-            if view_bit != ViewType::empty() {
-                let geo = view.get_geometry().expect("View had no geometry");
-                let borders = Borders::new(geo, output);
-                tree.add_floating_view(view, borders)?;
-            } else {
-                tree.add_floating_view(view, None)?;
+            match view_bit {
+                VIEW_BIT_MODAL => {
+                    let geo = view.get_geometry()
+                        .expect("View had no geometry");
+                    let borders = Borders::new(geo, output);
+                    tree.add_floating_view(view, borders)?;
+                },
+                VIEW_BIT_POPUP => {
+                    tree.add_floating_view(view, None)?;
+                },
+                _ => {
+                    tree.add_floating_view(view, None)?;
+                }
             }
         } else if view_bit != ViewType::empty() {
             tree.add_floating_view(view, None)?;

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -420,6 +420,10 @@ impl Tree {
         // If this view is a subsurface
         let has_parent = view.get_parent() != WlcView::root();
         let view_bit = view.get_type();
+        trace!("Adding view: {:?}\n w/ bit: {:?}\n has parent: {:?}\n\
+                title: {:?}\n class: {:?}\n appid: {:?}",
+               view, view_bit, has_parent,
+               view.get_title(), view.get_class(), view.get_app_id());
         if view_bit.intersects(VIEW_BIT_UNMANAGED) {
             tree.add_floating_view(view, None)?;
         } else if has_parent {

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -409,7 +409,9 @@ impl Container {
                     v_g.size.h = MIN_SIZE.h;
                 }
                 // if modal, center it if in the top left.
-                if handle.get_type().contains(VIEW_BIT_MODAL) {
+                let put_in_center = handle.get_type().contains(VIEW_BIT_MODAL) ||
+                    handle.get_parent() != WlcView::root();
+                if put_in_center {
                     if v_g.origin.x == 0 && v_g.origin.y == 0 {
                         let output = handle.get_output();
                         let res = output.get_resolution()


### PR DESCRIPTION
Fixes the issues raised in #218, including a regression on borders being added to drop down menus and a refinement on what popups need to be centered and have borders.

Namely, popup windows that are spawned from a program (e.g the configuration for `xfce4-terminal`, or the connection issue popup in `virt-manager` are now centered properly and also will have borders and also will be auto-focused.