### PR TITLE
Don't include floating window borders in tabbed/stacked container

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -929,18 +929,22 @@ impl LayoutTree {
 
             // I can't do it inside the match ahead because it borrows
             // self.tree, and I need self.tree to get the children's titles
-            let titles = children.iter().map(|&node_ix| {
-                match self.tree[node_ix] {
-                    Container::Container { ref mut borders, .. } |
-                    Container::View { ref mut borders, .. } => 
-                        borders.as_ref().map( |b| b.title() )
+            let titles = children.iter()
+                .filter(|&&node_ix| {
+                    !self.tree[node_ix].floating()
+                })
+                .map(|&node_ix| {
+                    match self.tree[node_ix] {
+                        Container::Container { ref borders, .. } |
+                        Container::View { ref borders, .. } =>
+                            borders.as_ref().map( |b| b.title() )
                             .unwrap_or("").into(),
-                    ref child => {
-                        error!("Container child is {:#?}", child);
-                        panic!("Container childr is not a Container nor a View")
+                        ref child => {
+                            error!("Container child is {:#?}", child);
+                            panic!("Container childr is not a Container nor a View")
+                        }
                     }
-                }
-            }).collect();
+                }).collect();
 
             if !self.tree.on_path(child_ix) && Some(child_ix) != self.active_container {
                 self.set_borders(child_ix, borders::Mode::Inactive)?;


### PR DESCRIPTION
Fixes #440 

Floating containers will no longer have an entry in Tabbed or Stacked borders.

 This makes it much less frustrating to use stacked containers (where the mouse would no longer be highlighting the floating popup that probably spawned it, causing it to do a little jig)