### PR TITLE
Remove lua::running()

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -195,9 +195,7 @@ fn xkb_get_group_names<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>>
 /// Restart Awesome by restarting the Lua thread
 fn restart<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
     use lua::{self, LuaQuery};
-    if let Err(err) = lua::send(LuaQuery::Restart) {
-        warn!("Could not restart Lua thread {:#?}", err);
-    }
+    lua::send(LuaQuery::Restart);
     Ok(())
 }
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -144,7 +144,7 @@ pub extern fn compositor_ready() {
 
 pub extern fn compositor_terminating() {
     info!("Compositor terminating!");
-    lua::send(lua::LuaQuery::Terminate).ok();
+    lua::send(lua::LuaQuery::Terminate);
     if let Ok(mut tree) = try_lock_tree() {
         tree.destroy_tree().unwrap_or_else(|err|
             error!("Could not destroy tree: {:#?}", err)

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -124,8 +124,7 @@ fn print_pointer() {
                 local x, y = wm.pointer.get_position()\n\
                 print('The cursor is at ' .. x .. ', ' .. y)\n\
                 end".to_string();
-    lua::send(LuaQuery::Execute(code))
-        .expect("Error telling Lua to get pointer coords");
+    lua::send(LuaQuery::Execute(code));
 }
 
 fn way_cooler_quit() {
@@ -150,7 +149,7 @@ fn dmenu_lua_dofile() {
         stdout.read_to_string(&mut output).expect("Unable to read stdout");
 
         let result = lua::send(LuaQuery::ExecFile(output))
-            .expect("unable to contact Lua").recv().expect("Can't get reply");
+            .recv().expect("Can't get reply");
         trace!("Lua result: {:?}", result);
     }).expect("Unable to spawn thread");
 }
@@ -170,16 +169,14 @@ fn dmenu_eval() {
            stdout.read_to_string(&mut output).expect("Unable to read stdout");
 
            let result = lua::send(LuaQuery::Execute(output))
-               .expect("Unable to contact Lua").recv().expect("Can't get reply");
+               .recv().expect("Can't get reply");
            trace!("Lua result: {:?}", result)
     }).expect("Unable to spawn thread");
 }
 
 fn way_cooler_restart() {
     keys::clear_keys();
-    if let Err(err) = lua::send(lua::LuaQuery::Restart) {
-        warn!("Could not send restart signal, {:?}", err);
-    }
+    lua::send(lua::LuaQuery::Restart);
 }
 
 /// A no-op(eration) command.

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -11,6 +11,5 @@ mod utils;
 
 
 pub use self::types::{LuaQuery, LuaResponse};
-pub use self::thread::{init, on_compositor_ready, send, update_registry_value,
-                       run_with_lua, LuaSendError};
+pub use self::thread::{init, on_compositor_ready, send, update_registry_value, run_with_lua};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -11,6 +11,6 @@ mod utils;
 
 
 pub use self::types::{LuaQuery, LuaResponse};
-pub use self::thread::{init, on_compositor_ready, running, send, update_registry_value,
+pub use self::thread::{init, on_compositor_ready, send, update_registry_value,
                        run_with_lua, LuaSendError};
 pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -115,8 +115,7 @@ fn ipc_get<'lua>(lua: &'lua rlua::Lua, (category, key): (String, String))
 /// ipc 'set' handler
 fn ipc_set(_lua: &rlua::Lua, category: String) -> Result<(), rlua::Error> {
     update_registry_value(category);
-    send(LuaQuery::UpdateRegistryFromCache)
-        .expect("Could not send message to Lua thread to update registry");
+    send(LuaQuery::UpdateRegistryFromCache);
     Ok(())
 }
 

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -3,7 +3,7 @@
 
 use rustc_serialize::json::ToJson;
 use uuid::Uuid;
-use super::{send, LuaQuery, running};
+use super::{send, LuaQuery};
 use rlua;
 use rlua::prelude::LuaResult;
 use ::convert::json::json_to_lua;
@@ -115,10 +115,8 @@ fn ipc_get<'lua>(lua: &'lua rlua::Lua, (category, key): (String, String))
 /// ipc 'set' handler
 fn ipc_set(_lua: &rlua::Lua, category: String) -> Result<(), rlua::Error> {
     update_registry_value(category);
-    if running() {
-        send(LuaQuery::UpdateRegistryFromCache)
-            .expect("Could not send message to Lua thread to update registry");
-    }
+    send(LuaQuery::UpdateRegistryFromCache)
+        .expect("Could not send message to Lua thread to update registry");
     Ok(())
 }
 

--- a/src/lua/tests.rs
+++ b/src/lua/tests.rs
@@ -13,8 +13,7 @@ fn activate_thread() {
 #[test]
 fn thread_exec_okay() {
     let hello_receiver = send(LuaQuery::Execute(
-        "hello = 'hello world'".to_string()))
-        .expect("Unable to send hello world");
+        "hello = 'hello world'".to_string()));
     let hello_result = hello_receiver.recv()
         .expect("Unable to receive hello world");
     assert!(hello_result.is_ok());
@@ -24,8 +23,7 @@ fn thread_exec_okay() {
     }
 
     let assert_receiver = send(LuaQuery::Execute(
-        "assert(hello == 'hello world')".to_string()))
-        .expect("Unble to send hello assertion");
+        "assert(hello == 'hello world')".to_string()));
     let assert_result = assert_receiver.recv()
         .expect("Unabel to receive hello assertion");
     assert!(hello_result.is_ok());
