### PR TITLE
Focusing on a nested popup will not make top parent inactive

### DIFF
--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -946,7 +946,10 @@ impl LayoutTree {
                     }
                 }).collect();
 
-            if !self.tree.on_path(child_ix) && Some(child_ix) != self.active_container {
+            if !self.tree.on_path(child_ix) && Some(child_ix) != self.active_container &&
+                self.active_container.map(|active|
+                                          self.tree.is_child_of(child_ix, active).ok() != Some(false) &&
+                                          self.tree.is_child_of(active, child_ix).ok() == Some(false)) == Some(true) {
                 self.set_borders(child_ix, borders::Mode::Inactive)?;
             } else {
                 match self.tree[parent_ix] {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -560,6 +560,19 @@ impl InnerTree {
         }
     }
 
+    pub fn is_child_of(&self, child_ix: NodeIndex, target_ix: NodeIndex)
+                       -> Result<bool, GraphError> {
+        let mut cur_ix = child_ix;
+        while cur_ix != target_ix {
+            cur_ix = self.parent_of(cur_ix)?;
+            match self.graph[cur_ix] {
+                Container::View { .. } | Container::Container { ..} => {},
+                _ => return Ok(false)
+            }
+        }
+        return Ok(true)
+    }
+
     /// Gets the parent of a node, if the node exists
     pub fn parent_of(&self, node_ix: NodeIndex) -> Result<NodeIndex, GraphError> {
         let mut neighbors = self.graph


### PR DESCRIPTION
To reproduce the bug this fixes:
1) Make a window that can spawn nested popups (e.g a context or right click menu with nested options)
2) Focus on a deeply nested option
3) Notice that the original application border highlighting is now no longer correct.

This fixes that bug.