### PR TITLE
fix crash on layout changed when have floating window.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Intellij IDE
 .idea
+
+# vscode IDE
+.vscode/

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -923,21 +923,19 @@ impl LayoutTree {
 
             let parent_ix = self.tree.parent_of(child_ix)
                 .expect("Node had no parent");
-            let children = self.tree.children_of(parent_ix);
-            let index = children.iter().position(|&node_ix| node_ix == child_ix);
+            let grounded_children = self.tree.grounded_children(parent_ix);
+
+            let index = grounded_children.iter().position(|&node_ix| node_ix == child_ix);
             let index_str = index.map(|num| (num + 1).to_string());
 
             // I can't do it inside the match ahead because it borrows
             // self.tree, and I need self.tree to get the children's titles
-            let titles = children.iter()
-                .filter(|&&node_ix| {
-                    !self.tree[node_ix].floating()
-                })
+            let titles = grounded_children.iter()
                 .map(|&node_ix| {
                     match self.tree[node_ix] {
                         Container::Container { ref borders, .. } |
                         Container::View { ref borders, .. } =>
-                            borders.as_ref().map( |b| b.title() )
+                            borders.as_ref().map(|b| b.title())
                             .unwrap_or("").into(),
                         ref child => {
                             error!("Container child is {:#?}", child);
@@ -954,7 +952,7 @@ impl LayoutTree {
                         if layout == Layout::Tabbed || layout == Layout::Stacked {
                             borders.as_mut().map(|b| {
 
-                                b.set_children(titles, index.expect("The node index was not a child"));
+                                b.set_children(titles, index);
 
                                 // Still necesary to draw the title when this
                                 // container is inside another tabbed/stacked

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -13,7 +13,7 @@ use super::super::container::Layout;
 pub struct Children {
     pub titles: Vec<String>,
     /// Index of the currently selected children
-    pub index: usize,
+    pub index: Option<usize>,
 }
 
 /// The borders of a container.
@@ -370,8 +370,7 @@ impl Borders {
         self.title = title;
     }
 
-    pub fn set_children(&mut self, titles: Vec<String>, index: usize) {
-        assert!(index < titles.len());
+    pub fn set_children(&mut self, titles: Vec<String>, index: Option<usize>) {
         self.children = Some(Children{
             titles: titles,
             index: index

--- a/src/layout/core/borders/container_draw.rs
+++ b/src/layout/core/borders/container_draw.rs
@@ -49,7 +49,7 @@ impl ContainerDraw {
 
                 // Iterate over the indices to not borrow self
                 for i in 0..child_count {
-                    let active = i == active_index;
+                    let active = Some(i) == active_index;
 
                     let title_color = if active { title_color }
                         else { Borders::default_title_color() };
@@ -86,7 +86,7 @@ impl ContainerDraw {
 
                 // Iterate over the indices to not borrow self
                 for i in 0..child_count {
-                    let active = i == active_index;
+                    let active = Some(i) == active_index;
 
                     let title_color = if active { title_color }
                         else { Borders::default_title_color() };


### PR DESCRIPTION
The active window (variable `index` in layout.rs) is calculate without the floating filter.
when some floating window exist. the index may out of `titles.len()`

BTW. another bug is the active index of `Container` can be a floating window when switch active window by shortcut key. Maybe is same reason that not filtered the floating ones.