### PR TITLE
Added Awesome interface: mousegrabber

### DIFF
--- a/lib/lua/awesome_init.lua
+++ b/lib/lua/awesome_init.lua
@@ -4,3 +4,10 @@ keygrabber = {
   -- Secret callback function that is called for every keyboard press.
   __callback = nil
 }
+
+mousegrabber = {
+  -- Secret callback function that is called for every mouse event
+  __callback = nil,
+  -- Secret cursor icon that we don't really apply because this is Wayland
+  __cursor = nil
+}

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -1,12 +1,15 @@
 //! Awesome compatibilty modules
 use rlua::{self, Lua};
 pub mod keygrabber;
+pub mod mousegrabber;
 pub mod awful;
 
 pub use self::keygrabber::keygrabber_handle;
+pub use self::mousegrabber::mousegrabber_handle;
 
 pub fn init(lua: &Lua) -> rlua::Result<()> {
     keygrabber::init(lua)?;
+    mousegrabber::init(lua)?;
     awful::init(lua)?;
     Ok(())
 }

--- a/src/awesome/mousegrabber.rs
+++ b/src/awesome/mousegrabber.rs
@@ -1,0 +1,75 @@
+//! AwesomeWM Mousegrabber interface
+
+use ::lua::LUA;
+use rlua::{self, Lua, Table, Function, Value};
+use rustwlc::ButtonState;
+
+pub const MOUSEGRABBER_TABLE: &str = "mousegrabber";
+const SECRET_CALLBACK: &str = "__callback";
+const SECRET_CURSOR: &str = "__cursor";
+
+
+/// Init the methods defined on this interface
+pub fn init(lua: &Lua) -> rlua::Result<()> {
+    let mousegrabber_table = lua.create_table();
+    mousegrabber_table.set("run", lua.create_function(run))?;
+    mousegrabber_table.set("stop", lua.create_function(stop))?;
+    mousegrabber_table.set("isrunning", lua.create_function(isrunning))?;
+    let globals = lua.globals();
+    globals.set(MOUSEGRABBER_TABLE, mousegrabber_table)
+}
+
+pub fn mousegrabber_handle(x: i32, y: i32, button: Option<(u32, ButtonState)>)
+                         -> rlua::Result<()> {
+    let lua = LUA.lock()
+        .map_err(|err| rlua::Error::RuntimeError(
+            format!("Lua lock was poisoned {:#?}", err)))?;
+    let button_events = button.map(|(button, button_state)|
+                                   ::lua::mouse_events_to_lua(&lua.0, button, button_state))
+        .unwrap_or_else(|| Ok(vec![false, false, false, false, false]))?;
+    call_mousegrabber(&lua.0, (x, y, button_events))
+}
+
+fn call_mousegrabber(lua: &Lua,
+                     (x, y, button_events):
+                     (i32, i32, Vec<bool>)) -> rlua::Result<()> {
+    let globals = lua.globals();
+    let lua_callback = globals
+        .get::<_, Table>(MOUSEGRABBER_TABLE)?
+        .get::<_, Function>(SECRET_CALLBACK)?;
+    let res_table = lua.create_table();
+    res_table.set("x", x)?;
+    res_table.set("y", y)?;
+    res_table.set("buttons", button_events)?;
+    match lua_callback.call(res_table)? {
+        Value::Boolean(true) => {Ok(())},
+        _ => stop(lua, ())
+    }
+}
+
+
+fn run(lua: &Lua, (function, cursor): (Function, String)) -> rlua::Result<()> {
+    let mousegrabber_table = lua.globals().get::<_, Table>(MOUSEGRABBER_TABLE)?;
+    match mousegrabber_table.get::<_, Value>(SECRET_CALLBACK)? {
+        Value::Function(_) =>
+            Err(rlua::Error::RuntimeError("mousegrabber callback already set!"
+                                          .into())),
+        _ => {
+            mousegrabber_table.set(SECRET_CALLBACK, function)?;
+            mousegrabber_table.set(SECRET_CURSOR, cursor)
+        }
+    }
+}
+
+fn stop(lua: &Lua, _: ()) -> rlua::Result<()> {
+    let mousegrabber_table = lua.globals().get::<_, Table>(MOUSEGRABBER_TABLE)?;
+    mousegrabber_table.set(SECRET_CALLBACK, Value::Nil)
+}
+
+fn isrunning(lua: &Lua, _: ()) -> rlua::Result<bool> {
+    let mousegrabber_table = lua.globals().get::<_, Table>(MOUSEGRABBER_TABLE)?;
+    match mousegrabber_table.get::<_, Value>(SECRET_CALLBACK)? {
+        Value::Function(_) => Ok(true),
+        _ => Ok(false)
+    }
+}

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -24,4 +24,4 @@ lazy_static! {
 pub use self::types::{LuaQuery, LuaResponse};
 pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
                        LuaSendError};
