### PR TITLE
Make border buffer allocator more explicit with vec! macro

### DIFF
--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use std::cmp::{Eq, PartialEq};
 use rustwlc::{Geometry, Size, WlcOutput};
 use rustwlc::render::{calculate_stride};
@@ -53,7 +52,7 @@ impl Renderable for Borders {
         geometry.size.h += title_size;
         let Size { w, h } = geometry.size;
         let stride = calculate_stride(w) as i32;
-        let data: Vec<u8> = iter::repeat(0).take(h as usize * stride as usize).collect();
+        let data: Vec<u8> = vec![0; h as usize * stride as usize];
         let buffer = data.into_boxed_slice();
         let surface = ImageSurface::create_for_data(buffer,
                                                     drop_data,
@@ -138,7 +137,7 @@ impl Renderable for Borders {
             return Some(self);
         }
         let stride = calculate_stride(w) as i32;
-        let data: Vec<u8> = iter::repeat(0).take(h as usize * stride as usize).collect();
+        let data: Vec<u8> = vec![0; h as usize * stride as usize];
         let buffer = data.into_boxed_slice();
         let surface = ImageSurface::create_for_data(buffer,
                                                     drop_data,

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -1,7 +1,6 @@
 //! Implementations of the default callbacks exposed by wlc.
 //! These functions are the main entry points into Way Cooler from user action.
 //! This is the default mode that Way Cooler is in at initilization
-use std::iter;
 use std::process::{Command};
 use std::path::PathBuf;
 use std::io;
@@ -116,8 +115,7 @@ impl Mode for LockScreen {
                 let resolution = output.get_resolution()
                     .expect("Output had no resolution");
                 // Give them zero-ed out pixels
-                let size = (resolution.w * resolution.h * 4) as usize;
-                *scraped_pixels = iter::repeat(0).take(size).collect();
+                *scraped_pixels = vec![0; resolution.w as usize * resolution.h as usize * 4];
                 sync_scrape();
             }
         }


### PR DESCRIPTION
Hi,

I've profiled app a bit and found, that using vec::repeat(0).take(n) is not an optimal way to allocate memory slice. 
It's a huge bottleneck.
The change replaces it with vec! macro.

The change may be related to https://github.com/way-cooler/way-cooler/issues/371

Attached profiling results. CPU spent on allocations dropped from 85% to less than 3%.

![way-cooler-prof-fixes](https://user-images.githubusercontent.com/5363954/31087807-1ba6894a-a7a7-11e7-83c4-2b0827e8b6a0.png)
![way-cooler-prof-master](https://user-images.githubusercontent.com/5363954/31087806-1ba63670-a7a7-11e7-99c1-58ee63a24f17.png)


