### PR TITLE
AwesomeWM mostly implement `awesome` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,14 @@ name = "way-cooler"
 version = "0.6.2"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cairo-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dummy-rustwlc 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdk-pixbuf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -39,22 +41,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -69,19 +61,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cairo-rs"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c_vec 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cairo-sys-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-sys-rs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,39 +163,76 @@ version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gdk-pixbuf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gdk-pixbuf-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "glib"
-version = "0.1.3"
+name = "gio-sys"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glib"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gobject-sys"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -544,14 +574,12 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
-"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum c_vec 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6237ac5a4b1e81c213c24c6437964c61e646df910a914b4ab1487b46df20bd13"
-"checksum cairo-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0180a8b65dc13e78479c6a47c4d5f094d64dc34465a9433c6daef9ae2fbfb3ee"
-"checksum cairo-sys-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2414b86c20c40dfb56a98b1dbca05bde56411f488d268c4289a86df1b648c61"
+"checksum cairo-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9d336f1b2ff46c17475a14360de7f456707008da475c54824887e52e453ab00"
+"checksum cairo-sys-rs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8a1e2a76ac09b959788c2c30a355d693ce6f7f7d7268f6d1dd5d8c3359c521"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "58ec7b4cac6f79f36af1cd9cfdb9b935fc5a4e899f494ee03a3a6165f7d10b4b"
 "checksum dbus-macros 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1e013b945c57472e5c016f3695114b00c774f03feed9b03df78a9759bb42beb"
@@ -563,10 +591,13 @@ dependencies = [
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gdk-pixbuf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caf05dab73febcc6e90abaff8f24cfe1cf1bd2222cd648ddfe337bf3b994489f"
+"checksum gdk-pixbuf-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85eb441420653b33e5a29d13227ea34995383e65bf4f33b16492ec95e44a8996"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
-"checksum glib 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "81f514a8abd315ede0e94e39ce5987fdb99191c5f812e5066bc5bdb965104fc4"
-"checksum glib-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8826cbc94631507bdd91ee40f7e099bfaa3cc4f43c086b4d1c15cff5b4e8220b"
-"checksum gobject-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "87373f64e136e9ea192ff5d3ef676a51e9ac6ab06b629223a081e0523c5f04e2"
+"checksum gio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "189969f8189604c371d42b613d928c9d17fcfbf6e175d6b0ce9475a950f76dc6"
+"checksum glib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d4da1d7f4bdc5c708d8ce4df1ac440dcb2f9d97d937c989032185a48aeef1d10"
+"checksum glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd7d911c5dc610aabe37caae7d3b9d2cfe6d8f4c85ff4c062f3d6f490e75067"
+"checksum gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edc95561e538381576425264a4ddd08c65d5da218f10b2a47b4479dd147775da"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum json_macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cae828a10b461ca79f7a1e366e4aead4c4bd8fc9c39a57546c39cbda8ee3a0c1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ uuid = { version = "0.3", features = ["v4", "rustc-serialize"]}
 wayland-sys = { version = "0.9.1", features = ["client", "dlopen"] }
 wayland-server = { version = "0.9.1" }
 getopts = "0.2"
-cairo-rs = "0.1.1"
+cairo-rs = "0.2.*"
 xcb = "0.8.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ wayland-sys = { version = "0.9.1", features = ["client", "dlopen"] }
 wayland-server = { version = "0.9.1" }
 getopts = "0.2"
 cairo-rs = "0.2.*"
+gdk-pixbuf = "0.2.*"
+glib = "0.3.*"
 xcb = "0.8.1"
 
 [dev-dependencies]

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -200,7 +200,11 @@ fn xkb_get_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
     Ok(())
 }
 
