### PR TITLE
Lockscreen protocol update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "cairo-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dummy-rustwlc 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dummy-rustwlc 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,7 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dummy-rustwlc"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,7 +573,7 @@ dependencies = [
 "checksum dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1e013b945c57472e5c016f3695114b00c774f03feed9b03df78a9759bb42beb"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum dummy-rustwlc 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "895d5f140314c0ba33a8c162da98ce210a07a97f4539606be66aae9cf4b4d6e3"
+"checksum dummy-rustwlc 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "02cc69b9159680c1b8a70d4640f860c8ee3c9a76d683c6e905c6d9d637afca86"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cairo-rs = "0.1.1"
 xcb = "0.8.1"
 
 [dev-dependencies]
-dummy-rustwlc = "0.6.4"
+dummy-rustwlc = "0.6.5"
 
 [build-dependencies]
 wayland-scanner = { version = "0.9.1" }

--- a/config/init.lua
+++ b/config/init.lua
@@ -77,9 +77,6 @@ local keys = {
   -- Open terminal
   key({ mod }, "return", util.program.spawn_once("weston-terminal")),
 
-  -- lock screen
-  key({ mod, "Shift" }, "l", "lock_screen"),
-
   -- Lua methods can be bound as well
   key({ mod, "Shift" }, "h", function () print("Hello world!") end),
 

--- a/config/init.lua
+++ b/config/init.lua
@@ -7,12 +7,6 @@ way_cooler.programs = {
   --
   -- Make sure you set your bar program to spawn at startup!
   x11_bar = "lemonbar",
-
-  -- The path to the lock screen program used by Way Cooler.
-  -- Once this program has been launched by Way Cooler
-  -- via the lock_screen keybinding, the screen is locked and all input goes
-  -- to the lock screen program. Once the program closes, all input is restored.
-  lock_screen = "wc-lock"
 }
 
 -- Registering programs to run at startup

--- a/config/init.lua
+++ b/config/init.lua
@@ -77,6 +77,9 @@ local keys = {
   -- Open terminal
   key({ mod }, "return", util.program.spawn_once("weston-terminal")),
 
+  -- lock screen
+  key({ mod, "Shift" }, "l" , util.program.spawn_once("wc-lock")),
+
   -- Lua methods can be bound as well
   key({ mod, "Shift" }, "h", function () print("Hello world!") end),
 

--- a/protocols/desktop-shell.xml
+++ b/protocols/desktop-shell.xml
@@ -18,6 +18,7 @@
     </request>
 
     <request name="set_lock_surface">
+      <arg name="output" type="object" interface="wl_output"/>
       <arg name="surface" type="object" interface="wl_surface"/>
     </request>
 

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -109,10 +109,6 @@ pub fn register_defaults() {
     // Modes
     register("default_mode", mode_cmds::set_default_mode);
     register("custom_mode", mode_cmds::set_custom_mode);
-    // Command that spawns the lock screen and moves to lock screen mode.
-    // Must have one specified in the registry first in order for it to work.
-    register("lock_screen", mode_cmds::spawn_lock_screen);
-
 }
 
 // All of the methods defined should be registered.

--- a/src/ipc/interfaces/layout.rs
+++ b/src/ipc/interfaces/layout.rs
@@ -209,10 +209,4 @@ dbus_interface! {
             .map(|container| container.name())
             .map_err(|err| MethodErr::failed(&format!("{:?}", err)))
     }
-
-    fn LockScreen() -> success: DBusResult<bool> {
-        use ::modes::spawn_lock_screen;
-        spawn_lock_screen();
-        Ok(true)
-    }
 }

--- a/src/ipc/interfaces/screen.rs
+++ b/src/ipc/interfaces/screen.rs
@@ -38,8 +38,12 @@ pub fn setup(f: &mut DBusFactory) -> DBusObjPath {
                     // ensure that no other threads can try to grab the pixels.
                     let _lock = read_screen_scrape_lock();
                     let mut args_iter = m.msg.iter_init();
-                    let output = args_iter.read::<u32>()?;
-                    let output = unsafe { WlcOutput::dummy(output)};
+                    let output_num = args_iter.read::<u32>()?;
+                    let output = if output_num == 0 {
+                        WlcOutput::focused()
+                    } else {
+                        unsafe { WlcOutput::dummy(output_num) }
+                    };
                     {
                         let mut scraped_pixels = scraped_pixels_lock().unwrap();
                         scraped_pixels.1 = Some(output);

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -50,8 +50,8 @@ impl LayoutTree {
                         *background = Some(bg.into());
                         Ok(())
                     },
-                    Some(MaybeBackground::Complete(_)) => {
-                        warn!("Tried to set background while one is still active");
+                    Some(MaybeBackground::Complete(complete)) => {
+                        warn!("Tried to set background while one is still active {:?}", complete);
                         warn!("This operation is not allowed, due to a bug with xwayland");
                         Ok(())
                     }

--- a/src/modes/commands.rs
+++ b/src/modes/commands.rs
@@ -1,7 +1,6 @@
 //! Commands to control the modes.
 
 use super::{Modes, Default, CustomLua, write_current_mode};
-pub use super::lock_screen::spawn_lock_screen;
 
 
 /// Sets the mode to the default (don't execute custom Lua code).

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -15,7 +15,7 @@ use ::layout::MIN_SIZE;
 use ::lua::{self, LuaQuery};
 
 use ::render::screen_scrape::{SCRAPED_PIXELS, read_screen_scrape_lock,
-                              scraped_pixels_lock, sync_scrape};
+                              sync_scrape};
 use ::awesome;
 
 use registry::{self};

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -14,8 +14,8 @@ use ::layout::commands::set_performing_action;
 use ::layout::MIN_SIZE;
 use ::lua::{self, LuaQuery};
 
-use ::render::screen_scrape::{read_screen_scrape_lock, scraped_pixels_lock,
-                              sync_scrape};
+use ::render::screen_scrape::{SCRAPED_PIXELS, read_screen_scrape_lock,
+                              scraped_pixels_lock, sync_scrape};
 use ::awesome;
 
 use registry::{self};
@@ -65,10 +65,10 @@ impl Mode for Default {
     fn output_render_post(&mut self, output: WlcOutput) {
         let need_to_fetch = read_screen_scrape_lock();
         if *need_to_fetch {
-            if WlcOutput::focused() != output {
-                return
-            }
-            if let Ok(mut scraped_pixels) = scraped_pixels_lock() {
+            if let Ok(mut scraped_pixels) = SCRAPED_PIXELS.try_lock() {
+                if scraped_pixels.1 != Some(output) {
+                    return
+                }
                 let resolution = output.get_resolution()
                     .expect("Output had no resolution");
                 let geo = Geometry {
@@ -76,7 +76,7 @@ impl Mode for Default {
                     size: resolution
                 };
                 let result = read_pixels(wlc_pixel_format::WLC_RGBA8888, geo).1;
-                *scraped_pixels = result;
+                scraped_pixels.0 = result;
                 sync_scrape();
             }
         }

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -108,7 +108,10 @@ impl LockScreen {
 #[allow(unused)]
 impl Mode for LockScreen {
     fn output_render_post(&mut self, output: WlcOutput) {
-        // Don't allow screen scraping during lock screen
+        Default.output_render_post(output);
+        // TODO Uncomment
+        // we should allow this some other way
+        /*// Don't allow screen scraping during lock screen
         let need_to_fetch = read_screen_scrape_lock();
         if *need_to_fetch {
             if let Ok(mut scraped_pixels) = scraped_pixels_lock() {
@@ -118,7 +121,7 @@ impl Mode for LockScreen {
                 *scraped_pixels = vec![0; resolution.w as usize * resolution.h as usize * 4];
                 sync_scrape();
             }
-        }
+        }*/
     }
 
     fn view_created(&mut self, view: WlcView) -> bool {

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -174,12 +174,7 @@ impl Mode for LockScreen {
     }
 
     fn view_focused(&mut self, current: WlcView, focused: bool) {
-        for &(_, _, view) in &self.clients {
-            if let Some(view) = view {
-                view.focus();
-                return
-            }
-        }
+        // Do nothing
     }
 
     fn view_request_state(&mut self, view: WlcView, state: ViewState, toggle: bool) {

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -235,58 +235,6 @@ pub enum LockScreenErr {
     AlreadyLocked
 }
 
-/*
-/// Locks the screen, with the stored path from the registry.
-///
-/// If it fails to lock the screen, then a warning is raised in
-/// the log and it other wise continues.
-///
-/// If you want to handle the error yourself, please use
-/// `lock_screen_with_path`.
-pub fn spawn_lock_screen() {
-    let lock = registry::clients_read();
-    let client = lock.client(Uuid::nil()).unwrap();
-    let handle = registry::ReadHandle::new(&client);
-    let path = handle.read("programs".into()).ok()
-        .and_then(|programs| programs.get("lock_screen"))
-        .and_then(|lock_screen| lock_screen.as_string());
-    match path {
-        None => warn!("No lock screen program set!"),
-        Some(path) => {
-            let path = path.into();
-            lock_screen_with_path(path).unwrap_or_else(|err| {
-                warn!("Could not lock screen: {:?}", err)
-            })
-        }
-    }
-}
-*/
-
-/*
-/// Locks the screen by spawning the program at the given path.
-///
-/// This modifies the global `LOCK_SCREEN` singleton,
-/// so that it can be used by wlc callbacks.
-///
-/// If the program could not be spawned, an `Err` is returned.
-pub fn lock_screen_with_path(path: PathBuf) -> Result<(), LockScreenErr> {
-    let mut mode = write_current_mode();
-    match *mode {
-        Modes::LockScreen(_) =>
-            return Err(LockScreenErr::AlreadyLocked),
-        _ => {}
-    };
-    // TODO This can fail badly, and we should use child_try_wait.
-    // It's possible the program can fail to spawn a window, which
-    // means we'll be waiting forever.
-    // HOWEVER that's behind a nightly flag, so we must wait.
-    let child = Command::new(path).spawn()
-        .map_err(|io_er| LockScreenErr::IO(io_er))?;
-    let id = child.id();
-    *mode = Modes::LockScreen(LockScreen::new(id as pid_t));
-    Ok(())
-}
-*/
 
 pub fn lock_screen(client: *mut wl_client, output: WlcOutput) -> Result<(), LockScreenErr> {
     let mut mode = write_current_mode();

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -169,7 +169,6 @@ impl Mode for LockScreen {
                               after removing lock screen");
                     })
             }
-            unlock_screen(self.clients[0].0 as _)
         }
     }
 

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -59,7 +59,6 @@ impl LockScreen {
         let cur_client = unsafe {
             wlc_view_get_wl_client(view.0 as _) as _
         };
-        warn!("Checkng view {:#?}", view);
         for client in &mut self.clients {
             if client.0 == cur_client && client.2 == None {
                 error!("Found a match, setting to output {:#?}", client.1);
@@ -218,11 +217,9 @@ impl Mode for LockScreen {
 
 pub fn lock_screen(client: *mut wl_client, output: WlcOutput) {
     let mut mode = write_current_mode();
-    warn!("Locking screen w/ mode {:#?}", mode);
     {
         match *mode {
             Modes::LockScreen(ref mut lock_mode) => {
-                warn!("Found another view");
                 lock_mode.clients.push((client as _, output, None));
                 return
             },

--- a/src/modes/lock_screen.rs
+++ b/src/modes/lock_screen.rs
@@ -254,9 +254,10 @@ pub fn lock_screen(client: *mut wl_client, output: WlcOutput) -> Result<(), Lock
 }
 
 pub fn unlock_screen(client: *mut wl_client) {
-    error!("Unlocking screen");
-    let mut mode = write_current_mode();
-    match *mode {
+    let mut mode = {
+        write_current_mode().clone()
+    };
+    match mode {
         Modes::LockScreen(ref lock_mode) => {
             for &(_, _, view) in &lock_mode.clients {
                 view.map(WlcView::close);
@@ -264,5 +265,5 @@ pub fn unlock_screen(client: *mut wl_client) {
         },
         _ => {}
     }
-    *mode = Modes::Default(Default);
+    *write_current_mode() = Modes::Default(Default);
 }

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -23,7 +23,7 @@ pub mod commands;
 pub use self::mode::Mode;
 pub use self::default::Default;
 pub use self::custom_lua::CustomLua;
-pub use self::lock_screen::{LockScreen, spawn_lock_screen};
+pub use self::lock_screen::{LockScreen, lock_screen};
 
 /// If the event is handled by way-cooler
 pub const EVENT_BLOCKED: bool = true;
@@ -39,7 +39,7 @@ pub const RIGHT_CLICK: u32 = 0x111;
 /// that it starts out in
 /// * `CustomLua`: Same as `Default`, except it calls any custom defined
 /// callbacks in the Lua configuration file at the end of the call back.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Modes {
     Default(Default),
     CustomLua(CustomLua),

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -23,7 +23,7 @@ pub mod commands;
 pub use self::mode::Mode;
 pub use self::default::Default;
 pub use self::custom_lua::CustomLua;
-pub use self::lock_screen::{LockScreen, lock_screen};
+pub use self::lock_screen::{LockScreen, lock_screen, unlock_screen};
 
 /// If the event is handled by way-cooler
 pub const EVENT_BLOCKED: bool = true;

--- a/src/render/screen_scrape.rs
+++ b/src/render/screen_scrape.rs
@@ -1,13 +1,14 @@
 use std::sync::{Arc, Barrier, Mutex, RwLock,
                 RwLockReadGuard, RwLockWriteGuard, MutexGuard, PoisonError};
+use rustwlc::WlcOutput;
 
 // 1366x768 is most common screen size.
 const DEFAULT_SCREEN_SIZE: usize = 1366 * 768;
 
 lazy_static! {
     static ref SCREEN_SCRAPE: RwLock<bool> = RwLock::new(false);
-    static ref SCRAPED_PIXELS: Mutex<Vec<u8>> = {
-        Mutex::new(Vec::with_capacity(DEFAULT_SCREEN_SIZE))
+    pub static ref SCRAPED_PIXELS: Mutex<(Vec<u8>, Option<WlcOutput>)> = {
+        Mutex::new((Vec::with_capacity(DEFAULT_SCREEN_SIZE), None))
     };
     static ref SCRAPE_BARRIER: Arc<Barrier> = Arc::new(Barrier::new(2));
 }
@@ -21,8 +22,8 @@ pub fn write_screen_scrape_lock<'a>() -> RwLockWriteGuard<'a, bool> {
     SCREEN_SCRAPE.write().expect("Lock was poisoned!")
 }
 
-pub fn scraped_pixels_lock() -> Result<MutexGuard<'static, Vec<u8>>,
-                                       PoisonError<MutexGuard<'static, Vec<u8>>>> {
+pub fn scraped_pixels_lock() -> Result<MutexGuard<'static, (Vec<u8>, Option<WlcOutput>)>,
+                                       PoisonError<MutexGuard<'static, (Vec<u8>, Option<WlcOutput>)>>> {
     trace!("Locking scraped pixels lock");
     SCRAPED_PIXELS.lock()
 }

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -6,7 +6,7 @@ use self::generated::server::desktop_shell::DesktopShell;
 use rustwlc::wayland::{get_display};
 use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
 use ::layout::{lock_tree, IncompleteBackground};
-use ::modes::{LockScreen, lock_screen, unlock_screen};
+use ::modes::{lock_screen, unlock_screen};
 use wayland_server::Resource;
 use wayland_sys::server::{WAYLAND_SERVER_HANDLE, wl_client, wl_resource};
 use std::os::raw::c_void;
@@ -147,7 +147,6 @@ unsafe extern "C" fn set_lock_surface(client: *mut wl_client,
     info!("Setting surface {:?} as lockscreen for output {}", surface, output);
     let output = WlcOutput::dummy(output as _);
     lock_screen(client, output)
-        .expect("Could not add lockscreen")
 }
 
 unsafe extern "C" fn unlock(client: *mut wl_client,

--- a/src/wayland/desktop_shell.rs
+++ b/src/wayland/desktop_shell.rs
@@ -6,7 +6,7 @@ use self::generated::server::desktop_shell::DesktopShell;
 use rustwlc::wayland::{get_display};
 use rustwlc::handle::{wlc_handle_from_wl_output_resource, WlcOutput};
 use ::layout::{lock_tree, IncompleteBackground};
-use ::modes::{LockScreen, lock_screen};
+use ::modes::{LockScreen, lock_screen, unlock_screen};
 use wayland_server::Resource;
 use wayland_sys::server::{WAYLAND_SERVER_HANDLE, wl_client, wl_resource};
 use std::os::raw::c_void;
@@ -144,16 +144,16 @@ unsafe extern "C" fn set_lock_surface(client: *mut wl_client,
     if output == 0 {
         return;
     }
-    let output = WlcOutput::dummy(output as _);
     info!("Setting surface {:?} as lockscreen for output {}", surface, output);
-    if let Ok(mut tree) = lock_tree() {
-        lock_screen(client, output)
-            .expect("Could not add lockscreen")
-    }
+    let output = WlcOutput::dummy(output as _);
+    lock_screen(client, output)
+        .expect("Could not add lockscreen")
 }
 
-unsafe extern "C" fn unlock(_client: *mut wl_client,
-                            _resource: *mut wl_resource) {}
+unsafe extern "C" fn unlock(client: *mut wl_client,
+                            _resource: *mut wl_resource) {
+    unlock_screen(client)
+}
 unsafe extern "C" fn set_grab_surface(_client: *mut wl_client,
                                       _resource: *mut wl_resource,
                                       _surface: *mut wl_resource) {}


### PR DESCRIPTION
Based on changes made in [this pr](https://github.com/way-cooler/way-cooler-lock/pull/5).

### Notable Features
* Ability to lock all the screens, not just one (means we are no longer compliant with desktop shell protocol though, might fix that in the future)
* Fixes the lockscreen so it's based on an actual Wayland protocol instead of a bad hack

### Breaking Changes
* `"lock_screen"` is no longer a built-in command, instead explicitly call `wc-lock`
* Can no longer lock screen using D-Bus (that method has been removed from the interface)
* Old versions of `wc-lock` will not work with this patch
* Scrape now takes an output as an argument, **this is a breaking change for `wc-grab` as well**. See [this pr for more details](https://github.com/way-cooler/way-cooler-grab/pull/4)
    + To use the old behaviour, simply pass `0` for the inputs to the `Scrape` D-Bus method

**Old versions of `wc-lock` are incompatible with this change. Please use a version >= 0.2**