### PR TITLE
Small improvement to drawin_geometry

### DIFF
--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -170,24 +170,20 @@ fn get_visible<'lua>(_: &'lua Lua, table: Table<'lua>) -> rlua::Result<bool> {
     // TODO signal
 }
 
-fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Value<'lua>)) -> rlua::Result<Table<'lua>> {
+fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Option<Table<'lua>>)) -> rlua::Result<Table<'lua>> {
     let mut drawin = Drawin::cast(drawin.into())?;
-    match geometry {
-        rlua::Value::Table(geometry) => {
-            let w = geometry.get::<_, i32>("width")?;
-            let h = geometry.get::<_, i32>("height")?;
-            let x = geometry.get::<_, i32>("x")?;
-            let y = geometry.get::<_, i32>("y")?;
-            if x > 0 && y > 0 {
-                let geo = Geometry {
-                    origin: Point { x, y },
-                    size: Size { w: w as u32, h: h as u32 }
-                };
-                drawin.resize(geo)?;
-            }
-        },
-        rlua::Value::Nil => {},
-        _ => return Err(rlua::Error::RuntimeError("Invalid argument".to_owned()))
+    if let Some(geometry) = geometry {
+        let w = geometry.get::<_, i32>("width")?;
+        let h = geometry.get::<_, i32>("height")?;
+        let x = geometry.get::<_, i32>("x")?;
+        let y = geometry.get::<_, i32>("y")?;
+        if x > 0 && y > 0 {
+            let geo = Geometry {
+                origin: Point { x, y },
+                size: Size { w: w as u32, h: h as u32 }
+            };
+            drawin.resize(geo)?;
+        }
     }
     let new_geo = drawin.get_geometry()?;
     let Size { w, h } = new_geo.size;


### PR DESCRIPTION
Commit 487b8d6e5 made the argument to the geometry method of a drawin
optional, so that the geometry can be queried without setting it. This
was done by directly matching on the Lua value.

However, rlua implements FromLua for Option<T>, so instead of
implementing this optionality directly, Option can be used instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>