### PR TITLE
Fix drawin resizing their drawable incorrectly

### DIFF
--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -95,10 +95,11 @@ impl <'lua> Drawin<'lua> {
             state.geometry.size.h = old_geometry.size.h
         }
         state.geometry_dirty = true;
-        self.update_drawing()?;
         // TODO emit signals
         // TODO update screen workareas like in awesome? Might not be necessary
-        self.set_state(state)
+        // TODO Currently have to call set_state() before update_drawing; change that
+        self.set_state(state)?;
+        self.update_drawing()
     }
 }
 


### PR DESCRIPTION
In a drawin's resize() method, the function update_drawing() (which
resizes the drawable) was called before the new state of the drawin was
set. This meant that the drawable was resized to the old size of the
drawin and not the new one.

Fix this by swapping the two calls.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-------

Let's just fix this piece of code for now before we tackle the general problem of "the state pattern encourages this kind of mistake".