### PR TITLE
Fixed floating display issue, and #407

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -39,8 +39,8 @@ impl LayoutTree {
                     Layout::Tabbed | Layout::Stacked => {
                         for child_ix in self.tree.children_of(parent_ix) {
                             match self.tree[child_ix] {
-                                Container::View { handle, .. } => {
-                                    if child_ix != node_ix {
+                                Container::View { handle, floating, .. } => {
+                                    if child_ix != node_ix && !floating {
                                         handle.send_to_back();
                                     }
                                 },

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -32,10 +32,33 @@ impl LayoutTree {
         }
         let node_ix = self.tree.lookup_id(uuid)
             .ok_or(TreeError::NodeNotFound(uuid))?;
+        let parent_ix = self.tree.parent_of(node_ix)?;
+        match self.tree[parent_ix] {
+            Container::Container { layout, .. } => {
+                match layout {
+                    Layout::Tabbed | Layout::Stacked => {
+                        for child_ix in self.tree.children_of(parent_ix) {
+                            match self.tree[child_ix] {
+                                Container::View { handle, .. } => {
+                                    if child_ix != node_ix {
+                                        handle.send_to_back();
+                                    }
+                                },
+                                Container::Container { ..}  => {
+                                    // do nothing
+                                },
+                                _ => unreachable!()
+                            }
+                        }
+                    },
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
         match self.tree[node_ix] {
             Container::View { handle, .. } => {
                 handle.focus();
-                handle.bring_to_front();
                 self.active_container = Some(node_ix);
             },
             _ => return Err(TreeError::Focus(FocusError::NotAView(uuid)))


### PR DESCRIPTION
cc @alexander-smoktal , there was an issue with your implementation so I modified it significantly. It's not nearly as pretty, but it fixes the original nested tabbed/stacked issue without causing floating views to hide behind tiled ones.

To reproduce the issue this fixes:

1) Spawn a tiled window (doesn't have to be tabbed or stacked)
2) Spawn a floating window
3) Focus on tiled window, notice how the floating window is hidden when it shouldn't be.

An alternative fix would be to keep your fix and enumerate the floating containers afterwards and make them come forward, but this is less complicated because it only touches the containers within the tiled/stacked container