### PR TITLE
Update background to use desktop-shell protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "cairo-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dummy-rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dummy-rustwlc 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,7 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dummy-rustwlc"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,7 +573,7 @@ dependencies = [
 "checksum dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1e013b945c57472e5c016f3695114b00c774f03feed9b03df78a9759bb42beb"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum dummy-rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "11dc11a78bd7081ca9122944f00500c57674ab40b35aca12ba07d4158dda410d"
+"checksum dummy-rustwlc 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "895d5f140314c0ba33a8c162da98ce210a07a97f4539606be66aae9cf4b4d6e3"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "petgraph 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustwlc 0.6.2",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-server 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -410,7 +410,6 @@ dependencies = [
 [[package]]
 name = "rustwlc"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,7 +606,6 @@ dependencies = [
 "checksum rlua 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "351c88c3a68e59c1d37f25f8988b50ff447cd4e14e5aa4604b8d85c417307b5f"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum rustwlc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1bc415a8f138e6a231c7f9ff696eb2f98ac13d2aeda1a30bc7ec2fe5b36133f1"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "petgraph 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustwlc 0.6.2",
+ "rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-server 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -409,7 +409,8 @@ dependencies = [
 
 [[package]]
 name = "rustwlc"
-version = "0.6.2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -606,6 +607,7 @@ dependencies = [
 "checksum rlua 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "351c88c3a68e59c1d37f25f8988b50ff447cd4e14e5aa4604b8d85c417307b5f"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum rustwlc 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6fccd4179611ec448236ee47925f0c986ef6862803e916687f6b1ab016305d08"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-#rustwlc = { version = "0.6.2", features = ["wlc-wayland"] }
-rustwlc = { version = "0.6.2", features = ["wlc-wayland"], path = "../rust-wlc" }
+rustwlc = { version = "0.6.3", features = ["wlc-wayland"] }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 build = "build.rs"
 
 [dependencies]
-rustwlc = { version = "0.6.2", features = ["wlc-wayland"] }
+#rustwlc = { version = "0.6.2", features = ["wlc-wayland"] }
+rustwlc = { version = "0.6.2", features = ["wlc-wayland"], path = "../rust-wlc" }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cairo-rs = "0.1.1"
 xcb = "0.8.1"
 
 [dev-dependencies]
-dummy-rustwlc = "0.6.3"
+dummy-rustwlc = "0.6.4"
 
 [build-dependencies]
 wayland-scanner = { version = "0.9.1" }

--- a/config/init.lua
+++ b/config/init.lua
@@ -24,7 +24,7 @@ way_cooler.programs = {
 
 -- Registering programs to run at startup
 -- These programs are only ran once util.program.spawn_programs is called.
-util.program.spawn_at_startup("way-cooler-bg")
+util.program.spawn_at_startup("wc-bg")
 
 -- These options are applied to all windows.
 way_cooler.windows = {

--- a/config/init.lua
+++ b/config/init.lua
@@ -1,12 +1,5 @@
 -- Lua configration file for way-cooler. Ran at startup and when restarted.
 
---
--- Background
---
---
--- A background can either be a 6 digit hex value or an image path
-local background = 0x5E4055
-
 -- Programs that Way Cooler can run
 way_cooler.programs = {
   -- Name of the window that will be the bar window.

--- a/config/init.lua
+++ b/config/init.lua
@@ -24,7 +24,7 @@ way_cooler.programs = {
 
 -- Registering programs to run at startup
 -- These programs are only ran once util.program.spawn_programs is called.
-util.program.spawn_at_startup("way-cooler-bg", "--color " .. background)
+util.program.spawn_at_startup("way-cooler-bg")
 
 -- These options are applied to all windows.
 way_cooler.windows = {

--- a/protocols/desktop-shell.xml
+++ b/protocols/desktop-shell.xml
@@ -1,0 +1,138 @@
+<protocol name="desktop">
+
+  <interface name="desktop_shell" version="3">
+    <description summary="create desktop widgets and helpers">
+      Traditional user interfaces can rely on this interface to define the
+      foundations of typical desktops. Currently it's possible to set up
+      background, panels and locking surfaces.
+    </description>
+
+    <request name="set_background">
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="set_panel">
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="set_lock_surface">
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="unlock"/>
+
+    <request name="set_grab_surface">
+      <description summary="set grab surface">
+	The surface set by this request will receive a fake
+	pointer.enter event during grabs at position 0, 0 and is
+	expected to set an appropriate cursor image as described by
+	the grab_cursor event sent just before the enter event.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <!-- We'll fold most of wl_shell into this interface and then
+         they'll share the configure event.  -->
+    <event name="configure">
+      <arg name="edges" type="uint"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+
+    <event name="prepare_lock_surface">
+      <description summary="tell the client to create, set the lock surface">
+	Tell the client we want it to create and set the lock surface, which is
+	a GUI asking the user to unlock the screen. The lock surface is
+	announced with 'set_lock_surface'. Whether or not the client actually
+	implements locking, it MUST send 'unlock' request to let the normal
+        desktop resume.
+      </description>
+    </event>
+
+    <event name="grab_cursor">
+      <description summary="tell client what cursor to show during a grab">
+	This event will be sent immediately before a fake enter event on the
+	grab surface.
+      </description>
+      <arg name="cursor" type="uint"/>
+    </event>
+
+    <enum name="cursor">
+      <entry name="none" value="0"/>
+
+      <entry name="resize_top" value="1"/>
+      <entry name="resize_bottom" value="2"/>
+
+      <entry name="arrow" value="3"/>
+
+      <entry name="resize_left" value="4"/>
+      <entry name="resize_top_left" value="5"/>
+      <entry name="resize_bottom_left" value="6"/>
+
+      <entry name="move" value="7"/>
+
+      <entry name="resize_right" value="8"/>
+      <entry name="resize_top_right" value="9"/>
+      <entry name="resize_bottom_right" value="10"/>
+
+      <entry name="busy" value="11"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="desktop_ready" since="2">
+      <description summary="desktop is ready to be shown">
+	Tell the server, that enough desktop elements have been drawn
+	to make the desktop look ready for use. During start-up, the
+	server can wait for this request with a black screen before
+	starting to fade in the desktop, for instance. If the client
+	parts of a desktop take a long time to initialize, we avoid
+	showing temporary garbage.
+      </description>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <enum name="panel_position">
+      <entry name="top" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="left" value="2"/>
+      <entry name="right" value="3"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_argument" value="0"
+        summary="an invalid argument was provided in a request"/>
+    </enum>
+
+    <request name="set_panel_position" since="3">
+      <description summary="set panel position">
+        Tell the shell which side of the screen the panel is
+        located. This is so that new windows do not overlap the panel
+        and maximized windows maximize properly.
+      </description>
+      <arg name="position" type="uint"/>
+    </request>
+
+  </interface>
+
+  <interface name="screensaver" version="1">
+    <description summary="interface for implementing screensavers">
+      Only one client can bind this interface at a time.
+    </description>
+
+    <request name="set_surface">
+      <description summary="set the surface type as a screensaver">
+	A screensaver surface is normally hidden, and only visible after an
+        idle timeout.
+      </description>
+
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+  </interface>
+</protocol>

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -32,9 +32,8 @@ impl LayoutTree {
                             MaybeBackground::Complete(_) => true,
                         })
                     },
-                    // TODO
-
-                    _ => unimplemented!()
+                    // TODO Allow hot-reloading like before? Should probably implement that...
+                    _ => {Ok(false)}
                 }
             },
             _ => Err(TreeError::UuidWrongType(output_id,

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -51,8 +51,8 @@ impl LayoutTree {
                         Ok(())
                     },
                     Some(MaybeBackground::Complete(complete)) => {
-                        complete.handle.close();
-                        *background = Some(bg.into());
+                        warn!("Tried to set background while one is still active");
+                        warn!("This operation is not allowed, due to a bug with xwayland");
                         Ok(())
                     }
                     _ => {

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -32,8 +32,7 @@ impl LayoutTree {
                             MaybeBackground::Complete(_) => true,
                         })
                     },
-                    // TODO Allow hot-reloading like before? Should probably implement that...
-                    _ => {Ok(false)}
+                    _ => Ok(false)
                 }
             },
             _ => Err(TreeError::UuidWrongType(output_id,
@@ -51,7 +50,15 @@ impl LayoutTree {
                         *background = Some(bg.into());
                         Ok(())
                     },
-                    _ => unimplemented!()
+                    Some(MaybeBackground::Complete(complete)) => {
+                        complete.handle.close();
+                        *background = Some(bg.into());
+                        Ok(())
+                    }
+                    _ => {
+                        warn!("Tried to set background while the other was still loading!");
+                        Ok(())
+                    }
                 }
             },
             _ => Err(TreeError::UuidWrongType(output_id,

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -1,43 +1,62 @@
 //! A collection of methods that modify the background of the outputs.
-use super::super::{Container, ContainerType, LayoutTree, TreeError};
+use super::super::{Container, ContainerType, LayoutTree, TreeError,
+                   MaybeBackground, IncompleteBackground};
 use super::super::commands::CommandResult;
 
 use uuid::Uuid;
-use rustwlc::{WlcView};
-
-use std::collections::HashSet;
+use wayland_sys::server::wl_client;
+use rustwlc::WlcView;
+use rustwlc::wayland::wlc_view_get_wl_client;
 
 impl LayoutTree {
     /// Attempts to attach the `bg` to the `outputs`.
     ///
     /// If any of them already have a background attached,
-    /// ``
     pub fn attach_background(&mut self, bg: WlcView, output_id: Uuid)
-                             -> CommandResult {
-        // TODO Remove this to remove when the wlc bug is fixed
-        // https://github.com/Cloudef/wlc/issues/221
-        let mut to_remove = HashSet::new();
-        match *try!(self.lookup_mut(output_id)) {
+                             -> Result<bool, TreeError> {
+        match *self.lookup_mut(output_id)? {
             Container::Output { ref mut background, .. } => {
-                if background.is_none() {
-                    *background = Some(bg);
-                } else {
-                    // TODO This can't be used right now, see this bug:
-                    // https://github.com/Cloudef/wlc/issues/221
-                    /*return Err(TreeError::Background(
-                        BackgroundErr::AlreadyAttached(output_id, background.clone().unwrap())))*/
-                    if let Some(view) = background.take() {
-                        to_remove.insert(view);
+                match *background {
+                    None => {
+                        // The background wasn't expecting it
+                        Ok(false)
                     }
-                    *background = Some(bg);
+                    Some(MaybeBackground::Incomplete(incomplete)) => {
+                        let client: *mut wl_client;
+                        unsafe {
+                            client = wlc_view_get_wl_client(bg.0 as _) as _;
+                        }
+                        *background = Some(incomplete.build(client, bg));
+                        Ok(match background.unwrap() {
+                            MaybeBackground::Incomplete(_) => false,
+                            MaybeBackground::Complete(_) => true,
+                        })
+                    },
+                    // TODO
+
+                    _ => unimplemented!()
                 }
             },
-            _ => return Err(TreeError::UuidWrongType(output_id,
-                                                        vec![ContainerType::Output]))
+            _ => Err(TreeError::UuidWrongType(output_id,
+                                              vec![ContainerType::Output]))
         }
-        for view in to_remove {
-            view.close();
+    }
+
+    pub fn attach_incomplete_background(&mut self,
+                                        bg: IncompleteBackground,
+                                        output_id: Uuid) -> CommandResult {
+        match *self.lookup_mut(output_id)? {
+            Container::Output { ref mut background, .. } => {
+                match *background {
+                    None => {
+                        *background = Some(bg.into());
+                        Ok(())
+                    },
+                    _ => unimplemented!()
+                }
+            },
+            _ => Err(TreeError::UuidWrongType(output_id,
+                                              vec![ContainerType::Output]))
         }
-        Ok(())
     }
 }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -9,6 +9,7 @@ use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
 use super::super::core::container::{Container, ContainerType, ContainerErr,
                                     Layout, Handle};
+use super::super::core::background::MaybeBackground;
 use super::borders;
 use ::layout::core::borders::Borders;
 use ::render::Renderable;
@@ -44,8 +45,11 @@ impl LayoutTree {
                     match *container {
                         Container::Output { ref mut background, .. } => {
                             // update the background size
-                            if let Some(background) = *background {
-                                background.set_geometry(ResizeEdge::empty(), actual_geometry)
+                            match *background {
+                                Some(MaybeBackground::Complete(background)) => {
+                                    background.handle.set_geometry(ResizeEdge::empty(), actual_geometry)
+                                },
+                                _ => {}
                             }
                         }
                         _ => unreachable!()

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 
 use super::{try_lock_tree, lock_tree, try_lock_action};
 use super::{Action, ActionErr, Bar, Container, ContainerType,
-            Direction, Handle, Layout, TreeError, ResizeErr};
+            Direction, Handle, Layout, TreeError, ResizeErr, IncompleteBackground};
 use super::core::borders::Borders;
 use ::render::Renderable;
 use super::Tree;
@@ -379,6 +379,22 @@ impl Tree {
             };
         }
         self.0.attach_background(view, id)
+    }
+
+
+    /// Adds a background to an output.
+    ///
+    /// NOTE That the background is not ready yet, because to make it ready requires
+    /// triggering the view callback. But, in order to not have it added twice we
+    /// need to check if it's already been added...which isn't possible if the tree is locked.
+    /// So, this will just add the meta data around it, and once it's added in the view callback
+    /// it will add it "for real".
+    /// Yes this is dumb, wlc can be kind of backwards...
+    /// NOTE At the end of this method it calls the special wlc method that
+    /// triggers the view_created callback. The view_callback needs to check that this
+    pub fn add_background_v2(&mut self, background: IncompleteBackground, output: WlcOutput)
+                             -> CommandResult {
+        unimplemented!()
     }
 
     /// Adds a Workspace to the tree. Never fails

--- a/src/layout/core/background.rs
+++ b/src/layout/core/background.rs
@@ -1,0 +1,54 @@
+//! Background for an output
+
+use rustwlc::WlcView;
+use wayland_sys::server::wl_client;
+
+/// A background is not complete until you call the "complete" method on it.
+/// This will need to be executed via the view_created callback, because before that
+/// we haven't properly set it.
+#[derive(Debug)]
+pub struct IncompleteBackground {
+    client: *mut wl_client
+}
+
+#[derive(Debug)]
+pub enum MaybeBackground {
+    Incomplete(IncompleteBackground),
+    Complete(Background)
+}
+
+impl Into<MaybeBackground> for IncompleteBackground {
+    fn into(self) -> MaybeBackground {
+        MaybeBackground::Incomplete(self)
+    }
+}
+
+impl Into<MaybeBackground> for Background {
+    fn into(self) -> MaybeBackground {
+        MaybeBackground::Complete(self)
+    }
+}
+
+impl IncompleteBackground {
+    pub fn new(client: *mut wl_client) -> Self {
+        IncompleteBackground { client }
+    }
+
+    /// Builds the background if the client matches
+    /// If it fails, then the incomplete background is returned instead.
+    pub fn build(self, client: *mut wl_client, handle: WlcView)
+                 -> Result<Background, IncompleteBackground> {
+        if self.client == client {
+            Ok(Background { handle })
+        } else {
+            Err(self)
+        }
+
+    }
+}
+
+/// A background for an output.
+#[derive(Debug)]
+pub struct Background {
+    handle: WlcView
+}

--- a/src/layout/core/background.rs
+++ b/src/layout/core/background.rs
@@ -6,12 +6,18 @@ use wayland_sys::server::wl_client;
 /// A background is not complete until you call the "complete" method on it.
 /// This will need to be executed via the view_created callback, because before that
 /// we haven't properly set it.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct IncompleteBackground {
-    client: *mut wl_client
+    client: usize
 }
 
-#[derive(Debug)]
+/// A background for an output.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Background {
+    pub handle: WlcView
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MaybeBackground {
     Incomplete(IncompleteBackground),
     Complete(Background)
@@ -31,24 +37,18 @@ impl Into<MaybeBackground> for Background {
 
 impl IncompleteBackground {
     pub fn new(client: *mut wl_client) -> Self {
-        IncompleteBackground { client }
+        IncompleteBackground { client: client as _ }
     }
 
     /// Builds the background if the client matches
     /// If it fails, then the incomplete background is returned instead.
     pub fn build(self, client: *mut wl_client, handle: WlcView)
-                 -> Result<Background, IncompleteBackground> {
-        if self.client == client {
-            Ok(Background { handle })
+                 -> MaybeBackground {
+        if self.client as *mut wl_client == client {
+            Background { handle }.into()
         } else {
-            Err(self)
+            self.into()
         }
 
     }
-}
-
-/// A background for an output.
-#[derive(Debug)]
-pub struct Background {
-    handle: WlcView
 }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -12,6 +12,7 @@ use ::layout::commands::CommandResult;
 use super::borders::{Borders, ViewDraw, ContainerDraw};
 use super::tree::TreeError;
 use super::bar::Bar;
+use super::background::MaybeBackground;
 
 pub static MIN_SIZE: Size = Size { w: 80u32, h: 40u32 };
 
@@ -101,7 +102,7 @@ pub enum Container {
         /// Handle to the wlc
         handle: WlcOutput,
         /// Optional background for the output
-        background: Option<WlcView>,
+        background: Option<MaybeBackground>,
         /// Optional bar for the output
         bar: Option<Bar>,
         /// UUID associated with container, client program can use container

--- a/src/layout/core/mod.rs
+++ b/src/layout/core/mod.rs
@@ -3,6 +3,7 @@ pub mod container;
 pub mod action;
 pub mod bar;
 pub mod borders;
+pub mod background;
 mod path;
 mod graph_tree;
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -14,6 +14,7 @@ use super::super::LayoutTree;
 use super::super::ActionErr;
 use super::container::{Container, ContainerType, ContainerErr, Layout, Handle};
 use super::borders::{Borders};
+use super::background::MaybeBackground;
 use ::layout::actions::borders;
 use ::layout::actions::focus::FocusError;
 use ::layout::actions::movement::MovementError;
@@ -483,8 +484,13 @@ impl LayoutTree {
             for output_ix in self.tree.children_of(self.tree.root_ix()) {
                 match self.tree[output_ix] {
                     Container::Output { ref mut background, ref mut bar, .. } => {
-                        if Some(view) == *background {
-                            background.take();
+                        match *background {
+                            Some(MaybeBackground::Complete(bg)) => {
+                                if bg.handle == view {
+                                    background.take();
+                                }
+                            },
+                            _ => {}
                         }
                         let bar_view = bar.as_ref().map(|bar| bar.view());
                         if Some(view) == bar_view {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -10,6 +10,8 @@ pub use self::actions::focus::FocusError;
 pub use self::actions::resize::ResizeErr;
 pub use self::core::GraphError;
 
+pub use self::core::background::{Background, IncompleteBackground,
+                                 MaybeBackground};
 pub use self::core::action::{Action, ActionErr};
 pub use self::core::container::{Container, ContainerType, Handle, Layout};
 pub use self::core::tree::{Direction, TreeError};

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -105,18 +105,20 @@ impl Mode for Default {
             }
         }
         if let Ok(mut tree) = lock_tree() {
-            let output = view.get_output();
-            if tree.add_background(view, output).expect("Couldn't try to add background") {
-                view.send_to_back();
-                view.set_mask(1);
-                let resolution = output.get_resolution()
-                    .expect("Couldn't get output resolution");
-                let fullscreen = Geometry {
-                    origin: Point { x: 0, y: 0 },
-                    size: resolution
-                };
-                view.set_geometry(ResizeEdge::empty(), fullscreen);
-                return true
+            for output in WlcOutput::list() {
+                if tree.add_background(view, output).expect("Couldn't try to add background") {
+                    view.set_output(output);
+                    view.send_to_back();
+                    view.set_mask(1);
+                    let resolution = output.get_resolution()
+                        .expect("Couldn't get output resolution");
+                    let fullscreen = Geometry {
+                        origin: Point { x: 0, y: 0 },
+                        size: resolution
+                    };
+                    view.set_geometry(ResizeEdge::empty(), fullscreen);
+                    return true
+                }
             }
         }
         if let Ok(mut tree) = lock_tree() {

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -25,6 +25,7 @@ struct DesktopShellImpl {
                                      *mut wl_resource),
     set_lock_surface: unsafe extern "C" fn (*mut wl_client,
                                             *mut wl_resource,
+                                            *mut wl_resource,
                                             *mut wl_resource),
     unlock: unsafe extern "C" fn (*mut wl_client,
                                   *mut wl_resource),
@@ -136,6 +137,7 @@ unsafe extern "C" fn desktop_ready(_client: *mut wl_client,
 // TODO Implement
 unsafe extern "C" fn set_lock_surface(_client: *mut wl_client,
                                       _resource: *mut wl_resource,
+                                      _output: *mut wl_resource,
                                       _surface: *mut wl_resource) {}
 unsafe extern "C" fn unlock(_client: *mut wl_client,
                             _resource: *mut wl_resource) {}

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -2,9 +2,6 @@
 //! See https://github.com/swaywm/sway/blob/master/protocols/desktop-shell.xml
 //! for more information about the spec
 
-// TODO remove
-#![allow(unused_variables)]
-
 use self::generated::server::desktop_shell::DesktopShell;
 use rustwlc::wayland::{get_display};
 use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
@@ -116,10 +113,8 @@ unsafe extern "C" fn bind(client: *mut wl_client,
     );
 }
 
-// FIXME background destructor, see extensions.c.
-
 unsafe extern "C" fn set_background(client: *mut wl_client,
-                                    resource: *mut wl_resource,
+                                    _resource: *mut wl_resource,
                                     output_: *mut wl_resource,
                                     surface: *mut wl_resource) {
     let output = wlc_handle_from_wl_output_resource(output_ as *const _);
@@ -127,34 +122,33 @@ unsafe extern "C" fn set_background(client: *mut wl_client,
         return;
     }
     info!("Setting surface {:?} as background for output {}", surface, output);
-    // TODO try_lock?
     if let Ok(mut tree) = lock_tree() {
         tree.add_incomplete_background(IncompleteBackground::new(client), WlcOutput::dummy(output as _))
             .expect("Could not add incomplete background");
     }
 }
 
-unsafe extern "C" fn desktop_ready(client: *mut wl_client,
-                                   resource: *mut wl_resource) {
+unsafe extern "C" fn desktop_ready(_client: *mut wl_client,
+                                   _resource: *mut wl_resource) {
     /* Intentionally left blank */
 }
 
 // TODO Implement
-unsafe extern "C" fn set_lock_surface(client: *mut wl_client,
-                                      resource: *mut wl_resource,
-                                      surface: *mut wl_resource) {}
-unsafe extern "C" fn unlock(client: *mut wl_client,
-                            resource: *mut wl_resource) {}
-unsafe extern "C" fn set_grab_surface(client: *mut wl_client,
-                                      resource: *mut wl_resource,
-                                      surface: *mut wl_resource) {}
-unsafe extern "C" fn set_panel(client: *mut wl_client,
-                               resource: *mut wl_resource,
-                               output_: *mut wl_resource,
-                               surface: *mut wl_resource) {}
-unsafe extern "C" fn set_panel_position(client: *mut wl_client,
-                                        resource:*mut wl_resource,
-                                        position: u32) {}
+unsafe extern "C" fn set_lock_surface(_client: *mut wl_client,
+                                      _resource: *mut wl_resource,
+                                      _surface: *mut wl_resource) {}
+unsafe extern "C" fn unlock(_client: *mut wl_client,
+                            _resource: *mut wl_resource) {}
+unsafe extern "C" fn set_grab_surface(_client: *mut wl_client,
+                                      _resource: *mut wl_resource,
+                                      _surface: *mut wl_resource) {}
+unsafe extern "C" fn set_panel(_client: *mut wl_client,
+                               _resource: *mut wl_resource,
+                               _output_: *mut wl_resource,
+                               _surface: *mut wl_resource) {}
+unsafe extern "C" fn set_panel_position(_client: *mut wl_client,
+                                        _resource:*mut wl_resource,
+                                        _position: u32) {}
 
 /// Sets up Way Cooler to announce the desktop-shell interface.
 pub fn init() {

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -6,7 +6,7 @@
 #![allow(unused_variables)]
 
 use self::generated::server::desktop_shell::DesktopShell;
-use rustwlc::wayland::{get_display, wlc_resource_from_wl_surface_resource};
+use rustwlc::wayland::{get_display};
 use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
 use ::layout::{lock_tree, IncompleteBackground};
 use wayland_server::Resource;
@@ -127,7 +127,6 @@ unsafe extern "C" fn set_background(client: *mut wl_client,
         return;
     }
     info!("Setting surface {:?} as background for output {}", surface, output);
-    let surface = wlc_resource_from_wl_surface_resource(surface as *const _);
     // TODO try_lock?
     if let Ok(mut tree) = lock_tree() {
         tree.add_incomplete_background(IncompleteBackground::new(client), WlcOutput::dummy(output as _))

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -1,0 +1,174 @@
+//! Module that defines the bindings for the desktop shell protocol
+//! See https://github.com/swaywm/sway/blob/master/protocols/desktop-shell.xml
+//! for more information about the spec
+
+// TODO remove
+#![allow(unused_variables)]
+
+use self::generated::server::desktop_shell::DesktopShell;
+use rustwlc::wayland::{get_display, wlc_resource_from_wl_surface_resource};
+use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
+use ::layout::{lock_tree, IncompleteBackground};
+use wayland_server::Resource;
+use wayland_sys::server::{WAYLAND_SERVER_HANDLE, wl_client, wl_resource};
+use std::os::raw::c_void;
+use nix::libc::{c_int};
+
+#[repr(C)]
+/// Holds pointers to the functions that should be called when a Wayland request
+/// is sent to Way Cooler that falls under the desktop shell's responsibility
+struct DesktopShellImpl {
+    set_background: unsafe extern "C" fn (*mut wl_client,
+                                          *mut wl_resource,
+                                          *mut wl_resource,
+                                          *mut wl_resource),
+    set_panel: unsafe extern "C" fn (*mut wl_client,
+                                     *mut wl_resource,
+                                     *mut wl_resource,
+                                     *mut wl_resource),
+    set_lock_surface: unsafe extern "C" fn (*mut wl_client,
+                                            *mut wl_resource,
+                                            *mut wl_resource),
+    unlock: unsafe extern "C" fn (*mut wl_client,
+                                  *mut wl_resource),
+    set_grab_surface: unsafe extern "C" fn (*mut wl_client,
+                                            *mut wl_resource,
+                                            *mut wl_resource),
+    desktop_ready: unsafe extern "C" fn (*mut wl_client,
+                                         *mut wl_resource),
+    set_panel_position: unsafe extern "C" fn (*mut wl_client,
+                                              *mut wl_resource,
+                                              u32)
+}
+
+static mut DESKTOP_SHELL_GLOBAL: DesktopShellImpl =
+    DesktopShellImpl {
+        set_background,
+        set_panel,
+        set_lock_surface,
+        unlock,
+        set_grab_surface,
+        desktop_ready,
+        set_panel_position
+    };
+
+mod generated {
+    // Generated code generally doesn't follow standards
+    #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
+    #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
+
+    pub mod interfaces {
+        #[doc(hidden)]
+        use wayland_server::protocol_interfaces::{wl_output_interface, wl_surface_interface};
+        include!(concat!(env!("OUT_DIR"), "/desktop-shell_interface.rs"));
+    }
+
+    pub mod server {
+        #[doc(hidden)]
+        use wayland_server::{Resource, Handler,
+                                 Client, Liveness,
+                                 EventLoopHandle, EventResult};
+        #[doc(hidden)]
+        use wayland_server::protocol::{wl_output, wl_surface};
+        #[doc(hidden)]
+        use super::interfaces;
+        include!(concat!(env!("OUT_DIR"), "/desktop-shell_api.rs"));
+    }
+}
+
+/// Binds the handler to a new Wayland resource, created by the client.
+/// See https://github.com/vberger/wayland-rs/blob/451ccab330b3d0ec18eaaf72ae17ac35cf432370/wayland-server/src/event_loop.rs#L617
+/// to see where I got this particular bit of magic from.
+unsafe extern "C" fn bind(client: *mut wl_client,
+                          _data: *mut c_void,
+                          version: u32,
+                          id: u32) {
+    info!("Binding Desktop Shell resource");
+    let cur_version = DesktopShell::supported_version();
+    if version > cur_version {
+        warn!("Unsupported desktop shell control protocol version {}!", version);
+        warn!("We only support version {}", cur_version);
+        return
+    }
+    let resource = ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                                 wl_resource_create,
+                                 client,
+                                 DesktopShell::interface_ptr(),
+                                 version as c_int,
+                                 id);
+    if resource.is_null() {
+        warn!("Out of memory, could not make a new wl_resource \
+               for desktop shell");
+        ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_client_post_no_memory,
+            client
+        );
+    }
+    let global_ptr = &mut DESKTOP_SHELL_GLOBAL as *mut _ as *mut c_void;
+    ffi_dispatch!(
+        WAYLAND_SERVER_HANDLE,
+        wl_resource_set_implementation,
+        resource,
+        global_ptr,
+        ::std::ptr::null_mut(),
+        None
+    );
+}
+
+// FIXME background destructor, see extensions.c.
+
+unsafe extern "C" fn set_background(client: *mut wl_client,
+                                    resource: *mut wl_resource,
+                                    output_: *mut wl_resource,
+                                    surface: *mut wl_resource) {
+    let output = wlc_handle_from_wl_output_resource(output_ as *const _);
+    if output == 0 {
+        return;
+    }
+    info!("Setting surface {:?} as background for output {}", surface, output);
+    let surface = wlc_resource_from_wl_surface_resource(surface as *const _);
+    // TODO try_lock?
+    if let Ok(mut tree) = lock_tree() {
+        tree.add_incomplete_background(IncompleteBackground::new(client), WlcOutput::dummy(output as _))
+            .expect("Could not add incomplete background");
+    }
+    // TODO How does this work? Like, when does it spawn a WlcView? Is its the clients job? Seems like it *shrugging guy*
+}
+
+unsafe extern "C" fn desktop_ready(client: *mut wl_client,
+                                   resource: *mut wl_resource) {
+    /* Intentionally left blank */
+}
+
+// TODO Implement
+unsafe extern "C" fn set_lock_surface(client: *mut wl_client,
+                                      resource: *mut wl_resource,
+                                      surface: *mut wl_resource) {}
+unsafe extern "C" fn unlock(client: *mut wl_client,
+                            resource: *mut wl_resource) {}
+unsafe extern "C" fn set_grab_surface(client: *mut wl_client,
+                                      resource: *mut wl_resource,
+                                      surface: *mut wl_resource) {}
+unsafe extern "C" fn set_panel(client: *mut wl_client,
+                               resource: *mut wl_resource,
+                               output_: *mut wl_resource,
+                               surface: *mut wl_resource) {}
+unsafe extern "C" fn set_panel_position(client: *mut wl_client,
+                                        resource:*mut wl_resource,
+                                        position: u32) {}
+
+/// Sets up Way Cooler to announce the desktop-shell interface.
+pub fn init() {
+    let w_display = get_display();
+    unsafe {
+        info!("Initializing desktop shell");
+        ffi_dispatch!(WAYLAND_SERVER_HANDLE,
+                    wl_global_create,
+                    w_display as *mut _,
+                    DesktopShell::interface_ptr(),
+                    DesktopShell::supported_version() as i32,
+                    ::std::ptr::null_mut(),
+                    bind);
+    }
+}

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -133,7 +133,6 @@ unsafe extern "C" fn set_background(client: *mut wl_client,
         tree.add_incomplete_background(IncompleteBackground::new(client), WlcOutput::dummy(output as _))
             .expect("Could not add incomplete background");
     }
-    // TODO How does this work? Like, when does it spawn a WlcView? Is its the clients job? Seems like it *shrugging guy*
 }
 
 unsafe extern "C" fn desktop_ready(client: *mut wl_client,

--- a/src/wayland/gamma_control.rs
+++ b/src/wayland/gamma_control.rs
@@ -178,9 +178,9 @@ unsafe extern "C" fn get_gamma_control(client: *mut wl_client,
 /// See https://github.com/vberger/wayland-rs/blob/451ccab330b3d0ec18eaaf72ae17ac35cf432370/wayland-server/src/event_loop.rs#L617
 /// to see where I got this particular bit of magic from.
 unsafe extern "C" fn bind(client: *mut wl_client,
-                              _data: *mut c_void,
-                              version: u32,
-                              id: u32) {
+                          _data: *mut c_void,
+                          version: u32,
+                          id: u32) {
     info!("Binding Gamma Control resource");
     let cur_version = GammaControlManager::supported_version();
     if version > cur_version {
@@ -206,7 +206,6 @@ unsafe extern "C" fn bind(client: *mut wl_client,
         );
     }
     let global_manager_ptr = &mut GAMMA_CONTROL_MANAGER as *mut _ as *mut c_void;
-    //let global_manager_ptr = &mut *manager as *mut _ as *mut c_void;
     ffi_dispatch!(
         WAYLAND_SERVER_HANDLE,
         wl_resource_set_implementation,

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,8 +1,10 @@
-pub mod gamma_control;
+mod gamma_control;
+mod desktop_shell;
 
 /// Initializes the appropriate handlers for each wayland protocol
 /// that Way Cooler supports.
 pub fn init_wayland_protocols() {
     info!("Initializing wayland protocols");
     gamma_control::init();
+    desktop_shell::init();
 }


### PR DESCRIPTION
This fixes the terrible, terrible hack that is the background program.

### Notable new features
* Allows the background client to specify which output to use (with `way-cooler-bg` now automatically covering all outputs, woohoo)
* No longer based on the name of the window (so clients named "background" will no longer suddenly become the background. Seriously, that was pretty silly)
* Adds the desktop-shell protocol 
* Switching TTYs no longer makes the background mysteriously disappear   

### Lost features
* Can't run `wc-bg` again while one is active, you need to manually kill the old process first. Note that restarting in place (e.g `mod+r`) still works

### This requires the latest version of `wc-bg` (formally `way-cooler-bg`). This is a backward incompatible change.

Fixes #141 (`wc-bg` now uses it by default), Fixes #159 and Fixes #159

