### PR TITLE
Some work on drawins and drawables to make the default config load

### DIFF
--- a/src/awesome/drawable.rs
+++ b/src/awesome/drawable.rs
@@ -40,6 +40,7 @@ impl <'lua> Drawable<'lua> {
         // TODO Do properly
         let table = lua.create_table();
         table.set("geometry", lua.create_function(geometry))?;
+        table.set("refresh", lua.create_function(refresh))?;
         Ok(builder.add_to_meta(table)?.build())
     }
 
@@ -80,6 +81,13 @@ impl <'lua> Drawable<'lua> {
                 // TODO emity property::surface
             }
         }
+        self.set_state(drawable)
+    }
+
+    /// Signals that the drawable's surface was updated.
+    pub fn refresh(&mut self) -> rlua::Result<()> {
+        let mut drawable = self.state()?;
+        drawable.refreshed = true;
         self.set_state(drawable)
     }
 }
@@ -127,4 +135,8 @@ fn geometry<'lua>(lua: &'lua Lua, table: Table<'lua>) -> rlua::Result<Table<'lua
     table.set("width", w)?;
     table.set("height", h)?;
     Ok(table)
+}
+
+fn refresh<'lua>(_: &'lua Lua, table: Table<'lua>) -> rlua::Result<()> {
+    Drawable::cast(table.into())?.refresh()
 }