-pub use self::utils::mods_to_lua;
+pub use self::utils::{mods_to_lua, mouse_events_to_lua};

--- a/src/lua/utils.rs
+++ b/src/lua/utils.rs
@@ -5,6 +5,18 @@ use rustwlc::*;
 
 const MOD_NAMES: [&str; 8] = ["Shift", "Caps", "Control", "Alt",
                               "Mod2", "Mod3", "Mod4", "Mod5"];
+const MOUSE_EVENTS: [u32; 6] = [
+    // TODO This only grabs the buttons, not the scroll
+    // This is a WLC limitation, it will be lifted later!
+
+    272,  // button mask 1
+    273,  // button mask 2
+    274, // button mask 3
+    275, // button mask 4
+    276, // button mask 5
+
+    // TODO currently unused
+    1 << 15  /* mask any */];
 
 /// Convert a modifier to the Lua interpretation
 pub fn mods_to_lua(lua: &rlua::Lua, mut mods: KeyMod) -> rlua::Result<Table> {
@@ -19,4 +31,16 @@ pub fn mods_to_lua(lua: &rlua::Lua, mut mods: KeyMod) -> rlua::Result<Table> {
         mods = KeyMod::from_bits_truncate(mods.bits() >> 1);
     }
     lua.create_table_from(mods_list.into_iter().enumerate())
+}
+
+/// Convert a mouse event from Wayland to the representation Lua expcets
+pub fn mouse_events_to_lua(_: &rlua::Lua, button: u32,
+                           button_state: ButtonState) -> rlua::Result<Vec<bool>> {
+    let mut event_list = Vec::with_capacity(MOUSE_EVENTS.len());
+    for mouse_event in &MOUSE_EVENTS[..5] {
+        let state_pressed = button_state == ButtonState::Pressed;
+        let is_pressed = button == *mouse_event && state_pressed;
+        event_list.push(is_pressed);
+    }
+    Ok(event_list)
 }

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -304,6 +304,9 @@ impl Mode for Default {
     fn on_pointer_button(&mut self, view: WlcView, _time: u32,
                             mods: KeyboardModifiers, button: u32,
                                 state: ButtonState, point: Point) -> bool {
+        awesome::mousegrabber_handle(point.x, point.y, Some((button, state)))
+            .unwrap_or_else(|err|
+                            warn!("handling keygrabber returned error: {:#?}", err));
         if state == ButtonState::Pressed {
             let mouse_mod = keys::mouse_modifier();
             if button == LEFT_CLICK && !view.is_root() {
@@ -399,6 +402,9 @@ impl Mode for Default {
                 maybe_action = action_lock.clone();
             }
         }
+        awesome::mousegrabber_handle(point.x, point.y, None)
+            .unwrap_or_else(|err|
+                            warn!("handling keygrabber returned error: {:#?}", err));
         match maybe_action {
             None => result = EVENT_PASS_THROUGH,
             Some(action) => {


### PR DESCRIPTION
Implements most of #391 

## API Incompatibility
* Cannot set the cursor style (Wayland limitation, will probably not be fixed)
* Does not get the events from scrolling (wlc limitation, will be fixed by wlroots)
* Does not receive data about a button being pressed while mouse is moving (wlc limitation, can be worked around. Will forgo that hack to see if wlroots improves things)