### PR TITLE
Floating containers pulled forward when focused

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -53,6 +53,12 @@ impl LayoutTree {
                 _ => {}
             }
         }
+        if let Container::View { handle, floating, ..} = self.tree[node_ix] {
+            if floating {
+                handle.bring_to_front();
+            }
+            handle.focus();
+        }
         Ok(())
     }
     /// Focus on the container relative to the active container.


### PR DESCRIPTION
Focusing a floating view now brings it forward above other views. This should also fixe tooltips being hidden behind containers

@alexander-smoktal Hopefully this fixes all the problems you found with floating views