### PR TITLE
Add noop command

### DIFF
--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -29,6 +29,8 @@ pub fn register_defaults() {
     register("way_cooler_restart", way_cooler_restart);
     register("dmenu_lua_dofile", dmenu_lua_dofile);
 
+    register("noop", noop);
+
     /// Generate switch_workspace methods and register them
     macro_rules! gen_switch_workspace {
         ( $($b:ident, $n:expr);+ ) => {
@@ -182,4 +184,11 @@ fn way_cooler_restart() {
     if let Err(err) = lua::send(lua::LuaQuery::Restart) {
         warn!("Could not send restart signal, {:?}", err);
     }
+}
+
+/// A no-op(eration) command.
+/// This can be used to register keys without assigning them an action (yet).
+/// The Lua configuration script could also create an empty Lua function,
+/// but doing it in Rust avoids a round-trip to Lua just to no nothing.
+fn noop () {
 }


### PR DESCRIPTION
For [apreggio](/z33ky/wc-apreggio) I currently use a Lua noop function (`function() end`) to register keys before they are used to avoid necessitating creating new hashmap entries in runtime. With this commit I provide an equivalent command "noop" in Rust.

Using a Lua function has no issues, but of course using a Rust function instead avoids a round-trip to Lua just for doing nothing.
Wanting to "pre-register" keys may no be a commonly requested feature, but this change is also very small and has almost no impact on binary size, maintenance efforts, ect.