### PR TITLE
xrdb_get_value: Don't pretend DPI is one

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -277,11 +277,8 @@ fn xkb_get_layout_group<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>
     }
 }
 
-fn xrdb_get_value(lua: &Lua, (_resource_class, resource_name): (String, String))
+fn xrdb_get_value(_lua: &Lua, (_resource_class, _resource_name): (String, String))
                   -> rlua::Result<Value> {
-    if &resource_name == "Xft.dpi" {
-        return Ok("1".to_lua(lua)?)
-    }
     warn!("xrdb_get_value not supported");
     Ok(Value::Nil)
 }


### PR DESCRIPTION
...and I was wondering why drawing fonts didn't work and the default
config constructed a tiny wibar.

The code in awesome can (and has to) handle a missing "Xft.dpi" value.
It does so by falling by to compute a DPI value via root.size() and
root.size_mm(). Since that doesn't produce useful values either, it just
falls back to a hardcoded 96. That produces way saner results than
trying to display text with 1 dot per inch. That's just too low-res.

This effectively reverts commit 4480fbc794ddcb4e5d1a659fca7b.

Signed-off-by: Uli Schlachter <psychon@znc.in>