### PR TITLE
Fix drawin_geometry() to behave like in awesome

### DIFF
--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -177,7 +177,7 @@ fn drawin_geometry<'lua>(lua: &'lua Lua, (drawin, geometry): (Table<'lua>, Optio
         let h = geometry.get::<_, i32>("height")?;
         let x = geometry.get::<_, i32>("x")?;
         let y = geometry.get::<_, i32>("y")?;
-        if x > 0 && y > 0 {
+        if w > 0 && h > 0 {
             let geo = Geometry {
                 origin: Point { x, y },
                 size: Size { w: w as u32, h: h as u32 }


### PR DESCRIPTION
...and this took me way too long to spot, even after staring at this
exact piece of code.

What happens is: Since there is only one screen, Lua does of course
place the wibar at position 0x0. It correctly ends up at this position
since it is the default, but it also ends up with a size of zero...

Signed-off-by: Uli Schlachter <psychon@znc.in>