### PR TITLE
Background and bar now bind to focused output.

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -365,8 +365,20 @@ impl Tree {
     /// Binds a view to be the background for the given outputs.
     ///
     /// If there was a previous background, it is removed and deallocated.
-    pub fn add_background(&mut self, view: WlcView, output: Uuid) -> CommandResult {
-        self.0.attach_background(view, output)
+    pub fn add_background(&mut self, view: WlcView, output: WlcOutput) -> CommandResult {
+        let id;
+        {
+            let output_c = self.0.output_by_handle_mut(output)
+                .ok_or(TreeError::OutputNotFound(output))?;
+            id = output_c.get_id();
+            match output_c.get_type() {
+                ContainerType::Output => {},
+                other => {
+                    return Err(TreeError::UuidNotAssociatedWith(other))
+                }
+            };
+        }
+        self.0.attach_background(view, id)
     }
 
     /// Adds a Workspace to the tree. Never fails

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -95,11 +95,10 @@ impl Mode for Default {
                 view.set_mask(1);
                 view.bring_to_front();
                 if let Ok(mut tree) = try_lock_tree() {
-                    for output in WlcOutput::list() {
-                        tree.add_bar(view, output).unwrap_or_else(|_| {
-                            warn!("Could not add bar {:#?} to output {:#?}", view, output);
-                        });
-                    }
+                    let output = WlcOutput::focused();
+                    tree.add_bar(view, output).unwrap_or_else(|_| {
+                        warn!("Could not add bar {:#?} to output {:#?}", view, output);
+                    });
                     return true;
                 }
             }
@@ -118,7 +117,7 @@ impl Mode for Default {
             };
             view.set_geometry(ResizeEdge::empty(), fullscreen);
             if let Ok(mut tree) = lock_tree() {
-                let output = tree.outputs()[0];
+                let output = WlcOutput::focused();
                 return tree.add_background(view, output).map(|_| true)
                     .unwrap_or_else(|err| {
                         warn!("Could not add background due to {:?}", err);


### PR DESCRIPTION
This lets you switch at runtime the output that uses the bar /
background by simply restarting Way Cooler in place while focused on the
desired output.

Fixes #375 