-fn xrdb_get_value(_: &Lua, _: Value) -> rlua::Result<()> {
+fn xrdb_get_value(lua: &Lua, (_resource_class, resource_name): (String, String))
+                  -> rlua::Result<Value> {
+    if &resource_name == "Xft.dpi" {
+        return Ok("1".to_lua(lua)?)
+    }
     warn!("xrdb_get_value not supported");
-    Ok(())
+    Ok(Value::Nil)
 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -90,7 +90,6 @@ fn restart<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
 /// Load an image from the given path
 /// Returns either a cairo surface as light user data, nil and an error message
 fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lua>> {
-    // TODO Move to render module
     let pixbuf = Pixbuf::new_from_file(file_path.as_str())
         .map_err(|err| rlua::Error::RuntimeError(format!("{}", err)))?;
     let surface = render::load_surface_from_pixbuf(pixbuf);

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -62,7 +62,7 @@ fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Resu
            .method("xkb_get_group_names".into(), lua.create_function(xkb_get_group_names))?
            .method("restart".into(), lua.create_function(restart))?
            .method("load_image".into(), lua.create_function(load_image))?
-           .method("quit".into(), lua.create_function(dummy))
+           .method("quit".into(), lua.create_function(quit))
 }
 
 /// Registers a new X property
@@ -99,6 +99,11 @@ fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lu
     let surface_ptr = surface.to_glib_none().0;
     ::std::mem::forget(surface);
     rlua::LightUserData(surface_ptr as _).to_lua(lua)
+}
+
+fn quit<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
+    ::rustwlc::terminate();
+    Ok(())
 }
 
 fn property_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Result<ClassBuilder<'lua>> {

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -1,8 +1,8 @@
 //! TODO Fill in
 
+use render;
 use gdk_pixbuf::Pixbuf;
 use glib::translate::ToGlibPtr;
-use cairo::{self, ImageSurface};
 use std::fmt::{self, Display, Formatter};
 use std::default::Default;
 use std::rc::Rc;
@@ -93,56 +93,7 @@ fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lu
     // TODO Move to render module
     let pixbuf = Pixbuf::new_from_file(file_path.as_str())
         .map_err(|err| rlua::Error::RuntimeError(format!("{}", err)))?;
-    let width = pixbuf.get_width();
-    let height = pixbuf.get_height();
-    let channels = pixbuf.get_n_channels();
-    let pix_stride = pixbuf.get_rowstride() as usize;
-    // NOTE This is safe because we aren't modifying the bytes, but there's no immutable view
-    let pixels = unsafe { pixbuf.get_pixels() };
-    let format = if channels == 3 {cairo::Format::Rgb24} else { cairo::Format::ARgb32};
-    let mut surface = ImageSurface::create(format, width, height)
-        .expect("Could not create image of that size");
-    let cairo_stride = surface.get_stride() as usize;
-    {
-        let mut cairo_data = surface.get_data().unwrap();
-        let mut pix_pixels_index = 0;
-        let mut cairo_pixels_index = 0;
-        for _ in 0..height {
-            let mut pix_pixels_index2 = pix_pixels_index;
-            let mut cairo_pixels_index2 = cairo_pixels_index;
-            for _ in 0..width {
-                if channels == 3 {
-                    let r = pixels[pix_pixels_index2];
-                    let g = pixels[pix_pixels_index2 + 1];
-                    let b = pixels[pix_pixels_index2 + 2];
-                    cairo_data[cairo_pixels_index2] = b;
-                    cairo_data[cairo_pixels_index2 + 1] = g;
-                    cairo_data[cairo_pixels_index2 + 2] = r;
-                    pix_pixels_index2 += 3;
-                    // NOTE Four because of the alpha value we ignore
-                    cairo_pixels_index2 += 4;
-                } else {
-                    // TODO TEST THIS BRANCH
-                    let mut r = pixels[pix_pixels_index];
-                    let mut g = pixels[pix_pixels_index + 1];
-                    let mut b = pixels[pix_pixels_index + 2];
-                    let a = pixels[pix_pixels_index + 3];
-                    let alpha = a as f64 / 255.0;
-                    r *= alpha as u8;
-                    g *= alpha as u8;
-                    b *= alpha as u8;
-                    cairo_data[cairo_pixels_index] = b;
-                    cairo_data[cairo_pixels_index + 1] = g;
-                    cairo_data[cairo_pixels_index + 2] = r;
-                    cairo_data[cairo_pixels_index + 3] = a;
-                    pix_pixels_index += 4;
-                    cairo_pixels_index += 4;
-                }
-            }
-            pix_pixels_index += pix_stride;
-            cairo_pixels_index += cairo_stride;
-        }
-    }
+    let surface = render::load_surface_from_pixbuf(pixbuf);
     // UGH, I wanted to do to_glib_full, but that isn't defined apparently
     // So now I have to ignore the lifetime completely and just forget about the surface.
     let surface_ptr = surface.to_glib_none().0;

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -65,6 +65,8 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("connect_signal", lua.create_function(connect_signal))?;
     awesome_table.set("disconnect_signal", lua.create_function(disconnect_signal))?;
     awesome_table.set("emit_signal", lua.create_function(emit_signal))?;