@@ -38,8 +36,7 @@ fn thread_exec_okay() {
 #[test]
 fn thread_exec_err() {
     let assert_receiver = send(LuaQuery::Execute(
-        "assert(true == false, 'Logic works')".to_string()))
-        .expect("send assertion error");
+        "assert(true == false, 'Logic works')".to_string()));
     let assert_result = assert_receiver.recv()
         .expect("receive assertion error result");
     assert!(assert_result.is_err(), "expected error from syntax error");
@@ -57,8 +54,7 @@ fn thread_exec_err() {
     }
 
     let syn_err_rx = send(LuaQuery::Execute(
-        "local variable_err = 'sequence\\y'".to_string()))
-        .expect("send syntax error");
+        "local variable_err = 'sequence\\y'".to_string()));
     let syn_err_result = syn_err_rx.recv()
         .expect("receive assertion error result");
     assert!(syn_err_result.is_err(), "expected error from syntax error");
@@ -78,7 +74,7 @@ fn thread_exec_err() {
 #[test]
 fn thread_exec_file_ok() {
     let file_receiver = send(LuaQuery::ExecFile(
-        "lib/test/lua-exec-file.lua".to_string())).unwrap();
+        "lib/test/lua-exec-file.lua".to_string()));
     let file_result = file_receiver.recv().unwrap();
     if let LuaResponse::Error(err) = file_result {
         if let rlua::Error::RuntimeError(ioerr) = err {
@@ -96,7 +92,7 @@ fn thread_exec_file_ok() {
 
     // Print the method from the file
     let test_receiver = send(LuaQuery::Execute(
-        "confirm_file()".to_string())).unwrap();
+        "confirm_file()".to_string()));
     let test_result = test_receiver.recv().unwrap();
     assert!(test_result.is_ok());
     match test_result {
@@ -108,8 +104,7 @@ fn thread_exec_file_ok() {
 #[test]
 fn thread_exec_file_err() {
     let run_receiver = send(LuaQuery::ExecFile(
-        "lib/test/lua-bad-assert.lua".to_string()))
-        .expect("Unable to request lua-bad-assert.lua");
+        "lib/test/lua-bad-assert.lua".to_string()));
     let run_result = run_receiver.recv()
         .expect("Unable to receive lua-bad-assert.lua");
     assert!(run_result.is_err());
@@ -126,8 +121,7 @@ fn thread_exec_file_err() {
     }
 
     let syntax_receiver = send(LuaQuery::ExecFile(
-        "lib/test/lua-syntax-err.txt".to_string()))
-        .expect("Unable to request lua-syntax-err.txt");
+        "lib/test/lua-syntax-err.txt".to_string()));
     let syntax_result = syntax_receiver.recv()
         .expect("Unable to receive lua-syntax-err.txt");
     assert!(syntax_result.is_err());
@@ -146,8 +140,7 @@ fn thread_exec_file_err() {
 
 #[test]
 fn test_rust_exec() {
-    let rust_receiver = send(LuaQuery::ExecRust(rust_lua_fn))
-        .expect("Unable to request rust func exec");
+    let rust_receiver = send(LuaQuery::ExecRust(rust_lua_fn));
     let rust_result = rust_receiver.recv()
         .expect("Unable to receive rust func exec");
     assert!(rust_result.is_ok());

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -69,9 +69,8 @@ impl Debug for LuaMessage {
     }
 }
 
-// Reexported in lua/mod.rs:11
 /// Whether the Lua thread is currently available.
-pub fn running() -> bool {
+fn running() -> bool {
     RUNNING.load(Ordering::Relaxed)
 }
 

--- a/src/modes/custom_lua.rs
+++ b/src/modes/custom_lua.rs
@@ -2,7 +2,7 @@
 //! then a custom, user-defined Lua callback is ran.
 use rustwlc::*;
 use rustwlc::Size;
-use ::lua::{self, LuaQuery, LuaSendError};
+use ::lua::{self, LuaQuery};
 use ::layout::{try_lock_tree, Handle};
 use ::convert::json::{size_to_json, point_to_json, geometry_to_json};
 
@@ -284,12 +284,7 @@ fn lookup_handle(handle: Handle) -> Option<String> {
 
 fn send_to_lua<Q: Into<String>>(msg: Q) {
     let msg = msg.into();
-    match lua::send(LuaQuery::Execute(msg.clone())) {
-        Ok(_) => {},
-        Err(LuaSendError::ThreadClosed) => {
-            warn!("Thread closed, could not execute {:?}", msg)
-        }
-    }
+    lua::send(LuaQuery::Execute(msg.clone()));
 }
 
 fn size_to_lua(size: Size) -> String {

--- a/src/modes/default.rs
+++ b/src/modes/default.rs
@@ -255,17 +255,7 @@ impl Mode for Default {
                         func();
                     },
                     KeyEvent::Lua => {
-                        match lua::send(LuaQuery::HandleKey(press)) {
-                            Ok(_) => {},
-                            Err(err) => {
-                                // We may want to wait for Lua's reply from
-                                // keypresses; for example if the table is tampered
-                                // with or Lua is restarted or Lua has an error.
-                                // ATM Lua asynchronously logs this but in the future
-                                // an error popup/etc is a good idea.
-                                warn!("Error sending keypress: {:?}", err);
-                            }
-                        }
+                        lua::send(LuaQuery::HandleKey(press));
                     }
                 }
                 return !passthrough


### PR DESCRIPTION
Its only (remaining) caller is a function that is only called from Lua
anyway, so it does not really make sense to check if the Lua thread is
running.

Signed-off-by: Uli Schlachter <psychon@znc.in>