### PR TITLE
Allow colors to contain alpha values

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -21,15 +21,15 @@ way_cooler.windows = {
   borders = { -- Options for borders
     root_borders = false, -- Display borders in root containers by default
     size = 20, -- The width of the borders between windows in pixels
-    inactive_color = 0x386890, -- Color of the borders for inactive containers
-    active_color = 0x57beb9 -- Color of active container borders
+    inactive_color = "386890", -- Color of the borders for inactive containers
+    active_color = "57beb9" -- Color of active container borders
   },
   title_bar = { -- Options for title bar above windows
     size = 20, -- Size of the title bar
-    background_color = 0x386690, -- Color of inactive title bar
-    active_background_color = 0x57beb9, -- Color of active title bar
-    font_color = 0x0, -- Color of the font for an inactive title bar
-    active_font_color = 0xffffff -- Color of font for active title bar
+    background_color = "386690", -- Color of inactive title bar
+    active_background_color = "57beb9", -- Color of active title bar
+    font_color = "000000", -- Color of the font for an inactive title bar
+    active_font_color = "ffffff" -- Color of font for active title bar
   }
 }
 

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -253,7 +253,7 @@ impl Borders {
             .and_then(|borders| borders.as_object()
                       .and_then(|borders| borders.get("inactive_color"))
                       .and_then(|gaps| gaps.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
             .unwrap_or(0u32.into())
     }
 
@@ -267,7 +267,7 @@ impl Borders {
             .and_then(|borders| borders.as_object()
                       .and_then(|borders| borders.get("active_color"))
                       .and_then(|gaps| gaps.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
     }
 
     /// Construct root borders, if the option is enabled.
@@ -301,7 +301,7 @@ impl Borders {
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("background_color"))
                       .and_then(|color| color.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
             .unwrap_or(0u32.into())
     }
 
@@ -315,7 +315,7 @@ impl Borders {
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("active_background_color"))
                       .and_then(|color| color.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
     }
 
     /// Fetches the default title font color from the registry.
@@ -330,7 +330,7 @@ impl Borders {
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("font_color"))
                       .and_then(|color| color.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
             .unwrap_or(0xffffff.into())
     }
 
@@ -344,7 +344,7 @@ impl Borders {
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("active_font_color"))
                       .and_then(|color| color.as_string()))
-            .and_then(|s| Color::parse(s.to_string()))
+            .and_then(|s| Color::parse(s))
     }
 
     /// Gets the color for these borders.

--- a/src/layout/core/borders/borders.rs
+++ b/src/layout/core/borders/borders.rs
@@ -252,9 +252,9 @@ impl Borders {
             .and_then(|windows| windows.get("borders".into()))
             .and_then(|borders| borders.as_object()
                       .and_then(|borders| borders.get("inactive_color"))
-                      .and_then(|gaps| gaps.as_f64()))
-            .map(|num| num as u32)
-            .unwrap_or(0u32).into()
+                      .and_then(|gaps| gaps.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
+            .unwrap_or(0u32.into())
     }
 
     /// Gets the active border color, if one is set.
@@ -266,8 +266,8 @@ impl Borders {
             .and_then(|windows| windows.get("borders".into()))
             .and_then(|borders| borders.as_object()
                       .and_then(|borders| borders.get("active_color"))
-                      .and_then(|gaps| gaps.as_f64()))
-            .map(|num| (num as u32).into())
+                      .and_then(|gaps| gaps.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
     }
 
     /// Construct root borders, if the option is enabled.
@@ -300,9 +300,9 @@ impl Borders {
             .and_then(|windows| windows.get("title_bar"))
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("background_color"))
-                      .and_then(|color| color.as_f64()))
-            .map(|num| num as u32)
-            .unwrap_or(0u32).into()
+                      .and_then(|color| color.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
+            .unwrap_or(0u32.into())
     }
 
     /// Gets the active border color, if one is set
@@ -314,8 +314,8 @@ impl Borders {
             .and_then(|windows| windows.get("title_bar"))
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("active_background_color"))
-                      .and_then(|color| color.as_f64()))
-            .map(|num| (num as u32).into())
+                      .and_then(|color| color.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
     }
 
     /// Fetches the default title font color from the registry.
@@ -329,9 +329,9 @@ impl Borders {
             .and_then(|windows| windows.get("title_bar"))
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("font_color"))
-                      .and_then(|color| color.as_f64()))
-            .map(|num| num as u32)
-            .unwrap_or(0xffffff).into()
+                      .and_then(|color| color.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
+            .unwrap_or(0xffffff.into())
     }
 
     /// Gets the active title border font, if one is set
@@ -343,8 +343,8 @@ impl Borders {
             .and_then(|windows| windows.get("title_bar"))
             .and_then(|title_bar| title_bar.as_object()
                       .and_then(|title_bar| title_bar.get("active_font_color"))
-                      .and_then(|color| color.as_f64()))
-            .map(|num| (num as u32).into())
+                      .and_then(|color| color.as_string()))
+            .and_then(|s| Color::parse(s.to_string()))
     }
 
     /// Gets the color for these borders.

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -1,6 +1,8 @@
 //! Colors used for drawing to a Cairo buffer
 
 use std::convert::From;