+    awesome_table.set("xkb_set_layout_group", lua.create_function(xkb_set_layout_group))?;
+    awesome_table.set("xkb_get_layout_group", lua.create_function(xkb_get_layout_group))?;
     awesome_table.set("set_preferred_icon_size", lua.create_function(set_preferred_icon_size))?;
     awesome_table.set("register_xproperty", lua.create_function(register_xproperty))?;
     awesome_table.set("xkb_get_group_names", lua.create_function(xkb_get_group_names))?;
@@ -184,5 +186,15 @@ fn set_xproperty(_: &Lua, _: Value) -> rlua::Result<()> {
 
 fn get_xproperty(_: &Lua, _: Value) -> rlua::Result<()> {
     warn!("get_xproperty not supported");
+    Ok(())
+}
+
+fn xkb_set_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
+    warn!("xkb_set_layout_group not supported; Wait until wlroots");
+    Ok(())
+}
+
+fn xkb_get_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
+    warn!("xkb_get_layout_group not supported; Wait until wlroots");
     Ok(())
 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -38,6 +38,7 @@ impl UserData for AwesomeState {}
 pub fn init(lua: &Lua) -> rlua::Result<()> {
     let awesome_table = lua.create_table();
     state_setup(lua, &awesome_table)?;
+    meta_setup(lua, &awesome_table)?;
     method_setup(lua, &awesome_table)?;
     property_setup(lua, &awesome_table)?;
     let globals = lua.globals();
@@ -46,6 +47,17 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 
 fn state_setup(lua: &Lua, awesome_table: &Table) -> rlua::Result<()> {
     awesome_table.set("__data", AwesomeState::default().to_lua(lua)?)
+}
+
+fn meta_setup(lua: &Lua, awesome_table: &Table) -> rlua::Result<()> {
+    let meta_table = awesome_table.get_metatable().unwrap_or_else(|| {
+        let table = lua.create_table();
+        awesome_table.set_metatable(Some(table.clone()));
+        table
+    });
+    meta_table.set("__tostring", lua.create_function(|_, val: Table| {
+        Ok(format!("{}", val.get::<_, AwesomeState>("__data")?))
+    }))
 }
 
 fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Result<()> {

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -53,6 +53,7 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("xkb_get_group_names", lua.create_function(xkb_get_group_names))?;
     awesome_table.set("restart", lua.create_function(restart))?;
     awesome_table.set("load_image", lua.create_function(load_image))?;
+    awesome_table.set("sync", lua.create_function(sync))?;
     awesome_table.set("exec", lua.create_function(exec))?;
     awesome_table.set("kill", lua.create_function(kill))?;
     awesome_table.set("quit", lua.create_function(quit))
@@ -145,3 +146,6 @@ fn quit(_: &Lua, _: ()) -> rlua::Result<()> {
     ::rustwlc::terminate();
     Ok(())
 }
+
+/// No need to sync in Wayland
+fn sync(_, &Lua, _: ()) -> rlua::Result<()> { Ok(()) }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -61,6 +61,8 @@ pub fn init(lua: &Lua) -> rlua::Result<Class> {
 fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Result<ClassBuilder<'lua>> {
     // TODO Fill in rest
     builder.method("connect_signal".into(), lua.create_function(connect_signal))?
+           .method("disconnect_signal".into(), lua.create_function(disconnect_signal))?
+           .method("emit_signal".into(), lua.create_function(emit_signal))?
            .method("register_xproperty".into(), lua.create_function(register_xproperty))?
            .method("xkb_get_group_names".into(), lua.create_function(xkb_get_group_names))?
            .method("restart".into(), lua.create_function(restart))?
@@ -74,6 +76,21 @@ fn connect_signal<'lua>(lua: &'lua Lua, (name, func): (String, rlua::Function<'l
     let fake_object = lua.create_table();
     fake_object.set("signals", global_signals)?;
     signal::connect_signal(lua, fake_object.into(), name, &[func])
+}
+
+fn disconnect_signal<'lua>(lua: &'lua Lua, name: String) -> rlua::Result<()> {
+    let global_signals = lua.globals().get::<_, Table>(GLOBAL_SIGNALS)?;
+    let fake_object = lua.create_table();
+    fake_object.set("signals", global_signals)?;
+    signal::disconnect_signal(lua, fake_object.into(), name)
+}
+
+fn emit_signal<'lua>(lua: &'lua Lua, (name, args): (String, Value))
+                     -> rlua::Result<()> {
+    let global_signals = lua.globals().get::<_, Table>(GLOBAL_SIGNALS)?;
+    let fake_object = lua.create_table();
+    fake_object.set("signals", global_signals)?;
+    signal::emit_signal(lua, fake_object.into(), name, args)
 }
 
 /// Registers a new X property

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -131,10 +131,10 @@ fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lu
                     r *= alpha as u8;
                     g *= alpha as u8;
                     b *= alpha as u8;
-                    cairo_data[cairo_pixels_index] = a;
-                    cairo_data[cairo_pixels_index + 1] = r;
-                    cairo_data[cairo_pixels_index + 2] = g;
-                    cairo_data[cairo_pixels_index + 3] = b;
+                    cairo_data[cairo_pixels_index] = b;
+                    cairo_data[cairo_pixels_index + 1] = g;
+                    cairo_data[cairo_pixels_index + 2] = r;
+                    cairo_data[cairo_pixels_index + 3] = a;
                     pix_pixels_index += 4;
                     cairo_pixels_index += 4;
                 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -68,6 +68,8 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("set_preferred_icon_size", lua.create_function(set_preferred_icon_size))?;
     awesome_table.set("register_xproperty", lua.create_function(register_xproperty))?;
     awesome_table.set("xkb_get_group_names", lua.create_function(xkb_get_group_names))?;
+    awesome_table.set("set_xproperty", lua.create_function(set_xproperty))?;
+    awesome_table.set("get_xproperty", lua.create_function(get_xproperty))?;
     awesome_table.set("restart", lua.create_function(restart))?;
     awesome_table.set("load_image", lua.create_function(load_image))?;
     awesome_table.set("sync", lua.create_function(sync))?;
@@ -173,3 +175,14 @@ fn quit(_: &Lua, _: ()) -> rlua::Result<()> {
 
 /// No need to sync in Wayland
 fn sync(_: &Lua, _: ()) -> rlua::Result<()> { Ok(()) }
+
+
+fn set_xproperty(_: &Lua, _: Value) -> rlua::Result<()> {
+    warn!("set_xproperty not supported");
+    Ok(())
+}
+
+fn get_xproperty(_: &Lua, _: Value) -> rlua::Result<()> {
+    warn!("get_xproperty not supported");
+    Ok(())
+}

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -65,6 +65,7 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("connect_signal", lua.create_function(connect_signal))?;
     awesome_table.set("disconnect_signal", lua.create_function(disconnect_signal))?;
     awesome_table.set("emit_signal", lua.create_function(emit_signal))?;
+    awesome_table.set("xrdb_get_value", lua.create_function(xrdb_get_value))?;
     awesome_table.set("xkb_set_layout_group", lua.create_function(xkb_set_layout_group))?;
     awesome_table.set("xkb_get_layout_group", lua.create_function(xkb_get_layout_group))?;
     awesome_table.set("set_preferred_icon_size", lua.create_function(set_preferred_icon_size))?;
@@ -196,5 +197,10 @@ fn xkb_set_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
 
 fn xkb_get_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
     warn!("xkb_get_layout_group not supported; Wait until wlroots");
+    Ok(())
+}
+
+fn xrdb_get_value(_: &Lua, _: Value) -> rlua::Result<()> {
+    warn!("xrdb_get_value not supported");
     Ok(())
 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -55,11 +55,33 @@ fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Resu
     // TODO Do properly
     use super::dummy;
     builder.method("connect_signal".into(), lua.create_function(dummy))?
-           .method("register_xproperty".into(), lua.create_function(dummy))?
-           .method("xkb_get_group_names".into(), lua.create_function(dummy))?
-           .method("restart".into(), lua.create_function(dummy))?
+           .method("register_xproperty".into(), lua.create_function(register_xproperty))?
+           .method("xkb_get_group_names".into(), lua.create_function(xkb_get_group_names))?
+           .method("restart".into(), lua.create_function(restart))?
            .method("load_image".into(), lua.create_function(dummy))?
            .method("quit".into(), lua.create_function(dummy))
+}
+
+/// Registers a new X property
+/// This actually does nothing, since this is Wayland.
+fn register_xproperty<'lua>(_: &'lua Lua, _: Value<'lua>) -> rlua::Result<()> {
+    warn!("register_xproperty not supported");
+    Ok(())
+}
+
+/// Get layout short names
+fn xkb_get_group_names<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
+    warn!("xkb_get_group_names not supported");
+    Ok(())
+}
+
+/// Restart Awesome by restarting the Lua thread
+fn restart<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
+    use lua::{self, LuaQuery};
+    if let Err(err) = lua::send(LuaQuery::Restart) {
+        warn!("Could not restart Lua thread {:#?}", err);
+    }
+    Ok(())
 }
 
 fn property_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Result<ClassBuilder<'lua>> {

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -11,9 +11,6 @@ use std::default::Default;
 use rlua::{self, Table, Lua, UserData, ToLua, Value};
 use super::{GLOBAL_SIGNALS, signal};
 
