### PR TITLE
Glib main loop fixes

### DIFF
--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -1,6 +1,6 @@
 //! AwesomeWM Keygrabber interface
 
-use ::lua::LUA;
+use ::lua::run_with_lua;
 use rlua::{self, Lua, Table, Function, Value};
 use rustwlc::*;
 #[allow(deprecated)]
@@ -29,26 +29,24 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 /// defined with the input.
 pub fn keygrabber_handle(mods: KeyboardModifiers, sym: Keysym, state: KeyState)
                          -> rlua::Result<()> {
-    let lua = LUA.lock()
-        .map_err(|err| rlua::Error::RuntimeError(
-            format!("Lua lock was poisoned {:#?}", err)))?;
-    let lua_state = if state == KeyState::Pressed {
-        "press"
-    } else {
-        "release"
-    }.into();
-    let lua_sym = sym.get_name()
-        .ok_or_else(|| rlua::Error::RuntimeError(
-                 format!("Symbol did not have a name: {:#?}", sym)))?;
-    let lua_mods = ::lua::mods_to_lua(&lua.0, mods.mods)?;
-    let res = call_keygrabber(&lua.0, (lua_mods, lua_sym, lua_state));
-    match res {
-        Ok(_) | Err(rlua::Error::FromLuaConversionError { .. }) => {Ok(())},
-        err => {
-            err
+    run_with_lua(move |lua| {
+        let lua_state = if state == KeyState::Pressed {
+            "press"
+        } else {
+            "release"
+        }.into();
+        let lua_sym = sym.get_name()
+            .ok_or_else(|| rlua::Error::RuntimeError(
+                     format!("Symbol did not have a name: {:#?}", sym)))?;
+        let lua_mods = ::lua::mods_to_lua(lua, mods.mods)?;
+        let res = call_keygrabber(lua, (lua_mods, lua_sym, lua_state));
+        match res {
+            Ok(_) | Err(rlua::Error::FromLuaConversionError { .. }) => {Ok(())},
+            err => {
+                err
+            }
         }
-    }
-
+    })
 }
 
 /// Call the Lua callback function for when a key is pressed.

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -18,10 +18,11 @@ unsafe impl Send for LuaWrapper{}
 
 
 lazy_static! {
-    pub static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
+    // XXX: The Mutex is not actually needed. The Lua state will be thread-local to the Lua thread.
+    static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
 }
 
 pub use self::types::{LuaQuery, LuaResponse};
 pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
-                       LuaSendError};
+                       run_with_lua, LuaSendError};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -1,8 +1,5 @@
 //! Lua functionality
 
-use rlua::Lua;
-use std::sync::Mutex;
-
 #[cfg(test)]
 mod tests;
 
@@ -12,15 +9,6 @@ mod rust_interop;
 mod init_path;
 mod utils;
 
-pub struct LuaWrapper(pub Lua);
-
-unsafe impl Send for LuaWrapper{}
-
-
-lazy_static! {
-    // XXX: The Mutex is not actually needed. The Lua state will be thread-local to the Lua thread.
-    static ref LUA: Mutex<LuaWrapper> = Mutex::new(LuaWrapper(Lua::new()));
-}
 
 pub use self::types::{LuaQuery, LuaResponse};
 pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -11,6 +11,6 @@ mod utils;
 
 
 pub use self::types::{LuaQuery, LuaResponse};
-pub use self::thread::{on_compositor_ready, running, send, update_registry_value,
+pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
                        run_with_lua, LuaSendError};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -11,6 +11,6 @@ mod utils;
 
 
 pub use self::types::{LuaQuery, LuaResponse};
-pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
+pub use self::thread::{on_compositor_ready, running, send, update_registry_value,
                        run_with_lua, LuaSendError};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -18,7 +18,7 @@ use super::thread::{update_registry_value};
 /// We've `include!`d the code which initializes from the Lua side.
 
 /// Register all the Rust functions for the lua libraries