+use std::str::Chars;
+
 
 /// Color to draw to the screen, including the alpha channel.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -14,13 +16,13 @@ pub struct Color {
 
 impl Color {
 
-    // Makes a new color with an alphachannel
-    pub fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
+    /// Creates a new color with an alphachannel
+    pub fn rgba(r: u8, g: u8, b: u8, a: u8) -> Color {
         Color {
-            red: red,
-            green: green,
-            blue: blue,
-            alpha: alpha
+            red: r,
+            green: g,
+            blue: b,
+            alpha: a
         }
     }
 
@@ -29,14 +31,301 @@ impl Color {
     pub fn values(&self) -> (u8, u8, u8, u8) {
         (self.red, self.green, self.blue, self.alpha)
     }
+
+    /// Parses a String into a Color
+    /// The following formats are supported:
+    /// - "RRGGBB"
+    /// - "AARRGGBB"
+    /// - "#RRGGBB"
+    /// - "#AARRGGBB"
+    /// - "0xRRGGBB"
+    /// - "0xAARRGGBB"
+    pub fn parse(s: String) -> Option<Color> {
+        if s.starts_with("#") {
+            Color::parse(s[1..].to_string())
+        } else if s.starts_with("0x") {
+            Color::parse(s[2..].to_string())
+        } else if s.len() == 8 {
+            Color::parse_rgba(s)
+        } else if s.len() == 6 {
+            Color::parse_rgb(s)
+        } else {
+            None
+        }
+    }
+
+    /// Parses an ARGB String into a Color
+    fn parse_rgba(s: String) -> Option<Color> {
+        if s.len() == 8 {
+            let mut chars = s.chars();
+            Color::parse_color(&mut chars)
+                .and_then(|a| Color::parse_rgb(chars.as_str().to_string())
+                    .map(|rgb| Color::rgba(rgb.red, rgb.green, rgb.blue, a)))
+        } else {
+            None
+        }
+    }
+
+    /// Parses a RGB String into a Color
+    fn parse_rgb(s: String) -> Option<Color> {
+        if s.len() == 6 {
+            let mut chars = s.chars();
+            Color::parse_color(&mut chars)
+                .and_then(|r| Color::parse_color(&mut chars)
+                    .and_then(|g| Color::parse_color(&mut chars)
+                        .map(|b| Color::rgba(r, g, b, 255))))
+        } else {
+            None
+        }
+    }
+
+    /// Parses exactly one single color value from a String (eg "AA", "RR", "GG" or "BB")
+    fn parse_color(chars: &mut Chars) -> Option<u8> {
+        chars.next().and_then(Color::hex_to_num)
+            .and_then(|i1| chars.next()
+                .and_then(Color::hex_to_num).map(|i2| (i1 << 4) | i2))
+    }
+
+    /// Converts a hex char into a number
+    fn hex_to_num(c: char) -> Option<u8>{
+        match c {
+            '0' => Some(0),
+            '1' => Some(1),
+            '2' => Some(2),
+            '3' => Some(3),
+            '4' => Some(4),
+            '5' => Some(5),
+            '6' => Some(6),
+            '7' => Some(7),
+            '8' => Some(8),
+            '9' => Some(9),
+            'a' | 'A' => Some(10),
+            'b' | 'B' => Some(11),
+            'c' | 'C' => Some(12),
+            'd' | 'D' => Some(13),
+            'e' | 'E' => Some(14),
+            'f' | 'F' => Some(15),
+             _   => None
+         }
+    }
+
 }
 
 impl From<u32> for Color {
     fn from(val: u32) -> Self {
-        let blue  =  (val & 0x000000ff) as u8;
-        let green = ((val & 0x0000ff00) >> 8) as u8;
-        let red   = ((val & 0x00ff0000) >> 16) as u8;
-        let alpha = ((val & 0xff000000) >> 24) as u8;
-        Color::rgba(red, green, blue, (255 - alpha))
+        let blue = ((val & 0xff0000) >> 16) as u8;
+        let green = ((val & 0x00ff00) >> 8) as u8;
+        let red = (val & 0x0000ff) as u8;
+        Color::rgba(red, green, blue, 255)
     }
 }
+
+mod test {
+
+    use ::render::Color;
+
+    #[test]
+    fn test_old_logic_failure() {
+        let hex_red   = 0xFF0000;
+	let hex_green = 0x00FF00;
+        let hex_blue  = 0x0000FF;
+	let r: Color = hex_red.into();
+	let g: Color = hex_green.into();
+	let b: Color = hex_blue.into();
+	// test red values
+	assert_eq!(0xFF, r.red);
+	assert_eq!(0x00, r.green);
+	assert_eq!(0x00, r.blue);
+	// test green values
+	assert_eq!(0x00, g.red);
+	assert_eq!(0xFF, g.green);
+	assert_eq!(0x00, g.blue);
+	// test blue values
+	assert_eq!(0x00, b.red);
+	assert_eq!(0x00, b.green);
+	assert_eq!(0xFF, b.blue);
+    }
+
+    #[test]
+    fn test_old_logic_working() {
+        let hex_red   = 0xFF0000;
+	let hex_green = 0x00FF00;
+        let hex_blue  = 0x0000FF;
+	let r: Color = hex_red.into();
+	let g: Color = hex_green.into();
+	let b: Color = hex_blue.into();
+	// test red values
+	assert_eq!(0x00, r.red);
+	assert_eq!(0x00, r.green);
+	assert_eq!(0xFF, r.blue);
+	// test green values
+	assert_eq!(0x00, g.red);
+	assert_eq!(0xFF, g.green);
+	assert_eq!(0x00, g.blue);
+	// test blue values
+	assert_eq!(0xFF, b.red);
+	assert_eq!(0x00, b.green);
+	assert_eq!(0x00, b.blue);
+    }
+    #[test]
+    fn parse_color() {
+        // test all numbers, uppercase and lowercase letters
+        assert_eq!(17 * 0,  Color::parse_color(&mut "00".chars()).unwrap());
+        assert_eq!(17 * 1,  Color::parse_color(&mut "11".chars()).unwrap());
+        assert_eq!(17 * 2,  Color::parse_color(&mut "22".chars()).unwrap());
+        assert_eq!(17 * 3,  Color::parse_color(&mut "33".chars()).unwrap());
+        assert_eq!(17 * 4,  Color::parse_color(&mut "44".chars()).unwrap());
+        assert_eq!(17 * 5,  Color::parse_color(&mut "55".chars()).unwrap());
+        assert_eq!(17 * 6,  Color::parse_color(&mut "66".chars()).unwrap());
+        assert_eq!(17 * 7,  Color::parse_color(&mut "77".chars()).unwrap());
+        assert_eq!(17 * 8,  Color::parse_color(&mut "88".chars()).unwrap());
+        assert_eq!(17 * 9,  Color::parse_color(&mut "99".chars()).unwrap());
+        assert_eq!(17 * 10, Color::parse_color(&mut "aa".chars()).unwrap());
+        assert_eq!(17 * 10, Color::parse_color(&mut "AA".chars()).unwrap());
+        assert_eq!(17 * 11, Color::parse_color(&mut "bb".chars()).unwrap());
+        assert_eq!(17 * 11, Color::parse_color(&mut "BB".chars()).unwrap());
+        assert_eq!(17 * 12, Color::parse_color(&mut "cc".chars()).unwrap());
+        assert_eq!(17 * 12, Color::parse_color(&mut "CC".chars()).unwrap());
+        assert_eq!(17 * 13, Color::parse_color(&mut "dd".chars()).unwrap());
+        assert_eq!(17 * 13, Color::parse_color(&mut "DD".chars()).unwrap());
+        assert_eq!(17 * 14, Color::parse_color(&mut "ee".chars()).unwrap());
+        assert_eq!(17 * 14, Color::parse_color(&mut "EE".chars()).unwrap());
+        assert_eq!(17 * 15, Color::parse_color(&mut "ff".chars()).unwrap());
+        assert_eq!(17 * 15, Color::parse_color(&mut "FF".chars()).unwrap());
+        // test a few mixed values
+        assert_eq!(00,      Color::parse_color(&mut "00".chars()).unwrap());
+        assert_eq!(50,      Color::parse_color(&mut "32".chars()).unwrap());
+        assert_eq!(100,     Color::parse_color(&mut "64".chars()).unwrap());
+        assert_eq!(150,     Color::parse_color(&mut "96".chars()).unwrap());
+        assert_eq!(200,     Color::parse_color(&mut "c8".chars()).unwrap());
+        assert_eq!(250,     Color::parse_color(&mut "fa".chars()).unwrap());
+        assert_eq!(255,     Color::parse_color(&mut "ff".chars()).unwrap());
+        // test invalid values
+        assert_eq!(false,   Color::parse_color(&mut "".chars()).is_some());
+        assert_eq!(false,   Color::parse_color(&mut "h".chars()).is_some());
+        assert_eq!(false,   Color::parse_color(&mut "h2".chars()).is_some());
+        assert_eq!(false,   Color::parse_color(&mut "yz".chars()).is_some());
+        assert_eq!(false,   Color::parse_color(&mut "3x".chars()).is_some());
+    }
+
+    #[test]
+    fn parse_rgb() {
+        // test some valid color values
+        let rgb_black = Color::parse_rgb("000000".to_string()).unwrap();
+        assert_eq!(0,   rgb_black.red);
+        assert_eq!(0,   rgb_black.green);
+        assert_eq!(0,   rgb_black.blue);
+        assert_eq!(255, rgb_black.alpha);
+        let rgb_red   = Color::parse_rgb("ff0000".to_string()).unwrap();
+        assert_eq!(255, rgb_red.red);
+        assert_eq!(0,   rgb_red.green);
+        assert_eq!(0,   rgb_red.blue);
+        assert_eq!(255, rgb_red.alpha);
+        let rgb_green = Color::parse_rgb("00ff00".to_string()).unwrap();
+        assert_eq!(0,   rgb_green.red);
+        assert_eq!(255, rgb_green.green);
+        assert_eq!(0,   rgb_green.blue);
+        assert_eq!(255, rgb_green.alpha);
+        let rgb_blue  = Color::parse_rgb("0000ff".to_string()).unwrap();
+        assert_eq!(0,   rgb_blue.red);
+        assert_eq!(0,   rgb_blue.green);
+        assert_eq!(255, rgb_blue.blue);
+        assert_eq!(255, rgb_blue.alpha);
+        let rgb_white = Color::parse_rgb("ffffff".to_string()).unwrap();
+        assert_eq!(255, rgb_white.red);
+        assert_eq!(255, rgb_white.green);
+        assert_eq!(255, rgb_white.blue);
+        assert_eq!(255, rgb_white.alpha);
+        // test invalid formats
+        assert_eq!(false, Color::parse_rgb("".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("0".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("00".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("0000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("00000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("xxxxxx".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("0000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("00000000".to_string()).is_some());
+    }
+
+    #[test]
+    fn parse_rgba() {
+        // test some valid color values
+        let rgb_transparent = Color::parse_rgba("00000000".to_string()).unwrap();
+        assert_eq!(0,   rgb_transparent.red);
+        assert_eq!(0,   rgb_transparent.green);
+        assert_eq!(0,   rgb_transparent.blue);
+        assert_eq!(0,   rgb_transparent.alpha);
+        let rgb_red   = Color::parse_rgba("40ff0000".to_string()).unwrap();
+        assert_eq!(255, rgb_red.red);
+        assert_eq!(0,   rgb_red.green);
+        assert_eq!(0,   rgb_red.blue);
+        assert_eq!(64, rgb_red.alpha);
+        let rgb_green = Color::parse_rgba("8000ff00".to_string()).unwrap();
+        assert_eq!(0,   rgb_green.red);
+        assert_eq!(255, rgb_green.green);
+        assert_eq!(0,   rgb_green.blue);
+        assert_eq!(128, rgb_green.alpha);
+        let rgb_blue  = Color::parse_rgba("c00000ff".to_string()).unwrap();
+        assert_eq!(0,   rgb_blue.red);
+        assert_eq!(0,   rgb_blue.green);
+        assert_eq!(255, rgb_blue.blue);
+        assert_eq!(192, rgb_blue.alpha);
+        let rgb_white = Color::parse_rgba("ffffffff".to_string()).unwrap();
+        assert_eq!(255, rgb_white.red);
+        assert_eq!(255, rgb_white.green);
+        assert_eq!(255, rgb_white.blue);
+        assert_eq!(255, rgb_white.alpha);
+        // test some invalid formats
+        assert_eq!(false, Color::parse_rgba("".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("0".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("00".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("0000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("00000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("0000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("xxxxxxxx".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("000000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgba("0000000000".to_string()).is_some());
+    }
+
+    #[test]
+    fn parse() {
+        // #-prefixed (HTML-style)
+        assert_eq!(true, Color::parse("#000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("#00000000".to_string()).is_some());
+        // 0x-prefixed (Hex-style)
+        assert_eq!(true, Color::parse("0x000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("0x00000000".to_string()).is_some());
+        // No prefix
+        assert_eq!(true, Color::parse("000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("00000000".to_string()).is_some());
+        // Actual colors
+        let red = Color::parse("0xFFFF0000".to_string()).unwrap();
+        assert_eq!(255, red.red);
+        assert_eq!(0,   red.green);
+        assert_eq!(0,   red.blue);
+        assert_eq!(255, red.alpha);
+        let green = Color::parse("0xFF00FF00".to_string()).unwrap();
+        assert_eq!(0,   green.red);
+        assert_eq!(255, green.green);
+        assert_eq!(0,   green.blue);
+        assert_eq!(255, green.alpha);
+        let blue = Color::parse("0xFF0000FF".to_string()).unwrap();
+        assert_eq!(0,   blue.red);
+        assert_eq!(0,   blue.green);
+        assert_eq!(255, blue.blue);
+        assert_eq!(255, blue.alpha);
+        // wrong formats
+        assert_eq!(false, Color::parse("".to_string()).is_some());
+        assert_eq!(false, Color::parse("0".to_string()).is_some());
+        assert_eq!(false, Color::parse("00".to_string()).is_some());
+        assert_eq!(false, Color::parse("000".to_string()).is_some());
+        assert_eq!(false, Color::parse("0000".to_string()).is_some());
+        assert_eq!(false, Color::parse("00000".to_string()).is_some());
+        assert_eq!(false, Color::parse("0000000".to_string()).is_some());
+    }
+
+}
+

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -1,7 +1,6 @@
 //! Colors used for drawing to a Cairo buffer
 
 use std::convert::From;
-use std::str::Chars;
 
 const WLC_BUG_INVERT_RED_BLUE: bool = true;
 
@@ -57,11 +56,13 @@ impl Color {
     /// - "#AARRGGBB"
     /// - "0xRRGGBB"
     /// - "0xAARRGGBB"
-    pub fn parse(s: String) -> Option<Color> {
+    pub fn parse(s: &str) -> Option<Color> {
         if s.starts_with("#") {
-            Color::parse(s[1..].to_string())
+            let (_, sub) = s.split_at(1);
+            Color::parse(sub)
         } else if s.starts_with("0x") {
-            Color::parse(s[2..].to_string())
+            let (_, sub) = s.split_at(2);
+            Color::parse(sub)
         } else if s.len() == 8 {
             Color::parse_argb(s)
         } else if s.len() == 6 {
@@ -72,11 +73,11 @@ impl Color {
     }
 
     /// Parses an ARGB String into a Color
-    fn parse_argb(s: String) -> Option<Color> {
+    fn parse_argb(s: &str) -> Option<Color> {
         if s.len() == 8 {
-            let mut chars = s.chars();
-            let alpha = Color::parse_color(&mut chars);
-            let color = Color::parse_rgb(chars.as_str().to_string());
+            let (str_a, str_color) = s.split_at(2);
+            let alpha = Color::parse_color(str_a);
+            let color = Color::parse_rgb(str_color);
             if WLC_BUG_INVERT_RED_BLUE {
 		// Due to the bug, the colors are already inverted, so in the returned color
                 // red is blue and blue is red.
@@ -90,12 +91,13 @@ impl Color {
     }
 
     /// Parses a RGB String into a Color
-    fn parse_rgb(s: String) -> Option<Color> {
+    fn parse_rgb(s: &str) -> Option<Color> {
         if s.len() == 6 {
-            let mut chars = s.chars();
-            let red   = Color::parse_color(&mut chars);
-            let green = Color::parse_color(&mut chars);
-            let blue  = Color::parse_color(&mut chars);
+            let (s_red, s_rest)   = s.split_at(2);
+            let (s_green, s_blue) = s_rest.split_at(2);
+            let red   = Color::parse_color(s_red);
+            let green = Color::parse_color(s_green);
+            let blue  = Color::parse_color(s_blue);
             red.and_then(|r| green.and_then(|g| blue.map(|b| Color::rgba(r, g, b, 255))))
         } else {
             None
@@ -103,15 +105,11 @@ impl Color {
     }
 
     /// Parses exactly one single color value from a String (eg "AA", "RR", "GG" or "BB")
-    fn parse_color(chars: &mut Chars) -> Option<u8> {
-        let mut next_two_chars = chars.take(2);
-        let digit1 = Color::parse_next_char(next_two_chars.next());
-        let digit2 = Color::parse_next_char(next_two_chars.next());
+    fn parse_color(s: &str) -> Option<u8> {
+        let mut chars = s.chars().take(2);
+	let digit1 = chars.next().and_then(Color::hex_to_u8);
+	let digit2 = chars.next().and_then(Color::hex_to_u8);
         digit1.and_then(|i1| digit2.map(|i2| (i1 << 4) | i2))
-    }
-
-    fn parse_next_char(c: Option<char>) -> Option<u8> {
-        c.and_then(Color::hex_to_u8)
     }
 
     /// Converts a hex char into a u8
@@ -158,161 +156,161 @@ mod test {
     #[test]
     fn parse_color() {
         // test all numbers, uppercase and lowercase letters
-        assert_eq!(17 * 0,  Color::parse_color(&mut "00".chars()).unwrap());
-        assert_eq!(17 * 1,  Color::parse_color(&mut "11".chars()).unwrap());
-        assert_eq!(17 * 2,  Color::parse_color(&mut "22".chars()).unwrap());
-        assert_eq!(17 * 3,  Color::parse_color(&mut "33".chars()).unwrap());
-        assert_eq!(17 * 4,  Color::parse_color(&mut "44".chars()).unwrap());
-        assert_eq!(17 * 5,  Color::parse_color(&mut "55".chars()).unwrap());
-        assert_eq!(17 * 6,  Color::parse_color(&mut "66".chars()).unwrap());
-        assert_eq!(17 * 7,  Color::parse_color(&mut "77".chars()).unwrap());
-        assert_eq!(17 * 8,  Color::parse_color(&mut "88".chars()).unwrap());
-        assert_eq!(17 * 9,  Color::parse_color(&mut "99".chars()).unwrap());
-        assert_eq!(17 * 10, Color::parse_color(&mut "aa".chars()).unwrap());
-        assert_eq!(17 * 10, Color::parse_color(&mut "AA".chars()).unwrap());
-        assert_eq!(17 * 11, Color::parse_color(&mut "bb".chars()).unwrap());
-        assert_eq!(17 * 11, Color::parse_color(&mut "BB".chars()).unwrap());
-        assert_eq!(17 * 12, Color::parse_color(&mut "cc".chars()).unwrap());
-        assert_eq!(17 * 12, Color::parse_color(&mut "CC".chars()).unwrap());
-        assert_eq!(17 * 13, Color::parse_color(&mut "dd".chars()).unwrap());
-        assert_eq!(17 * 13, Color::parse_color(&mut "DD".chars()).unwrap());
-        assert_eq!(17 * 14, Color::parse_color(&mut "ee".chars()).unwrap());
-        assert_eq!(17 * 14, Color::parse_color(&mut "EE".chars()).unwrap());
-        assert_eq!(17 * 15, Color::parse_color(&mut "ff".chars()).unwrap());
-        assert_eq!(17 * 15, Color::parse_color(&mut "FF".chars()).unwrap());
+        assert_eq!(17 * 0,  Color::parse_color("00").unwrap());
+        assert_eq!(17 * 1,  Color::parse_color("11").unwrap());
+        assert_eq!(17 * 2,  Color::parse_color("22").unwrap());
+        assert_eq!(17 * 3,  Color::parse_color("33").unwrap());
+        assert_eq!(17 * 4,  Color::parse_color("44").unwrap());
+        assert_eq!(17 * 5,  Color::parse_color("55").unwrap());
+        assert_eq!(17 * 6,  Color::parse_color("66").unwrap());
+        assert_eq!(17 * 7,  Color::parse_color("77").unwrap());
+        assert_eq!(17 * 8,  Color::parse_color("88").unwrap());
+        assert_eq!(17 * 9,  Color::parse_color("99").unwrap());
+        assert_eq!(17 * 10, Color::parse_color("aa").unwrap());
+        assert_eq!(17 * 10, Color::parse_color("AA").unwrap());
+        assert_eq!(17 * 11, Color::parse_color("bb").unwrap());
+        assert_eq!(17 * 11, Color::parse_color("BB").unwrap());
+        assert_eq!(17 * 12, Color::parse_color("cc").unwrap());
+        assert_eq!(17 * 12, Color::parse_color("CC").unwrap());
+        assert_eq!(17 * 13, Color::parse_color("dd").unwrap());
+        assert_eq!(17 * 13, Color::parse_color("DD").unwrap());
+        assert_eq!(17 * 14, Color::parse_color("ee").unwrap());
+        assert_eq!(17 * 14, Color::parse_color("EE").unwrap());
+        assert_eq!(17 * 15, Color::parse_color("ff").unwrap());
+        assert_eq!(17 * 15, Color::parse_color("FF").unwrap());
         // test a few mixed values
-        assert_eq!(00,      Color::parse_color(&mut "00".chars()).unwrap());
-        assert_eq!(50,      Color::parse_color(&mut "32".chars()).unwrap());
-        assert_eq!(100,     Color::parse_color(&mut "64".chars()).unwrap());
-        assert_eq!(150,     Color::parse_color(&mut "96".chars()).unwrap());
-        assert_eq!(200,     Color::parse_color(&mut "c8".chars()).unwrap());
-        assert_eq!(250,     Color::parse_color(&mut "fa".chars()).unwrap());
-        assert_eq!(255,     Color::parse_color(&mut "ff".chars()).unwrap());
+        assert_eq!(00,      Color::parse_color("00").unwrap());
+        assert_eq!(50,      Color::parse_color("32").unwrap());
+        assert_eq!(100,     Color::parse_color("64").unwrap());
+        assert_eq!(150,     Color::parse_color("96").unwrap());
+        assert_eq!(200,     Color::parse_color("c8").unwrap());
+        assert_eq!(250,     Color::parse_color("fa").unwrap());
+        assert_eq!(255,     Color::parse_color("ff").unwrap());
         // test invalid values
-        assert_eq!(false,   Color::parse_color(&mut "".chars()).is_some());
-        assert_eq!(false,   Color::parse_color(&mut "h".chars()).is_some());
-        assert_eq!(false,   Color::parse_color(&mut "h2".chars()).is_some());
-        assert_eq!(false,   Color::parse_color(&mut "yz".chars()).is_some());
-        assert_eq!(false,   Color::parse_color(&mut "3x".chars()).is_some());
+        assert_eq!(false,   Color::parse_color("").is_some());
+        assert_eq!(false,   Color::parse_color("h").is_some());
+        assert_eq!(false,   Color::parse_color("h2").is_some());
+        assert_eq!(false,   Color::parse_color("yz").is_some());
+        assert_eq!(false,   Color::parse_color("3x").is_some());
     }
 
     #[test]
     fn parse_rgb() {
         // test some valid color values
-        let rgb_black = Color::parse_rgb("000000".to_string()).unwrap();
+        let rgb_black = Color::parse_rgb("000000").unwrap();
         assert_eq!(0,   rgb_black.red);
         assert_eq!(0,   rgb_black.green);
         assert_eq!(0,   rgb_black.blue);
         assert_eq!(255, rgb_black.alpha);
-        let rgb_red   = Color::parse_rgb("ff0000".to_string()).unwrap();
+        let rgb_red   = Color::parse_rgb("ff0000").unwrap();
         assert_eq!(0,   rgb_red.red);
         assert_eq!(0,   rgb_red.green);
         assert_eq!(255, rgb_red.blue);
         assert_eq!(255, rgb_red.alpha);
-        let rgb_green = Color::parse_rgb("00ff00".to_string()).unwrap();
+        let rgb_green = Color::parse_rgb("00ff00").unwrap();
         assert_eq!(0,   rgb_green.red);
         assert_eq!(255, rgb_green.green);
         assert_eq!(0,   rgb_green.blue);
         assert_eq!(255, rgb_green.alpha);
-        let rgb_blue  = Color::parse_rgb("0000ff".to_string()).unwrap();
+        let rgb_blue  = Color::parse_rgb("0000ff").unwrap();
         assert_eq!(255, rgb_blue.red);
         assert_eq!(0,   rgb_blue.green);
         assert_eq!(0,   rgb_blue.blue);
         assert_eq!(255, rgb_blue.alpha);
-        let rgb_white = Color::parse_rgb("ffffff".to_string()).unwrap();
+        let rgb_white = Color::parse_rgb("ffffff").unwrap();
         assert_eq!(255, rgb_white.red);
         assert_eq!(255, rgb_white.green);
         assert_eq!(255, rgb_white.blue);
         assert_eq!(255, rgb_white.alpha);
         // test invalid formats
-        assert_eq!(false, Color::parse_rgb("".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("0".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("00".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("000".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("0000".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("00000".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("xxxxxx".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("0000000".to_string()).is_some());
-        assert_eq!(false, Color::parse_rgb("00000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_rgb("").is_some());
+        assert_eq!(false, Color::parse_rgb("0").is_some());
+        assert_eq!(false, Color::parse_rgb("00").is_some());
+        assert_eq!(false, Color::parse_rgb("000").is_some());
+        assert_eq!(false, Color::parse_rgb("0000").is_some());
+        assert_eq!(false, Color::parse_rgb("00000").is_some());
+        assert_eq!(false, Color::parse_rgb("xxxxxx").is_some());
+        assert_eq!(false, Color::parse_rgb("0000000").is_some());
+        assert_eq!(false, Color::parse_rgb("00000000").is_some());
     }
 
     #[test]
     fn parse_argb() {
         // test some valid color values
-        let rgb_transparent = Color::parse_argb("00000000".to_string()).unwrap();
+        let rgb_transparent = Color::parse_argb("00000000").unwrap();
         assert_eq!(0,   rgb_transparent.red);
         assert_eq!(0,   rgb_transparent.green);
         assert_eq!(0,   rgb_transparent.blue);
         assert_eq!(0,   rgb_transparent.alpha);
-        let rgb_red   = Color::parse_argb("40ff0000".to_string()).unwrap();
+        let rgb_red   = Color::parse_argb("40ff0000").unwrap();
         assert_eq!(0,   rgb_red.red);
         assert_eq!(0,   rgb_red.green);
         assert_eq!(255, rgb_red.blue);
         assert_eq!(64,  rgb_red.alpha);
-        let rgb_green = Color::parse_argb("8000ff00".to_string()).unwrap();
+        let rgb_green = Color::parse_argb("8000ff00").unwrap();
         assert_eq!(0,   rgb_green.red);
         assert_eq!(255, rgb_green.green);
         assert_eq!(0,   rgb_green.blue);
         assert_eq!(128, rgb_green.alpha);
-        let rgb_blue  = Color::parse_argb("c00000ff".to_string()).unwrap();
+        let rgb_blue  = Color::parse_argb("c00000ff").unwrap();
         assert_eq!(255, rgb_blue.red);
         assert_eq!(0,   rgb_blue.green);
         assert_eq!(0,   rgb_blue.blue);
         assert_eq!(192, rgb_blue.alpha);
-        let rgb_white = Color::parse_argb("ffffffff".to_string()).unwrap();
+        let rgb_white = Color::parse_argb("ffffffff").unwrap();
         assert_eq!(255, rgb_white.red);
         assert_eq!(255, rgb_white.green);
         assert_eq!(255, rgb_white.blue);
         assert_eq!(255, rgb_white.alpha);
         // test some invalid formats
-        assert_eq!(false, Color::parse_argb("".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("0".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("00".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("0000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("00000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("000000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("0000000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("xxxxxxxx".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("000000000".to_string()).is_some());
-        assert_eq!(false, Color::parse_argb("0000000000".to_string()).is_some());
+        assert_eq!(false, Color::parse_argb("").is_some());
+        assert_eq!(false, Color::parse_argb("0").is_some());
+        assert_eq!(false, Color::parse_argb("00").is_some());
+        assert_eq!(false, Color::parse_argb("000").is_some());
+        assert_eq!(false, Color::parse_argb("0000").is_some());
+        assert_eq!(false, Color::parse_argb("00000").is_some());
+        assert_eq!(false, Color::parse_argb("000000").is_some());
+        assert_eq!(false, Color::parse_argb("0000000").is_some());
+        assert_eq!(false, Color::parse_argb("xxxxxxxx").is_some());
+        assert_eq!(false, Color::parse_argb("000000000").is_some());
+        assert_eq!(false, Color::parse_argb("0000000000").is_some());
     }
 
     #[test]
     fn parse() {
         // #-prefixed (HTML-style)
-        assert_eq!(true, Color::parse("#000000".to_string()).is_some());
-        assert_eq!(true, Color::parse("#00000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("#000000").is_some());
+        assert_eq!(true, Color::parse("#00000000").is_some());
         // 0x-prefixed (Hex-style)
-        assert_eq!(true, Color::parse("0x000000".to_string()).is_some());
-        assert_eq!(true, Color::parse("0x00000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("0x000000").is_some());
+        assert_eq!(true, Color::parse("0x00000000").is_some());
         // No prefix
-        assert_eq!(true, Color::parse("000000".to_string()).is_some());
-        assert_eq!(true, Color::parse("00000000".to_string()).is_some());
+        assert_eq!(true, Color::parse("000000").is_some());
+        assert_eq!(true, Color::parse("00000000").is_some());
         // Actual colors
-        let red = Color::parse("0xFFFF0000".to_string()).unwrap();
+        let red = Color::parse("0xFFFF0000").unwrap();
         assert_eq!(0,   red.red);
         assert_eq!(0,   red.green);
         assert_eq!(255, red.blue);
         assert_eq!(255, red.alpha);
-        let green = Color::parse("0xFF00FF00".to_string()).unwrap();
+        let green = Color::parse("0xFF00FF00").unwrap();
         assert_eq!(0,   green.red);
         assert_eq!(255, green.green);
         assert_eq!(0,   green.blue);
         assert_eq!(255, green.alpha);
-        let blue = Color::parse("0xFF0000FF".to_string()).unwrap();
+        let blue = Color::parse("0xFF0000FF").unwrap();
         assert_eq!(255, blue.red);
         assert_eq!(0,   blue.green);
         assert_eq!(0,   blue.blue);
         assert_eq!(255, blue.alpha);
         // wrong formats
-        assert_eq!(false, Color::parse("".to_string()).is_some());
-        assert_eq!(false, Color::parse("0".to_string()).is_some());
-        assert_eq!(false, Color::parse("00".to_string()).is_some());
-        assert_eq!(false, Color::parse("000".to_string()).is_some());
-        assert_eq!(false, Color::parse("0000".to_string()).is_some());
-        assert_eq!(false, Color::parse("00000".to_string()).is_some());
-        assert_eq!(false, Color::parse("0000000".to_string()).is_some());
+        assert_eq!(false, Color::parse("").is_some());
+        assert_eq!(false, Color::parse("0").is_some());
+        assert_eq!(false, Color::parse("00").is_some());
+        assert_eq!(false, Color::parse("000").is_some());
+        assert_eq!(false, Color::parse("0000").is_some());
+        assert_eq!(false, Color::parse("00000").is_some());
+        assert_eq!(false, Color::parse("0000000").is_some());
     }
 
 }

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -13,13 +13,14 @@ pub struct Color {
 
 
 impl Color {
-    /// Makes a new solid color, with no transparency.
-    pub fn solid_color(red: u8, green: u8, blue: u8) -> Self {
+
+    // Makes a new color with an alphachannel
+    pub fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
         Color {
             red: red,
             green: green,
             blue: blue,
-            alpha: 255
+            alpha: alpha
         }
     }
 
@@ -32,9 +33,10 @@ impl Color {
 
 impl From<u32> for Color {
     fn from(val: u32) -> Self {
-        let blue = ((val & 0xff0000) >> 16) as u8;
-        let green = ((val & 0x00ff00) >> 8) as u8;
-        let red = (val & 0x0000ff) as u8;
-        Color::solid_color(red, green, blue)
+        let blue  =  (val & 0x000000ff) as u8;
+        let green = ((val & 0x0000ff00) >> 8) as u8;
+        let red   = ((val & 0x00ff0000) >> 16) as u8;
+        let alpha = ((val & 0xff000000) >> 24) as u8;
+        Color::rgba(red, green, blue, (255 - alpha))
     }
 }


### PR DESCRIPTION
Hi

This patch will allow ARGB values to be defined:

* `0xbbggrr` - Normal (non-transparent) color (still works)
* `0xaabbggrr` - Transparent color

That's also the reason I chose ARGB over RGBA - it makes parsing the value very simple. This way, I can just parse the u32, and don't have to look at the original string (eg. the alpha bits are optional).

Looking at the string would have some advantages however:
* Distinct between formats like: "0xrgb", "0xrrggbb" and "0xaarrggbb"
* Allow different parsing methods for different formats

I think this could be adressed in a later patch, with a notice communicated to the users.

I've noticed, the colors in the hex value are defined as `0xbbggrr` - which is a bit weird - but I didn't want to change it yet, as it breaks backwards-compatibility with old config files (users probably will be confused when their colors suddenly look different). Thus, I haven't changed it. Swapping `red` and `blue` in `from` would easily fix this.

Thank you all for developing this software, its very fun to use and simple to set up!