-// TODO This isn't used yet, but it will be eventually.
-// It'll all be "global" values though, so we'll probably
-// just store it in Lua (hence the UserData trait)
 #[derive(Clone, Debug)]
 pub struct AwesomeState {
     preferred_icon_size: u32

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -1,5 +1,6 @@
 //! TODO Fill in
 
+use nix::{self, libc};
 use render;
 use gdk_pixbuf::Pixbuf;
 use glib::translate::ToGlibPtr;
@@ -53,6 +54,7 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("restart", lua.create_function(restart))?;
     awesome_table.set("load_image", lua.create_function(load_image))?;
     awesome_table.set("exec", lua.create_function(exec))?;
+    awesome_table.set("kill", lua.create_function(kill))?;
     awesome_table.set("quit", lua.create_function(quit))
 }
 
@@ -130,6 +132,13 @@ fn exec(_: &Lua, command: String) -> rlua::Result<()> {
             .expect("Could not spawn command")
     }).expect("Unable to spawn thread");
     Ok(())
+}
+
+/// Kills a PID with the given signal
+///
+/// Returns false if it could not send the signal to that process
+fn kill(_: &Lua, (pid, sig): (libc::pid_t, libc::c_int)) -> rlua::Result<bool> {
+    Ok(nix::sys::signal::kill(pid, sig).is_ok())
 }
 
 fn quit(_: &Lua, _: ()) -> rlua::Result<()> {

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -143,7 +143,6 @@ fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lu
             cairo_pixels_index += cairo_stride;
         }
     }