-pub fn register_libraries(lua: &mut rlua::Lua) -> LuaResult<()> {
+pub fn register_libraries(lua: &rlua::Lua) -> LuaResult<()> {
     trace!("Registering Rust libraries...");
     {
         let rust_table = lua.create_table();

--- a/src/lua/tests.rs
+++ b/src/lua/tests.rs
@@ -19,7 +19,7 @@ fn wait_for_thread() {
 
 #[test]
 fn activate_thread() {
-    super::init().unwrap();
+    super::init();
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn test_rust_exec() {
     }
 }
 
-fn rust_lua_fn(lua: &mut Lua) -> rlua::Value<'static> {
+fn rust_lua_fn(lua: &Lua) -> rlua::Value<'static> {
     {
         let globals = lua.globals();
         let foo = lua.create_table();

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -88,6 +88,16 @@ pub fn update_registry_value(category: String) {
     queue.push(category);
 }
 
+// Reexported in lua/mod.rs
+/// Run a closure with the Lua state. The closure will execute in the Lua thread.
+pub fn run_with_lua<F, G>(func: F) -> G
+    where F: FnOnce(&mut rlua::Lua) -> G
+{
+    let mut lua = LUA.lock().expect("LUA was poisoned!");
+    let lua = &mut lua.0;
+    func(lua)
+}
+
 // Reexported in lua/mod.rs:11
 /// Attemps to send a LuaQuery to the Lua thread.
 pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -1,7 +1,5 @@
 //! Code for the internal Lua thread which handles all Lua requests.
 
-extern crate glib;
-
 use std::collections::btree_map::BTreeMap;
 use std::thread;
 use std::fs::{File};

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -139,7 +139,7 @@ pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {
 }
 
 /// Initialize the Lua thread.
-pub fn init() -> Result<(), rlua::Error> {
+fn init() {
     info!("Starting Lua thread...");
     RUNNING.store(true, Ordering::Relaxed);
     let _lua_handle = thread::Builder::new()
@@ -161,14 +161,12 @@ pub fn init() -> Result<(), rlua::Error> {
                 .expect("Could not focus on the focused id");
         }
     }
-    Ok(())
 }
 
 pub fn on_compositor_ready() {
     info!("Running lua on_init()");
     // Call the special init hook function that we read from the init file
-    ::lua::init()
-        .expect("Could not initialize lua thread!");
+    init();
     send(LuaQuery::Execute(INIT_LUA_FUNC.to_owned())).err()
         .map(|error| warn!("Lua init callback returned an error: {:?}", error));
 }
@@ -279,7 +277,7 @@ fn handle_message(request: LuaMessage, lua: &rlua::Lua) -> bool {
             let _new_handle = thread::Builder::new()
                 .name("Lua re-init".to_string())
                 .spawn(move || {
-                    init().expect("Could not init");
+                    init();
                     keys::init();
                 });
 

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -142,7 +142,7 @@ pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {
 }
 
 /// Initialize the Lua thread.
-fn init() {
+pub fn init() {
     info!("Starting Lua thread...");
     RUNNING.store(true, Ordering::Relaxed);
     let _lua_handle = thread::Builder::new()

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::fs::{File};
 use std::path::Path;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Sender, Receiver};
@@ -113,12 +113,9 @@ pub fn run_with_lua<F>(func: F) -> rlua::Result<()>
 fn idle_add_once<F>(func: F)
     where F: Send + 'static + FnOnce() -> ()
 {
-    let cell = RefCell::new(Some(func));
+    let mut cell = Cell::new(Some(func));
     idle_add(move || {
-        match cell.borrow_mut().take() {
-            Some(f) => f(),
-            None => { panic!("The impossible happened"); }
-        };
+        (&mut cell).get_mut().take().unwrap()();
         Continue(false)
     });
 }

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -138,9 +138,6 @@ pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {
 
 /// Initialize the Lua thread.
 pub fn init() -> Result<(), rlua::Error> {
-    {
-        LUA.with(|lua| rust_interop::register_libraries(&*lua.borrow()))?;
-    }
     info!("Starting Lua thread...");
     RUNNING.store(true, Ordering::Relaxed);
     let _lua_handle = thread::Builder::new()
@@ -243,6 +240,8 @@ fn lua_init() {
 /// * Initialise the Lua state
 /// * Run a GMainLoop
 fn main_loop() {
+    LUA.with(|lua| rust_interop::register_libraries(&*lua.borrow()))
+        .expect("Could not register lua libraries");
     lua_init();
     MainLoop::new(None, false).run();
     RUNNING.store(false, Ordering::Relaxed);

--- a/src/lua/types.rs
+++ b/src/lua/types.rs
@@ -23,6 +23,8 @@ pub enum LuaQuery {
     ExecFile(String),
     /// Execute some Rust using the Lua context.
     ExecRust(fn(&mut rlua::Lua) -> rlua::Value<'static>),
+    /// Execute some Rust using the Lua context.
+    ExecWithLua(Box<FnMut(&mut rlua::Lua) -> rlua::Result<()>>),
 
     /// Handle the key press for the given key.
     HandleKey(KeyPress),
@@ -45,6 +47,8 @@ impl Debug for LuaQuery {
             // and why we have lua/types.rs
             LuaQuery::ExecRust(_) =>
                 write!(f, "LuaQuery::ExecRust()"),
+            LuaQuery::ExecWithLua(_) =>
+                write!(f, "LuaQuery::ExecWithLua()"),
             LuaQuery::HandleKey(ref press) =>
                 write!(f, "LuaQuery::HandleKey({:?})", press),
             LuaQuery::UpdateRegistryFromCache =>

--- a/src/lua/types.rs
+++ b/src/lua/types.rs
@@ -22,9 +22,9 @@ pub enum LuaQuery {
     /// Execute a file
     ExecFile(String),
     /// Execute some Rust using the Lua context.
-    ExecRust(fn(&mut rlua::Lua) -> rlua::Value<'static>),
+    ExecRust(fn(&rlua::Lua) -> rlua::Value<'static>),
     /// Execute some Rust using the Lua context.
-    ExecWithLua(Box<FnMut(&mut rlua::Lua) -> rlua::Result<()>>),
+    ExecWithLua(Box<FnMut(&rlua::Lua) -> rlua::Result<()>>),
 
     /// Handle the key press for the given key.
     HandleKey(KeyPress),

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -288,9 +288,6 @@ fn send_to_lua<Q: Into<String>>(msg: Q) {
         Ok(_) => {},
         Err(LuaSendError::Sender(err)) =>
             warn!("Error while executing {:?}: {:?}", msg, err),
-        Err(LuaSendError::ThreadUninitialized) =>
-            warn!("Thread was not initilazed yet, could not execute {:?}",
-                   msg),
         Err(LuaSendError::ThreadClosed) => {
             warn!("Thread closed, could not execute {:?}", msg)
         }

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -286,8 +286,6 @@ fn send_to_lua<Q: Into<String>>(msg: Q) {
     let msg = msg.into();
     match lua::send(LuaQuery::Execute(msg.clone())) {
         Ok(_) => {},
-        Err(LuaSendError::Sender(err)) =>
-            warn!("Error while executing {:?}: {:?}", msg, err),
         Err(LuaSendError::ThreadClosed) => {
             warn!("Thread closed, could not execute {:?}", msg)
         }


### PR DESCRIPTION
Continuation of #472.

Main thing this adds is a glib main loop so that we can let Lua access things directly through LGI just like awesome.

This fixes the segfault issue and some other issues in the previous PR.

This changes how the Lua thread is restarted. There might be bugs with it, but with my limited testing it seems correct.

To test, add this to the init file (assuming you have Awesome installed):

```lua
require("gears").timer.start_new(1, function() print "I live!" return true end)
```