--- a/src/awesome/drawable.rs
+++ b/src/awesome/drawable.rs
@@ -36,7 +36,11 @@ impl Default for DrawableState {
 impl <'lua> Drawable<'lua> {
     pub fn new(lua: &Lua) -> rlua::Result<Object> {
         let class = class::class_setup(lua, "drawable")?;
-        Ok(Drawable::allocate(lua, class)?.build())
+        let builder = Drawable::allocate(lua, class)?;
+        // TODO Do properly
+        let table = lua.create_table();
+        table.set("geometry", lua.create_function(geometry))?;
+        Ok(builder.add_to_meta(table)?.build())
     }
 
     pub fn get_geometry(&self) -> rlua::Result<Geometry> {

--- a/src/awesome/drawable.rs
+++ b/src/awesome/drawable.rs
@@ -28,7 +28,7 @@ impl Default for DrawableState {
         DrawableState {
             surface: None,
             geo: Geometry::zero(),
-            refreshed: true
+            refreshed: false
         }
     }
 }
@@ -70,6 +70,7 @@ impl <'lua> Drawable<'lua> {
         drawable.geo = geometry;
         if size_changed {
             drawable.surface = None;
+            drawable.refreshed = false;
             let size = geometry.size;
             if size.w > 0 && size.h > 0 {
                 drawable.surface = Some(ImageSurface::create(Format::ARgb32,

--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -169,18 +169,24 @@ fn get_visible<'lua>(_: &'lua Lua, table: Table<'lua>) -> rlua::Result<bool> {
     // TODO signal
 }
 
-fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Table<'lua>)) -> rlua::Result<Table<'lua>> {
+fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Value<'lua>)) -> rlua::Result<Table<'lua>> {
     let mut drawin = Drawin::cast(drawin.into())?;
-    let w = geometry.get::<_, i32>("width")?;
-    let h = geometry.get::<_, i32>("height")?;
-    let x = geometry.get::<_, i32>("x")?;
-    let y = geometry.get::<_, i32>("y")?;
-    if x > 0 && y > 0 {
-        let geo = Geometry {
-            origin: Point { x, y },
-            size: Size { w: w as u32, h: h as u32 }
-        };
-        drawin.resize(geo)?;
+    match geometry {
+        rlua::Value::Table(geometry) => {
+            let w = geometry.get::<_, i32>("width")?;
+            let h = geometry.get::<_, i32>("height")?;
+            let x = geometry.get::<_, i32>("x")?;
+            let y = geometry.get::<_, i32>("y")?;
+            if x > 0 && y > 0 {
+                let geo = Geometry {
+                    origin: Point { x, y },
+                    size: Size { w: w as u32, h: h as u32 }
+                };
+                drawin.resize(geo)?;
+            }
+        },
+        rlua::Value::Nil => {},
+        _ => return Err(rlua::Error::RuntimeError("Invalid argument".to_owned()))
     }
     let new_geo = drawin.get_geometry()?;
     let Size { w, h } = new_geo.size;

--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Display, Formatter};
 use std::rc::Rc;
 use rustwlc::{Geometry, Point, Size};
 use rlua::{self, Table, Lua, UserData, ToLua, Value};
+use rlua::prelude::LuaInteger;
 use super::drawable::Drawable;
 use super::property::Property;
 
@@ -124,6 +125,22 @@ fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Resu
 
 fn property_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Result<ClassBuilder<'lua>> {
     builder
+        .property(Property::new("x".into(),
+                                Some(lua.create_function(set_x)),
+                                Some(lua.create_function(get_x)),
+                                Some(lua.create_function(set_x))))?
+        .property(Property::new("y".into(),
+                                Some(lua.create_function(set_y)),
+                                Some(lua.create_function(get_y)),
+                                Some(lua.create_function(set_y))))?
+        .property(Property::new("width".into(),
+                                Some(lua.create_function(set_width)),
+                                Some(lua.create_function(get_width)),
+                                Some(lua.create_function(set_width))))?
+        .property(Property::new("height".into(),
+                                Some(lua.create_function(set_height)),
+                                Some(lua.create_function(get_height)),
+                                Some(lua.create_function(set_height))))?
         .property(Property::new("visible".into(),
                                 Some(lua.create_function(set_visible)),
                                 Some(lua.create_function(get_visible)),
@@ -174,4 +191,64 @@ fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Table
     res.set("height", h)?;
     res.set("width", w)?;
     Ok(res)
+}
+
+fn get_x<'lua>(_: &'lua Lua, drawin: Table<'lua>) -> rlua::Result<LuaInteger> {
+    let drawin = Drawin::cast(drawin.into())?;
+    let Point { x, .. } = drawin.get_geometry()?.origin;
+    Ok(x as LuaInteger)
+}
+
+fn set_x<'lua>(_: &'lua Lua, (drawin, x): (Table<'lua>, LuaInteger)) -> rlua::Result<()> {
+    let mut drawin = Drawin::cast(drawin.into())?;
+    let mut geo = drawin.get_geometry()?;
+    geo.origin.x = x as i32;
+    drawin.resize(geo)?;
+    Ok(())
+}
+
+fn get_y<'lua>(_: &'lua Lua, drawin: Table<'lua>) -> rlua::Result<LuaInteger> {
+    let drawin = Drawin::cast(drawin.into())?;
+    let Point { y, .. } = drawin.get_geometry()?.origin;
+    Ok(y as LuaInteger)
+}
+
+fn set_y<'lua>(_: &'lua Lua, (drawin, y): (Table<'lua>, LuaInteger)) -> rlua::Result<()> {
+    let mut drawin = Drawin::cast(drawin.into())?;
+    let mut geo = drawin.get_geometry()?;
+    geo.origin.y = y as i32;
+    drawin.resize(geo)?;
+    Ok(())
+}
+
+fn get_width<'lua>(_: &'lua Lua, drawin: Table<'lua>) -> rlua::Result<LuaInteger> {
+    let drawin = Drawin::cast(drawin.into())?;
+    let Size { w, .. } = drawin.get_geometry()?.size;
+    Ok(w as LuaInteger)
+}
+
+fn set_width<'lua>(_: &'lua Lua, (drawin, width): (Table<'lua>, LuaInteger)) -> rlua::Result<()> {
+    let mut drawin = Drawin::cast(drawin.into())?;
+    let mut geo = drawin.get_geometry()?;
+    if width > 0 {
+        geo.size.w = width as u32;
+        drawin.resize(geo)?;
+    }
+    Ok(())
+}
+
+fn get_height<'lua>(_: &'lua Lua, drawin: Table<'lua>) -> rlua::Result<LuaInteger> {
+    let drawin = Drawin::cast(drawin.into())?;
+    let Size { h, .. } = drawin.get_geometry()?.size;
+    Ok(h as LuaInteger)
+}
+
+fn set_height<'lua>(_: &'lua Lua, (drawin, height): (Table<'lua>, LuaInteger)) -> rlua::Result<()> {
+    let mut drawin = Drawin::cast(drawin.into())?;
+    let mut geo = drawin.get_geometry()?;
+    if height > 0 {
+        geo.size.h = height as u32;
+        drawin.resize(geo)?;
+    }
+    Ok(())
 }

--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -153,6 +153,7 @@ fn object_setup<'lua>(lua: &'lua Lua, builder: ObjectBuilder<'lua>) -> rlua::Res
     let drawable_table = Drawable::new(lua)?.to_lua(lua)?;
     table.set("drawable", drawable_table)?;
     table.set("geometry", lua.create_function(drawin_geometry))?;
+    table.set("struts", lua.create_function(drawin_struts))?;
     builder.add_to_meta(table)
 }
 
@@ -257,4 +258,15 @@ fn set_height<'lua>(_: &'lua Lua, (drawin, height): (Table<'lua>, LuaInteger)) -
         drawin.resize(geo)?;
     }
     Ok(())
+}
+
+fn drawin_struts<'lua>(lua: &'lua Lua, _drawin: Table<'lua>) -> rlua::Result<Table<'lua>> {
+    // TODO: Implement this properly. Struts means this drawin reserves some space on the screen
+    // that it is visible on, shrinking the workarea in the specified directions.
+    let res = lua.create_table();
+    res.set("left", 0)?;
+    res.set("right", 0)?;
+    res.set("top", 0)?;
+    res.set("bottom", 0)?;
+    Ok(res)
 }

--- a/src/awesome/object.rs
+++ b/src/awesome/object.rs
@@ -255,7 +255,7 @@ pub fn default_newindex<'lua>(_: &'lua Lua,
         }
         match class.get::<_, Function>("__newindex_miss_handler") {
             Ok(function) => {
-                return function.bind(obj_table)?.call(index)
+                return function.bind(obj_table)?.call((index, val))
             },
             Err(_) => {}
         }

--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -86,6 +86,19 @@ impl <'lua> Screen<'lua> {
         self.set_state(state)
     }
 
+    fn get_geometry(&self, lua: &'lua Lua) -> rlua::Result<Table<'lua>> {
+        let state = self.state()?;
+        let Point { x, y } = state.geometry.origin;
+        let Size { w, h } = state.geometry.size;
+        // TODO I do this a lot, put it somewhere
+        let table = lua.create_table();
+        table.set("x", x)?;
+        table.set("y", y)?;
+        table.set("width", w)?;
+        table.set("height", h)?;
+        Ok(table)
+    }
+
     fn get_workarea(&self, lua: &'lua Lua) -> rlua::Result<Table<'lua>> {
         let state = self.state()?;
         let Point { x, y } = state.workarea.origin;
@@ -128,10 +141,19 @@ fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Resu
 
 fn property_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Result<ClassBuilder<'lua>> {
     builder
+        .property(Property::new("geometry".into(),
+                                None,
+                                Some(lua.create_function(get_geometry)),
+                                None))?
         .property(Property::new("workarea".into(),
                                 None,
                                 Some(lua.create_function(get_workarea)),
                                 None))
+}
+
+fn get_geometry<'lua>(lua: &'lua Lua, table: Table<'lua>) -> rlua::Result<Table<'lua>> {
+    let screen = Screen::cast(table.into())?;
+    screen.get_geometry(lua)
 }
 
 fn get_workarea<'lua>(lua: &'lua Lua, table: Table<'lua>) -> rlua::Result<Table<'lua>> {


### PR DESCRIPTION
With these changes, I can run way-cooler with the following patch:
```diff
diff --git a/build.rs b/build.rs
index e84f2a8..69aaaa5 100644
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    println!("cargo:rustc-link-search=native=/home/psychon/projects/wlc/my-install-prefix/lib");
     dump_git_version();
     generate_wayland_protocols();
 }
diff --git a/config/init.lua b/config/init.lua
index 31e1761..129afab 100644
--- a/config/init.lua
+++ b/config/init.lua
@@ -140,3 +140,5 @@ end
 way_cooler.on_terminate = function()
   util.program.terminate_startup_programs()
 end
+
+dofile("/home/psychon/projects/way-cooler/config/rc.lua")
diff --git a/config/rc.lua b/config/rc.lua
index d08dc18..8dc5916 100644
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -1,3 +1,5 @@
+print(require("wibox"){}:geometry())
+
 -- If LuaRocks is installed, make sure that packages installed through it are
 -- found (e.g. lgi). If LuaRocks is not installed, do nothing.
 pcall(require, "luarocks.loader")
@@ -210,10 +212,20 @@ awful.screen.connect_for_each_screen(function(s)
                            awful.button({ }, 4, function () awful.layout.inc( 1) end),
                            awful.button({ }, 5, function () awful.layout.inc(-1) end)))
     -- Create a taglist widget
-    s.mytaglist = awful.widget.taglist(s, awful.widget.taglist.filter.all, taglist_buttons)
+    --s.mytaglist = awful.widget.taglist(s, awful.widget.taglist.filter.all, taglist_buttons)
+    s.mytaglist = awful.widget.taglist {
+            screen = s,
+            filter = awful.widget.taglist.filter.all,
+            buttons = taglist_buttons
+    }
 
     -- Create a tasklist widget
-    s.mytasklist = awful.widget.tasklist(s, awful.widget.tasklist.filter.currenttags, tasklist_buttons)
+    --s.mytasklist = awful.widget.tasklist(s, awful.widget.tasklist.filter.currenttags, tasklist_buttons)
+    s.mytasklist = awful.widget.tasklist {
+            screen = s,
+            filter = awful.widget.tasklist.filter.currenttags,
+            buttons = tasklist_buttons
+    }
 
     -- @DOC_WIBAR@
     -- Create the wibox
@@ -588,3 +600,38 @@ end)
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)
 client.connect_signal("unfocus", function(c) c.border_color = beautiful.border_normal end)
 -- }}}
+
+-- [[
+print("\nbefore creating wibox\n")
+local w = wibox{}
+w:geometry { x = 10, y = 10, width = 100, height = 100 }
+w:set_widget(wibox.widget.textbox("Hello world"))
+w.visible = true
+print("\nafter creating wibox\n")
+gears.timer.delayed_call(function()
+	print("in delayed call")
+end)
+awesome.emit_signal("refresh")
+--]]
+
+--[[
+local d = drawin{}
+d:geometry { x = 10, y = 10, width = 100, height = 100 }
+d.visible = true
+local surf = gears.surface.load_silently(d.drawable.surface, false)
+if surf then
+    local cr = require("lgi").cairo.Context(surf)
+    cr:set_source_rgb(1, 1, 1)
+    cr:paint()
+    cr:set_source_rgb(1, 0, 0)
+    cr:move_to(0, 0)
+    cr:line_to(100, 100)
+    cr:set_line_width(5)
+    cr:stroke()
+    d.drawable:refresh()
+
+gears.surface.load_silently(d.drawable.surface, false):write_to_png("/tmp/foo.png")
+    print("I survived!")
+
+end
+--]]
diff --git a/src/awesome/screen.rs b/src/awesome/screen.rs
index f117e66..1ed1c8d 100644
--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -127,7 +127,10 @@ pub fn init(lua: &Lua) -> rlua::Result<Class> {
     // TODO Uncomment
     // This breaks rc.lua because of layoutbox stuff.
     // Please fix that when you uncomment this.
-    lua.globals().set(SCREENS_HANDLE, lua.create_table()/*screens.to_lua(lua)?*/)?;
+    lua.globals().set(SCREENS_HANDLE,
+                      //lua.create_table()
+                      screens.to_lua(lua)?
+                      )?;
     Ok(res)
 }
 
diff --git a/src/lua/thread.rs b/src/lua/thread.rs
index 6e8d979..479aa45 100644
--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -167,13 +167,15 @@ pub fn init() -> Result<(), rlua::Error> {
                         lua.exec(init_path::DEFAULT_CONFIG,
                                  Some("init.lua <DEFAULT>".into()))
                         })
+                    .map_err(|e| {println!("{}", e); e})
                     .expect("Unable to load pre-compiled init file");
             }
             Err(_) => {
                 warn!("Defaulting to pre-compiled init.lua");
                 let _: () = lua.exec(init_path::DEFAULT_CONFIG,
                                      Some("init.lua <DEFAULT>".into()))
-                    .expect("Unable to load pre-compiled init file");
+                    .map_err(|e| {println!("{}", e); e})
+                    .expect("UUUUnable to load pre-compiled init file");
             }
         }
     }
```