### PR TITLE
Don't show view title twice for Tabbed/Stacked borders

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -19,6 +19,7 @@ way_cooler.windows = {
     size = 0, -- The width of gaps between windows in pixels
   },
   borders = { -- Options for borders
+    root_borders = false, -- Display borders in root containers by default
     size = 20, -- The width of the borders between windows in pixels
     inactive_color = 0x386890, -- Color of the borders for inactive containers
     active_color = 0x57beb9 -- Color of active container borders

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -901,7 +901,7 @@ impl LayoutTree {
                         Layout::Stacked =>
                             // I don't understand why I have to use this
                             // instead of just child_count, but seems to work...
-                            (2 * child_count.saturating_sub(1)) as u32,
+                            (2 * child_count).saturating_sub(1) as u32,
                         _ => 1
                     };
                     let gap = Borders::gap_size();

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -940,13 +940,18 @@ impl LayoutTree {
                 }
                 if let Some(borders) = borders.as_ref() {
                     let edge_thickness = (thickness / 2) as i32;
-                    let title_size = borders.title_bar_size();
                     geometry.origin.x += edge_thickness;
-                    geometry.origin.y += edge_thickness;
-                    geometry.origin.y += title_size as i32;
+                    if borders.draw_title {
+                        let title_size = borders.title_bar_size();
+                        geometry.origin.y += edge_thickness;
+                        geometry.origin.y += title_size as i32;
+                        geometry.size.h = geometry.size.h.saturating_sub(thickness);
+                        geometry.size.h = geometry.size.h.saturating_sub(title_size);
+                    } else {
+                        // Gotta always subtract the size of the bottom border
+                        geometry.size.h = geometry.size.h.saturating_sub(thickness / 2);
+                    }
                     geometry.size.w = geometry.size.w.saturating_sub(thickness);
-                    geometry.size.h = geometry.size.h.saturating_sub(thickness);
-                    geometry.size.h = geometry.size.h.saturating_sub(title_size);
                     handle.set_geometry(ResizeEdge::empty(), geometry);
                 }
             },

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -875,7 +875,7 @@ impl LayoutTree {
                         Layout::Stacked =>
                             // I don't understand why I have to use this
                             // instead of just child_count, but seems to work...
-                            (2*child_count-1) as u32,
+                            (2 * child_count.saturating_sub(1)) as u32,
                         _ => 1
                     };
                     let gap = Borders::gap_size();

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -4,7 +4,6 @@ use uuid::Uuid;
 use super::super::{LayoutTree, TreeError, FocusError};
 use ::layout::core::container::{Container, ContainerType, Layout, Handle};
 use ::layout::core::borders::Borders;
-use ::render::Renderable;
 use ::debug_enabled;
 
 // TODO This module needs to be updated like the other modules...
