### PR TITLE
Tabbed/Stacked container titlebars

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -931,10 +931,8 @@ impl LayoutTree {
             // self.tree, and I need self.tree to get the children's titles
             let titles = children.iter().map(|&node_ix| {
                 match self.tree[node_ix] {
-                    Container::Container { ref mut borders, .. } =>
-                        borders.as_ref().map( |b| b.title() )
-                            .unwrap_or("").into(),
-                    Container::View { ref mut borders, .. } =>
+                    Container::Container { ref mut borders, .. } |
+                    Container::View { ref mut borders, .. } => 
                         borders.as_ref().map( |b| b.title() )
                             .unwrap_or("").into(),
                     ref child => {
@@ -952,13 +950,13 @@ impl LayoutTree {
                         if layout == Layout::Tabbed || layout == Layout::Stacked {
                             borders.as_mut().map(|b| {
 
-                                b.set_children(titles, index.unwrap());
+                                b.set_children(titles, index.expect("The node index was not a child"));
 
                                 // Still necesary to draw the title when this
                                 // container is inside another tabbed/stacked
                                 b.set_title(format!("{:?} ({}/{})",
                                                     layout,
-                                                    index_str.unwrap_or("?".into()),
+                                                    index_str.unwrap_or_else(|| "?".into()),
                                                     children.len()
                                 ));
                             });

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -112,8 +112,8 @@ impl Renderable for Borders {
         // Add the thickness to the geometry.
         let thickness = Borders::thickness();
 
-        let title_count = match (self.layout, &self.children) {
-            (Some(Layout::Stacked), &Some(ref children)) =>
+        let title_count = match (self.layout, self.children.as_ref()) {
+            (Some(Layout::Stacked), Some(children)) =>
                 // I don't understand why I have to use this
                 // instead of just child_count, but seems to work...
                 2 * children.titles.len() as u32 - 1,
@@ -371,6 +371,7 @@ impl Borders {
     }
 
     pub fn set_children(&mut self, titles: Vec<String>, index: usize) {
+        assert!(index < titles.len());
         self.children = Some(Children{
             titles: titles,
             index: index

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -7,6 +7,14 @@ use uuid::Uuid;
 use ::registry;
 use ::render::{Color, Renderable};
 
+/// Data of the container's children, necessary to draw Tabbed and Stacked layouts
+#[derive(Clone, Debug)]
+pub struct Children {
+    pub titles: Vec<String>,
+    /// Index of the currently selected children
+    pub index: usize,
+}
+
 /// The borders of a container.
 ///
 /// This type just deals with rendering,
@@ -16,6 +24,8 @@ pub struct Borders {
     pub title: String,
     /// The surface that contains the bytes we give to wlc to draw.
     surface: ImageSurface,
+    /// Children titles to be used tabbed/stacked layouts
+    pub children: Option<Children>,
     /// The geometry where the buffer is written.
     ///
     /// Should correspond with the geometry of the container.
@@ -68,7 +78,8 @@ impl Renderable for Borders {
             output: output,
             color: None,
             title_color: None,
-            title_font_color: None
+            title_font_color: None,
+            children: None,
         })
     }
 
@@ -344,6 +355,13 @@ impl Borders {
 
     pub fn set_title(&mut self, title: String) {
         self.title = title;
+    }
+
+    pub fn set_children(&mut self, titles: Vec<String>, index: usize) {
+        self.children = Some(Children{
+            titles: titles,
+            index: index
+        });
     }
 }
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -51,11 +51,6 @@ impl ContainerDraw {
                 for i in 0..child_count {
                     let active = i == active_index;
 
-                    let title = match self.base.inner().children.as_ref() {
-                        Some(children) => children.titles[i].clone(),
-                        None => unreachable!()
-                    };
-
                     let title_color = if active { title_color }
                         else { Borders::default_title_color() };
 
@@ -78,7 +73,12 @@ impl ContainerDraw {
                     self.base = try!(self.base.check_cairo());
                     self.base.set_color_source(title_font_color);
                     self.base = try!(self.base.check_cairo());
-                    self.base.show_text(title.as_str());
+                    self.base.show_text(
+                        match self.base.inner().children.as_ref() {
+                            Some(children) => children.titles[i].as_str(),
+                            None => unreachable!()
+                        }
+                    );
                     self.base = try!(self.base.check_cairo());
                 }
             }
@@ -87,11 +87,6 @@ impl ContainerDraw {
                 // Iterate over the indices to not borrow self
                 for i in 0..child_count {
                     let active = i == active_index;
-
-                    let title = match self.base.inner().children.as_ref() {
-                        Some(children) => children.titles[i].clone(),
-                        None => unreachable!()
-                    };
 
                     let title_color = if active { title_color }
                         else { Borders::default_title_color() };
@@ -115,13 +110,16 @@ impl ContainerDraw {
                     self.base = try!(self.base.check_cairo());
                     self.base.set_color_source(title_font_color);
                     self.base = try!(self.base.check_cairo());
-                    self.base.show_text(title.as_str());
+                    self.base.show_text(
+                        match self.base.inner().children.as_ref() {
+                            Some(children) => children.titles[i].as_str(),
+                            None => unreachable!()
+                        }
+                    );
                     self.base = try!(self.base.check_cairo());
                 }
             }
             _ => {
-                let title: String = self.inner().title().into();
-
                 // Draw background of title bar
                 self.base.set_source_rgb(1.0, 0.0, 0.0);
                 self.base.set_color_source(title_color);
@@ -135,7 +133,7 @@ impl ContainerDraw {
                 self.base = try!(self.base.check_cairo());
                 self.base.set_color_source(title_font_color);
                 self.base = try!(self.base.check_cairo());
-                self.base.show_text(title.as_str());
+                self.base.show_text(self.inner().title());
                 self.base = try!(self.base.check_cairo());
             }
         }

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -9,14 +9,12 @@ use super::super::container::Layout;
 /// edge borders are handled by the child views.
 pub struct ContainerDraw {
     base: BaseDraw<Borders>,
-    layout: Layout,
 }
 
 impl ContainerDraw {
-    pub fn new(base: BaseDraw<Borders>, layout: Layout) -> Self {
+    pub fn new(base: BaseDraw<Borders>) -> Self {
         ContainerDraw {
-            base,
-            layout,
+            base
         }
     }
 
@@ -39,28 +37,78 @@ impl ContainerDraw {
         // needs to not be borrowed later with all the paint operations, and
         // I didn't know how to work around that.
         let children = self.base.inner().children.clone();
+        let layout = self.base.inner().layout;
 
-        if self.layout == Layout::Tabbed && children.is_some() {
-            let children = children.unwrap();
+        match (layout, children) {
+            (Some(Layout::Tabbed), Some(children)) => {
+                let tab_width = w / children.titles.len() as f64;
 
-            let tab_width = w / children.titles.len() as f64;
+                for (i, title) in children.titles.iter().enumerate() {
+                    let active = children.index == i;
 
-            for (i, title) in children.titles.iter().enumerate() {
-                let active = children.index == i;
+                    let title_color = if active { title_color }
+                        else { Borders::default_title_color() };
 
-                let title_color = if active { title_color }
-                    else { Borders::default_title_color() };
+                    let title_font_color = if active { title_font_color }
+                        else { Borders::default_title_font_color() };
 
-                let title_font_color = if active { title_font_color }
-                    else { Borders::default_title_font_color() };
+                    let x = x + tab_width*i as f64;
+                    let title_x = title_x + tab_width*i as f64;
 
-                let x = x + tab_width*i as f64;
-                let title_x = title_x + tab_width*i as f64;
+                    // Draw background of title bar
+                    self.base.set_source_rgb(1.0, 0.0, 0.0);
+                    self.base.set_color_source(title_color);
+                    self.base.rectangle(x, 0.0, tab_width, title_size);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.fill();
+                    self.base = try!(self.base.check_cairo());
+
+                    // Draw title text
+                    self.base.move_to(title_x, title_y);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.set_color_source(title_font_color);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.show_text(title.as_str());
+                    self.base = try!(self.base.check_cairo());
+                }
+            }
+            (Some(Layout::Stacked), Some(children)) => {
+                for (i, title) in children.titles.iter().enumerate() {
+                    let active = children.index == i;
+
+                    let title_color = if active { title_color }
+                        else { Borders::default_title_color() };
+
+                    let title_font_color = if active { title_font_color }
+                        else { Borders::default_title_font_color() };
+
+                    let y = title_size*i as f64;
+                    let title_y = title_y as f64 + y;
+
+                    // Draw background of title bar
+                    self.base.set_source_rgb(1.0, 0.0, 0.0);
+                    self.base.set_color_source(title_color);
+                    self.base.rectangle(x, y, w, title_size);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.fill();
+                    self.base = try!(self.base.check_cairo());
+
+                    // Draw title text
+                    self.base.move_to(title_x, title_y);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.set_color_source(title_font_color);
+                    self.base = try!(self.base.check_cairo());
+                    self.base.show_text(title.as_str());
+                    self.base = try!(self.base.check_cairo());
+                }
+            }
+            _ => {
+                let title: String = self.inner().title().into();
 
                 // Draw background of title bar
                 self.base.set_source_rgb(1.0, 0.0, 0.0);
                 self.base.set_color_source(title_color);
-                self.base.rectangle(x, 0.0, tab_width, title_size);
+                self.base.rectangle(x, 0.0, w, title_size);
                 self.base = try!(self.base.check_cairo());
                 self.base.fill();
                 self.base = try!(self.base.check_cairo());
@@ -73,25 +121,8 @@ impl ContainerDraw {
                 self.base.show_text(title.as_str());
                 self.base = try!(self.base.check_cairo());
             }
-        } else {
-            let title: String = self.inner().title().into();
-
-            // Draw background of title bar
-            self.base.set_source_rgb(1.0, 0.0, 0.0);
-            self.base.set_color_source(title_color);
-            self.base.rectangle(x, 0.0, w, title_size);
-            self.base = try!(self.base.check_cairo());
-            self.base.fill();
-            self.base = try!(self.base.check_cairo());
-
-            // Draw title text
-            self.base.move_to(title_x, title_y);
-            self.base = try!(self.base.check_cairo());
-            self.base.set_color_source(title_font_color);
-            self.base = try!(self.base.check_cairo());
-            self.base.show_text(title.as_str());
-            self.base = try!(self.base.check_cairo());
         }
+
         Ok(self)
     }
 }
@@ -101,14 +132,23 @@ impl Drawable<Borders> for ContainerDraw {
     fn draw(mut self, container_g: Geometry) -> Result<Borders, DrawErr<Borders>> {
         let mut border_g = container_g;
         let thickness = Borders::thickness();
-        let title_size = Borders::title_bar_size();
+
+        let title_count = match (self.inner().layout, &self.inner().children) {
+            (Some(Layout::Stacked), &Some(ref children)) =>
+                // I don't understand why I have to use this
+                // instead of just child_count, but seems to work...
+                2 * children.titles.len() as u32 - 1,
+            _ => 1
+        };
+
+        let title_size = Borders::title_bar_size() * title_count;
         let edge_thickness = thickness / 2;
 
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
         border_g.origin.y -= (title_size / 2) as i32;
         border_g.size.w += thickness;
-        border_g.size.h = thickness;
+        border_g.size.h = edge_thickness + title_size/2;
 
         self.base.set_source_rgba(0.0, 0.0, 0.0, 0.0);
         self.base.paint();

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -352,6 +352,7 @@ impl Container {
                 *layout = new_layout;
                 if let Some(ref mut borders) = borders.as_mut() {
                     borders.title = format!("{:?} container", new_layout);
+                    borders.layout = Some(new_layout);
                 }
                 Ok(())
             },
@@ -634,7 +635,6 @@ impl Container {
                     }
                     *borders = ContainerDraw::new(
                             borders_.enable_cairo().unwrap(),
-                            layout
                         ).draw(geometry).ok();
                 }
                 Ok(())

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -632,8 +632,10 @@ impl Container {
                             return Ok(())
                         }
                     }
-                    *borders = ContainerDraw::new(borders_.enable_cairo().unwrap())
-                        .draw(geometry).ok();
+                    *borders = ContainerDraw::new(
+                            borders_.enable_cairo().unwrap(),
+                            layout
+                        ).draw(geometry).ok();
                 }
                 Ok(())
             },


### PR DESCRIPTION
Display titlebars of tabbed and stacked containers like i3 does. Children containers/views still draw their titlebars though.

Probably fixes #410, but needs more testing to confirm.