### PR TITLE
Tabbed/Stacked title info updates with child container title

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -907,7 +907,7 @@ impl LayoutTree {
     }
 
     /// Draws the borders recursively, down from the top to the bottom.
-    fn draw_borders_rec(&mut self, mut children: Vec<NodeIndex>)
+    pub fn draw_borders_rec(&mut self, mut children: Vec<NodeIndex>)
                         -> CommandResult {
         let mut updated_nodes: HashSet<NodeIndex> = HashSet::from_iter(children.iter().cloned());
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -549,9 +549,15 @@ impl Tree {
     pub fn update_title(&mut self, view: WlcView) -> CommandResult {
         let id = try!(self.lookup_handle(view.into())
                       .map_err(|_|TreeError::ViewNotFound(view)));
-        let container = try!(self.0.lookup_mut(id));
-        container.set_name(Container::get_title(view));
-        container.draw_borders()?;
+        {
+            let container = try!(self.0.lookup_mut(id));
+            container.set_name(Container::get_title(view));
+            container.draw_borders()?;
+        }
+        // Update the parent container using draw_borders_rec
+        let node_ix = self.0.tree.lookup_id(id)
+            .ok_or(TreeError::ViewNotFound(view))?;
+        self.0.draw_borders_rec(vec![node_ix])?;
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #443 

Tabbed/Stacked container titles now update their title information when the child updates.