@@ -43,7 +42,7 @@ impl LayoutTree {
 
         trace!("Adding workspace {:?}", worksp);
         let worksp_ix = self.tree.add_child(output_ix, worksp, false);
-        let borders = Borders::new(geometry, output_handle);
+        let borders = Borders::make_root_borders(geometry, output_handle);
         let container = Container::new_container(geometry,
                                                  output_handle,
                                                  borders);

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -277,6 +277,20 @@ impl LayoutTree {
             info!("Moving container {:?} to workspace {}",
                 self.get_active_container(), name);
             self.tree.move_node(active_ix, next_work_root_ix);
+            let new_parent_ix = self.tree.parent_of(active_ix)
+                .expect("Couldn't get parent of moved container");
+            let layout = self.tree[new_parent_ix].get_layout()
+                .expect("Couldn't get layout of new parent");
+            let draw_title = match layout {
+                Layout::Tabbed | Layout::Stacked => false,
+                Layout::Horizontal | Layout::Vertical => true
+            };
+            match self.tree[active_ix] {
+                Container::View { ref mut borders, .. } => {
+                    borders.as_mut().map(|b| b.draw_title = draw_title);
+                },
+                _ => {}
+            }
 
             // If different outputs, show it on the new output.
             let cur_output_ix = self.tree.parent_of(curr_work_ix)

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -254,6 +254,25 @@ impl Borders {
             .map(|num| (num as u32).into())
     }
 
+    /// Construct root borders, if the option is enabled.
+    pub fn make_root_borders(geo: Geometry, output: WlcOutput)
+                             -> Option<Borders> {
+        let lock = registry::clients_read();
+        let client = lock.client(Uuid::nil()).unwrap();
+        let handle = registry::ReadHandle::new(&client);
+        let root_borders_on = handle.read("windows".into()).ok()
+            .and_then(|windows| windows.get("borders".into()))
+            .and_then(|borders| borders.as_object()
+                      .and_then(|borders| borders.get("root_borders"))
+                      .and_then(|active| active.as_boolean())
+            ).unwrap_or(true);
+        if root_borders_on {
+            Borders::new(geo, output)
+        } else {
+            None
+        }
+    }
+
     /// Fetches the default title background color from the registry.
     ///
     /// If the value is unset, black borders are returned.

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -46,13 +46,15 @@ pub struct Borders {
     /// The specific color the font for the title bar should be colored.
     ///
     /// If unspecified, the default is used.
-    title_font_color: Option<Color>
+    title_font_color: Option<Color>,
+    /// Specifies if we should draw the title or not
+    pub draw_title: bool
 }
 
 impl Renderable for Borders {
     fn new(mut geometry: Geometry, output: WlcOutput) -> Option<Self> {
         let thickness = Borders::thickness();
-        let title_size = Borders::title_bar_size();
+        let title_size = Borders::fetch_title_bar_size();
         if thickness == 0 {
             return None
         }
@@ -84,6 +86,7 @@ impl Renderable for Borders {
             color: None,
             title_color: None,
             title_font_color: None,
+            draw_title: true
         })
     }
 
@@ -119,7 +122,7 @@ impl Renderable for Borders {
                 2 * children.titles.len() as u32 - 1,
             _ => 1
         };
-        let title_size = Borders::title_bar_size() * title_count;
+        let title_size = self.title_bar_size() * title_count;
 
         if thickness == 0 {
             return None;
@@ -211,8 +214,21 @@ impl Borders {
 
     /// Gets the size of the title bar.
     ///
+    /// If the view doesn't want to display it, returns 0.
+    ///
     /// Defaults to 0 if not set.
-    pub fn title_bar_size() -> u32 {
+    pub fn title_bar_size(&self) -> u32 {
+        if !self.draw_title {
+            0
+        } else {
+            Borders::fetch_title_bar_size()
+        }
+    }
+
+    /// Gets the size of the title bar.
+    ///
+    /// Defaults to 0 if not set.
+    fn fetch_title_bar_size() -> u32 {
         let lock = registry::clients_read();
         let client = lock.client(Uuid::nil()).unwrap();
         let handle = registry::ReadHandle::new(&client);

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -119,7 +119,7 @@ impl Renderable for Borders {
             (Some(Layout::Stacked), Some(children)) =>
                 // I don't understand why I have to use this
                 // instead of just child_count, but seems to work...
-                2 * children.titles.len() as u32 - 1,
+                2 * children.titles.len().saturating_sub(1) as u32,
             _ => 1
         };
         let title_size = self.title_bar_size() * title_count;

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -119,7 +119,7 @@ impl Renderable for Borders {
             (Some(Layout::Stacked), Some(children)) =>
                 // I don't understand why I have to use this
                 // instead of just child_count, but seems to work...
-                2 * children.titles.len().saturating_sub(1) as u32,
+                (2 * children.titles.len()).saturating_sub(1) as u32,
             _ => 1
         };
         let title_size = self.title_bar_size() * title_count;

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -152,7 +152,7 @@ impl Drawable<Borders> for ContainerDraw {
             (Some(Layout::Stacked), &Some(ref children)) =>
                 // I don't understand why I have to use this
                 // instead of just child_count, but seems to work...
-                2 * children.titles.len().saturating_sub(1) as u32,
+                (2 * children.titles.len()).saturating_sub(1) as u32,
             _ => 1
         };
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -22,7 +22,7 @@ impl ContainerDraw {
                       mut x: f64,
                       mut w: f64,) -> Result<Self, DrawErr<Borders>> {
         let gap = Borders::gap_size() as f64;
-        let title_size = Borders::title_bar_size() as f64;
+        let title_size = self.base.inner().title_bar_size() as f64;
         let title_color = self.base.inner().title_background_color();
         let title_font_color = self.base.inner().title_font_color();
         if x < 0.0 {
@@ -156,7 +156,7 @@ impl Drawable<Borders> for ContainerDraw {
             _ => 1
         };
 
-        let title_size = Borders::title_bar_size() * title_count;
+        let title_size = self.base.inner().title_bar_size() * title_count;
         let edge_thickness = thickness / 2;
 
         border_g.origin.x -= edge_thickness as i32;

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -152,7 +152,7 @@ impl Drawable<Borders> for ContainerDraw {
             (Some(Layout::Stacked), &Some(ref children)) =>
                 // I don't understand why I have to use this
                 // instead of just child_count, but seems to work...
-                2 * children.titles.len() as u32 - 1,
+                2 * children.titles.len().saturating_sub(1) as u32,
             _ => 1
         };
 

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -29,7 +29,14 @@ impl ContainerDraw {
             w += x;
         }
         let title_x = Borders::thickness() as f64 + gap / 2.0;
-        let title_y = title_size - 5.0;
+        let mut border_diff = Borders::thickness().saturating_sub(title_size as u32);
+        if border_diff == 0 {
+            border_diff = (title_size as u32).saturating_sub(Borders::thickness());
+        }
+        if border_diff < 5 {
+            border_diff = 5
+        }
+        let title_y = title_size - border_diff as f64;
         x = gap / 2.0;
         w -= gap;
 

--- a/src/layout/core/borders/view_draw.rs
+++ b/src/layout/core/borders/view_draw.rs
@@ -141,6 +141,10 @@ impl ViewDraw {
                          mut h: f64,
                          border_geometry: Geometry,
                          output_res: Size) -> Result<Self, DrawErr<Borders>> {
+        // Don't draw the top bar when we are in tabbed/stacked
+        if !self.base.inner().draw_title {
+            return Ok(self)
+        }
         let title_size = self.base.inner().title_bar_size() as f64;
         // yay clamping
         if x < 0.0 {

--- a/src/layout/core/borders/view_draw.rs
+++ b/src/layout/core/borders/view_draw.rs
@@ -24,7 +24,7 @@ impl ViewDraw {
                         border_geometry: Geometry,
                         output_res: Size)
                         -> Result<Self, DrawErr<Borders>> {
-        let title_size = Borders::title_bar_size() as f64;
+        let title_size = self.base.inner().title_bar_size() as f64;
         // yay clamping
         if x < 0.0 {
             w += x;
@@ -60,7 +60,7 @@ impl ViewDraw {
                          border_geometry: Geometry,
                          output_res: Size)
                          -> Result<Self, DrawErr<Borders>> {
-        let title_size = Borders::title_bar_size() as f64;
+        let title_size = self.base.inner().title_bar_size() as f64;
         // yay clamping
         if border_geometry.origin.x < 0 {
             x += border_geometry.origin.x as f64;
@@ -93,7 +93,7 @@ impl ViewDraw {
                       _h: f64,
                       border_geometry: Geometry,
                       output_res: Size) -> Result<Self, DrawErr<Borders>> {
-        let title_size = Borders::title_bar_size() as f64;
+        let title_size = self.base.inner().title_bar_size() as f64;
         let title_color = self.base.inner().title_background_color();
         let title_font_color = self.base.inner().title_font_color();
         let title: String = self.inner().title().into();
@@ -141,7 +141,7 @@ impl ViewDraw {
                          mut h: f64,
                          border_geometry: Geometry,
                          output_res: Size) -> Result<Self, DrawErr<Borders>> {
-        let title_size = Borders::title_bar_size() as f64;
+        let title_size = self.base.inner().title_bar_size() as f64;
         // yay clamping
         if x < 0.0 {
             w += x;
@@ -209,7 +209,7 @@ impl Drawable<Borders> for ViewDraw {
         let edge_thickness = thickness / 2;
         let output_res = self.inner().get_output().get_resolution()
             .expect("Could not get focused output's resolution");
-        let title_size = Borders::title_bar_size();
+        let title_size = self.base.inner().title_bar_size();
         border_g.origin.x -= edge_thickness as i32;
         border_g.origin.y -= edge_thickness as i32;
         border_g.origin.y -= title_size as i32;

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -353,12 +353,17 @@ impl LayoutTree {
                 active_ix = try!(self.tree.parent_of(active_ix)
                                  .map_err(|err| TreeError::PetGraph(err)));
             }
+            let draw_title = match self.tree[active_ix].get_layout()? {
+                Layout::Tabbed | Layout::Stacked => false,
+                Layout::Horizontal | Layout::Vertical => true
+            };
             let geometry = view.get_geometry()
                 .expect("View had no geometry");
             let output = view.get_output();
             let borders = Borders::new(geometry, output)
                 .map(|mut b| {
                     b.title = Container::get_title(view);
+                    b.draw_title = draw_title;
                     b
                 });
             let view_ix = self.tree.add_child(active_ix,


### PR DESCRIPTION
This completes #439, to make the Tabbed/Stacked borders behave exactly like they do in i3.

Now, the titles of views no longer show up twice in Tabbed/Stacked layouts.

@Arnaz87 visually, is there anything I missed? Combined with #448 and #447 this should make complete the i3-style tiling for Way Cooler.

Example of what Tabbed and Stacked looks like:
![proper-i3](https://user-images.githubusercontent.com/3515754/33593174-fd8dd404-d942-11e7-830d-399fe1d2bfee.png)
