### PR TITLE
WIP: Run a Glib main loop (GMainLoop)

### DIFF
--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -1,6 +1,6 @@
 //! AwesomeWM Keygrabber interface
 
-use ::lua::LUA;
+use ::lua::run_with_lua;
 use rlua::{self, Lua, Table, Function, Value};
 use rustwlc::*;
 #[allow(deprecated)]
@@ -29,26 +29,24 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 /// defined with the input.
 pub fn keygrabber_handle(mods: KeyboardModifiers, sym: Keysym, state: KeyState)
                          -> rlua::Result<()> {
-    let lua = LUA.lock()
-        .map_err(|err| rlua::Error::RuntimeError(
-            format!("Lua lock was poisoned {:#?}", err)))?;
-    let lua_state = if state == KeyState::Pressed {
-        "press"
-    } else {
-        "release"
-    }.into();
-    let lua_sym = sym.get_name()
-        .ok_or_else(|| rlua::Error::RuntimeError(
-                 format!("Symbol did not have a name: {:#?}", sym)))?;
-    let lua_mods = ::lua::mods_to_lua(&lua.0, mods.mods)?;
-    let res = call_keygrabber(&lua.0, (lua_mods, lua_sym, lua_state));
-    match res {
-        Ok(_) | Err(rlua::Error::FromLuaConversionError { .. }) => {Ok(())},
-        err => {
-            err
+    run_with_lua(move |lua| {
+        let lua_state = if state == KeyState::Pressed {
+            "press"
+        } else {
+            "release"
+        }.into();
+        let lua_sym = sym.get_name()
+            .ok_or_else(|| rlua::Error::RuntimeError(
+                     format!("Symbol did not have a name: {:#?}", sym)))?;
+        let lua_mods = ::lua::mods_to_lua(lua, mods.mods)?;
+        let res = call_keygrabber(lua, (lua_mods, lua_sym, lua_state));
+        match res {
+            Ok(_) | Err(rlua::Error::FromLuaConversionError { .. }) => {Ok(())},
+            err => {
+                err
+            }
         }
-    }
-
+    })
 }
 
 /// Call the Lua callback function for when a key is pressed.

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -18,10 +18,11 @@ unsafe impl Send for LuaWrapper{}
 
 
 lazy_static! {
-    pub static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
+    // XXX: The Mutex is not actually needed. The Lua state will be thread-local to the Lua thread.
+    static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
 }
 
 pub use self::types::{LuaQuery, LuaResponse};
 pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
-                       LuaSendError};
+                       run_with_lua, LuaSendError};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -1,8 +1,5 @@
 //! Lua functionality
 
-use rlua::Lua;
-use std::sync::Mutex;
-
 #[cfg(test)]
 mod tests;
 
@@ -12,15 +9,6 @@ mod rust_interop;
 mod init_path;
 mod utils;
 
-pub struct LuaWrapper(pub Lua);
-
-unsafe impl Send for LuaWrapper{}
-
-
-lazy_static! {
-    // XXX: The Mutex is not actually needed. The Lua state will be thread-local to the Lua thread.
-    static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
-}
 
 pub use self::types::{LuaQuery, LuaResponse};
 pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -88,6 +88,16 @@ pub fn update_registry_value(category: String) {
     queue.push(category);
 }
 
