### PR TITLE
screen: Fix screen index method

### DIFF
--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -225,7 +225,7 @@ fn index<'lua>(lua: &'lua Lua,
                     format!("invalid screen number: {} (of {} existing)",
                             screen_index, screens.len())))
             }
-            return screens[screen_index as usize].get_table().clone().to_lua(lua).clone()
+            return screens[(screen_index - 1) as usize].get_table().clone().to_lua(lua).clone()
         },
         Value::Table(ref table) => {
             // If this is a screen, just return it


### PR DESCRIPTION
Before this, screen[1] caused a panic:

  thread 'Lua thread' panicked at 'index out of bounds: the len is 1 but
  the index is 1', src/liballoc/vec.rs:1552:10

Signed-off-by: Uli Schlachter <psychon@znc.in>