-    surface.get_data().unwrap();
     // UGH, I wanted to do to_glib_full, but that isn't defined apparently
     // So now I have to ignore the lifetime completely and just forget about the surface.
     let surface_ptr = surface.to_glib_none().0;

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -46,8 +46,6 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 fn set_up_awesome_path(lua: &Lua) -> rlua::Result<()> {
     let globals = lua.globals();
     let package: rlua::Table = globals.get("package")?;
-    //let paths: String = package.get("path")?;
-    // TODO Do this right, I'm too lazy and just scrapped from my awesome env
     let mut path = package.get::<_, String>("path")?;
     let mut cpath = package.get::<_, String>("cpath")?;
     let mut xdg_data_path: PathBuf = env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".into()).into();

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -1,5 +1,5 @@
 //! Awesome compatibilty modules
-use rlua::{self, Lua};
+use rlua::{self, Lua, Table};
 pub mod keygrabber;
 pub mod mousegrabber;
 pub mod awful;
@@ -22,11 +22,14 @@ pub use self::object::Object;
 pub use self::keygrabber::keygrabber_handle;
 pub use self::mousegrabber::mousegrabber_handle;
 
+pub const GLOBAL_SIGNALS: &'static str = "__awesome_global_signals";
+
 use std::env;
 use std::path::PathBuf;
 
 pub fn init(lua: &Lua) -> rlua::Result<()> {
-    set_up_awesome_path(lua)?;
+    setup_awesome_path(lua)?;
+    setup_global_signals(lua)?;
     button::init(lua)?;
     awesome::init(lua)?;
     key::init(lua)?;
@@ -43,9 +46,9 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
     Ok(())
 }
 
-fn set_up_awesome_path(lua: &Lua) -> rlua::Result<()> {
+fn setup_awesome_path(lua: &Lua) -> rlua::Result<()> {
     let globals = lua.globals();
-    let package: rlua::Table = globals.get("package")?;
+    let package: Table = globals.get("package")?;
     let mut path = package.get::<_, String>("path")?;
     let mut cpath = package.get::<_, String>("cpath")?;
     let mut xdg_data_path: PathBuf = env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".into()).into();
@@ -66,6 +69,14 @@ fn set_up_awesome_path(lua: &Lua) -> rlua::Result<()> {
         lua.load_debug();
     }
     Ok(())
+}
+
+/// Set up global signals value
+///
+/// We need to store this in Lua, because this make it safer to use.
+fn setup_global_signals(lua: &Lua) -> rlua::Result<()> {
+    let globals = lua.globals();
+    globals.set::<_, Table>(GLOBAL_SIGNALS, lua.create_table())
 }
 
 pub fn dummy<'lua>(_: &'lua Lua, _: rlua::Value) -> rlua::Result<()> { Ok(()) }

--- a/src/awesome/signal.rs
+++ b/src/awesome/signal.rs
@@ -4,7 +4,7 @@
 //! Signals are stored with the object in its metatable,
 //! the methods defined here are just to make it easier to use.
 
-use rlua::{self, Lua, ToLuaMulti, Table, Value, Function};
+use rlua::{self, Lua, ToLuaMulti, Value, Function};
 use super::Object;
 
 /// Connects functions to a signal. Creates a new entry in the table if it
@@ -12,7 +12,7 @@ use super::Object;
 pub fn connect_signal(lua: &Lua, obj: Object, name: String, funcs: &[Function])
                       -> rlua::Result<()>{
     let signals = obj.signals()?;
-    if let Ok(table) = signals.get::<_, Table>(name.as_str()) {
+    if let Ok(Value::Table(table)) = signals.get::<_, Value>(name.as_str()) {
         let mut length = table.len()? + 1;
         for func in funcs {
             table.set(length, func.clone())?;
@@ -45,7 +45,7 @@ pub fn emit_signal<'lua, A>(_: &'lua Lua,
     let signals = obj.signals()?;
     trace!("Checking signal {}", name);
     let obj_table = obj.table();
-    if let Ok(table) = signals.get::<_, Table>(name) {
+    if let Ok(Value::Table(table)) = signals.get::<_, Value>(name) {
         for entry in table.pairs::<Value, Function>() {
             if let Ok((_, func)) = entry {
                 trace!("Found func for signal");

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -59,7 +59,8 @@ impl Renderable for Borders {
                                                     Format::ARgb32,
                                                     w as i32,
                                                     h as i32,
-                                                    stride);
+                                                    stride)
+            .expect("Could not make ImageSurface");
         Some(Borders {
             title: "".into(),
             surface: surface,
@@ -144,7 +145,8 @@ impl Renderable for Borders {
                                                     Format::ARgb32,
                                                     w as i32,
                                                     h as i32,
-                                                    stride);
+                                                    stride)
+            .expect("Could not create ImageSurface");
         self.geometry = geometry;
         self.surface = surface;
         Some(self)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ extern crate petgraph;
 extern crate uuid;
 extern crate dbus;
 extern crate cairo;
+extern crate gdk_pixbuf;
+extern crate glib;
 #[macro_use]
 extern crate wayland_sys;
 extern crate wayland_server;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -53,8 +53,8 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
                     cairo_data[cairo_pixels_index + 1] = g;
                     cairo_data[cairo_pixels_index + 2] = r;
                     cairo_data[cairo_pixels_index + 3] = a;
-                    pix_pixels_index += 4;
-                    cairo_pixels_index += 4;
+                    pix_pixels_index2 += 4;
+                    cairo_pixels_index2 += 4;
                 }
             }
             pix_pixels_index += pix_stride;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,63 @@ mod draw;
 mod color;
 pub mod screen_scrape;
 
+use cairo::{self, ImageSurface};
+use gdk_pixbuf::Pixbuf;
 pub use self::renderable::Renderable;
 pub use self::draw::{Drawable, DrawErr, BaseDraw};
 pub use self::color::Color;
+
+
+/// Using a Pixbuf buffer, loads the data into a Cairo surface.
+pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
+    let width = pixbuf.get_width();
+    let height = pixbuf.get_height();
+    let channels = pixbuf.get_n_channels();
+    let pix_stride = pixbuf.get_rowstride() as usize;
+    // NOTE This is safe because we aren't modifying the bytes, but there's no immutable view
+    let pixels = unsafe { pixbuf.get_pixels() };
+    let format = if channels == 3 {cairo::Format::Rgb24} else { cairo::Format::ARgb32};
+    let mut surface = ImageSurface::create(format, width, height)
+        .expect("Could not create image of that size");
+    let cairo_stride = surface.get_stride() as usize;
+    {
+        let mut cairo_data = surface.get_data().unwrap();
+        let mut pix_pixels_index = 0;
+        let mut cairo_pixels_index = 0;
+        for _ in 0..height {
+            let mut pix_pixels_index2 = pix_pixels_index;
+            let mut cairo_pixels_index2 = cairo_pixels_index;
+            for _ in 0..width {
+                if channels == 3 {
+                    let r = pixels[pix_pixels_index2];
+                    let g = pixels[pix_pixels_index2 + 1];
+                    let b = pixels[pix_pixels_index2 + 2];
+                    cairo_data[cairo_pixels_index2] = b;
+                    cairo_data[cairo_pixels_index2 + 1] = g;
+                    cairo_data[cairo_pixels_index2 + 2] = r;
+                    pix_pixels_index2 += 3;
+                    // NOTE Four because of the alpha value we ignore
+                    cairo_pixels_index2 += 4;
+                } else {
+                    let mut r = pixels[pix_pixels_index];
+                    let mut g = pixels[pix_pixels_index + 1];
+                    let mut b = pixels[pix_pixels_index + 2];
+                    let a = pixels[pix_pixels_index + 3];
+                    let alpha = a as f64 / 255.0;
+                    r *= alpha as u8;
+                    g *= alpha as u8;
+                    b *= alpha as u8;
+                    cairo_data[cairo_pixels_index] = b;
+                    cairo_data[cairo_pixels_index + 1] = g;
+                    cairo_data[cairo_pixels_index + 2] = r;
+                    cairo_data[cairo_pixels_index + 3] = a;
+                    pix_pixels_index += 4;
+                    cairo_pixels_index += 4;
+                }
+            }
+            pix_pixels_index += pix_stride;
+            cairo_pixels_index += cairo_stride;
+        }
+    }
+    surface
+}


### PR DESCRIPTION
* Updated cairo-rs dependency
* Added gdk_pixbuf dependency
* Added glib dependency
* Added function to load surface data from pixbuf. This is useful to get a cairo surface that's loaded from a file
  - That means you can now load an image from Lua, store it in a surface using `lgi.cairo` and do stuff with it (like it save it back to a file, not that that's especially useful except for testing this stuff)
* Can use this to spawn and kill programs now, which makes the `util` module we currently support officially deprecated. It'll be removed in a future update.
* Implemented all the `awesome` methods used currently by the default `rc.lua`. Still need to implement the others though, as they'll probably be exposed/called once others are implemented. (See #385 for the list of methods to still implement)