+// Reexported in lua/mod.rs
+/// Run a closure with the Lua state. The closure will execute in the Lua thread.
+pub fn run_with_lua<F, G>(func: F) -> G
+    where F: FnOnce(&mut rlua::Lua) -> G
+{
+    let mut lua = LUA.lock().expect("LUA was poisoned!");
+    let lua = &mut lua.0;
+    func(lua)
+}
+
 // Reexported in lua/mod.rs:11
 /// Attemps to send a LuaQuery to the Lua thread.
 pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {

--- a/src/lua/types.rs
+++ b/src/lua/types.rs
@@ -23,6 +23,8 @@ pub enum LuaQuery {
     ExecFile(String),
     /// Execute some Rust using the Lua context.
     ExecRust(fn(&mut rlua::Lua) -> rlua::Value<'static>),
+    /// Execute some Rust using the Lua context.
+    ExecWithLua(Box<FnMut(&mut rlua::Lua) -> rlua::Result<()>>),
 
     /// Handle the key press for the given key.
     HandleKey(KeyPress),
@@ -45,6 +47,8 @@ impl Debug for LuaQuery {
             // and why we have lua/types.rs
             LuaQuery::ExecRust(_) =>
                 write!(f, "LuaQuery::ExecRust()"),
+            LuaQuery::ExecWithLua(_) =>
+                write!(f, "LuaQuery::ExecWithLua()"),
             LuaQuery::HandleKey(ref press) =>
                 write!(f, "LuaQuery::HandleKey({:?})", press),
             LuaQuery::UpdateRegistryFromCache =>

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -288,9 +288,6 @@ fn send_to_lua<Q: Into<String>>(msg: Q) {
         Ok(_) => {},
         Err(LuaSendError::Sender(err)) =>
             warn!("Error while executing {:?}: {:?}", msg, err),
-        Err(LuaSendError::ThreadUninitialized) =>
-            warn!("Thread was not initilazed yet, could not execute {:?}",
-                   msg),
         Err(LuaSendError::ThreadClosed) => {
             warn!("Thread closed, could not execute {:?}", msg)
         }


### PR DESCRIPTION
GLib provides a default GMainContext (`g_main_context_default`). Awesome's Lua code accesses this directly through LGI for things, e.g. `gears.timer.start_new`. However, this only works if a GMainLoop is actually running for the default context. Thus, if way-cooler wants to be compatible with awesome's Lua code, it needs to run a GMainLoop.

Lua by itself is not thread-safe. Thus, LGI implements locking and automatically locks/unlock stuff at the C/Lua transition. However, LGI cannot detect the Lua->C transition that happens when way-cooler loads the `rc.lua` and then at the end continues running. Thus, from LGI's point-of-view, it is still in Lua-land and so its mutex is locked. Thus, LGI must be loaded from the same thread that will also run the main loop (since the mutex is recursive; aka can be locked multiple times by the same thread).

The above considerations resulted in this patch series.

- The first commit unexports the LUA global so that it can be enforced that only one thread every runs Lua code.
- The second commit actually changes the API added in the previous commit to switch to the Lua thread. This is a separate commit since I had quite some problems in getting this to work and the resulting code is bad (especially the error handling, aka `unwrap()`)
- The next commit only happened accidentally, because without it the following commit would not work (the main thread tries to `send()` to the Lua thread immediately after starting it, but `send()` does not work yet because `RUNNING` is still `false` => panic). This is just a (bad) work-around which a later commit (silently) reverts.
- Next, Lua initialisation is actually moved to the thread running Lua code.
- The following commit switches to using `GMainLoop`. This also reverts the removal of `RUNNING` and instead removes `SENDER` (since `std::sync::mpsc` cannot easily be polled inside a `GMainLoop`).
- The last commit happened because I wanted to get rid of the LUA global. It is only accessed from the Lua thread and so I thought I could get away with a a `thread_local!`. Well... some banging my head against `rustc` later I gave up and instead "only" moved the `LUA` global into the only module using it.

This PR was only lightly tested, mainly by "does `require("gears.timer").start_new(function() print("I live!") return true end)` work?" and by "is there a deadlock?" (I'm actually surprised by how many deadlocks I encountered along the way and how long it took me to figure out what I just wrote in the second paragraph of this text about "LGI's lock is never unlocked"). Also, the resulting code feels "wrong/bad" to me. I'd be happy for suggestions on how to improve this.

If you want to, you can merge this (and just commit follow up commits to make the code less ugly (`run_with_lua`, the introduction of a new (untested) `ExecWithLua`, ...)). However, I feel bad for even proposing this and am quite unhappy with some of the ugliness lurking in here.

NOTE: While writing the above it occurred to me: I'm not actually sure if `send()` is still order-preserving, aka earlier `send()`s are handled before later ones. I guess it is, but if this might be a problem, please tell me to double-check.

NOTE: Calling `g_source_attach` from other threads is actually documented as being safe:

>  A GMainContext can only be running in a single thread, but sources can be added to it and removed from it from other threads.

https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#glib-The-Main-Event-Loop.description

Edit: Some docs on LGI's mutex: https://github.com/pavouk/lgi/blob/master/docs/guide.md#6-threading-and-synchronization