### PR TITLE
Save some things in the registry instead of as globals

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -113,7 +113,7 @@ fn register_xproperty<'lua>(lua: &'lua Lua, (name_rust, v_type): (String, String
     let arg_type = XPropertyType::from_string(v_type.clone())
         .ok_or(rlua::Error::RuntimeError(format!("{} not a valid xproperty", v_type)))?;
     unsafe {
-        let raw_con = lua.globals().get::<_, LightUserData>(XCB_CONNECTION_HANDLE)?.0 as _;
+        let raw_con = lua.named_registry_value::<LightUserData>(XCB_CONNECTION_HANDLE)?.0 as _;
         let atom_c = xproto::xcb_intern_atom_unchecked(raw_con,
                                                        false as u8,
                                                        name.to_bytes().len() as u16,
@@ -140,7 +140,7 @@ fn register_xproperty<'lua>(lua: &'lua Lua, (name_rust, v_type): (String, String
 
 /// Get layout short names
 fn xkb_get_group_names<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>> {
-    let xcb_con = lua.globals().get::<_, LightUserData>(XCB_CONNECTION_HANDLE)?.0;
+    let xcb_con = lua.named_registry_value::<LightUserData>(XCB_CONNECTION_HANDLE)?.0;
     unsafe {
         let con = Connection::from_raw_conn(xcb_con as _);
         let raw_con = con.get_raw_conn();
@@ -269,7 +269,7 @@ fn xkb_set_layout_group(_: &Lua, _group: i32) -> rlua::Result<()> {
 fn xkb_get_layout_group<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>> {
     use xcb::ffi::xkb;
     unsafe {
-        let raw_con = lua.globals().get::<_, LightUserData>(XCB_CONNECTION_HANDLE)?.0 as _;
+        let raw_con = lua.named_registry_value::<LightUserData>(XCB_CONNECTION_HANDLE)?.0 as _;
         let state_c = xkb::xcb_xkb_get_state_unchecked(raw_con, xkb::XCB_XKB_ID_USE_CORE_KBD as _);
         let state_r = xkb::xcb_xkb_get_state_reply(raw_con, state_c, ptr::null_mut());
         if state_r.is_null() {

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -78,8 +78,7 @@ fn setup_awesome_path(lua: &Lua) -> rlua::Result<()> {
 ///
 /// We need to store this in Lua, because this make it safer to use.
 fn setup_global_signals(lua: &Lua) -> rlua::Result<()> {
-    let globals = lua.globals();
-    globals.set::<_, Table>(GLOBAL_SIGNALS, lua.create_table()?)
+    lua.set_named_registry_value(GLOBAL_SIGNALS, lua.create_table()?)
 }
 
 /// Sets up the xcb connection and stores it in Lua (for us to access it later)

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -103,7 +103,7 @@ fn setup_xcb_connection(lua: &Lua) -> rlua::Result<()> {
             panic!("Could not get xkb extension supported version {:?}", err);
         }
     }
-    lua.globals().set(XCB_CONNECTION_HANDLE, LightUserData(con.get_raw_conn() as _))?;
+    lua.set_named_registry_value(XCB_CONNECTION_HANDLE, LightUserData(con.get_raw_conn() as _))?;
     mem::forget(con);
     Ok(())
 }

--- a/src/awesome/mouse.rs
+++ b/src/awesome/mouse.rs
@@ -107,7 +107,7 @@ fn index<'lua>(lua: &'lua Lua,
                 .position(|&output| output == WlcOutput::focused())
                 // NOTE Best to just lie because no one handles nil screens properly
                 .unwrap_or(0);
-            let screens = lua.globals().get::<_, Vec<AnyUserData>>(SCREENS_HANDLE)?;
+            let screens = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?;
             if index < screens.len() {
                 return screens[index].clone().to_lua(lua)
             }

--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -133,7 +133,7 @@ pub fn init(lua: &Lua) -> rlua::Result<Class> {
         // TODO Move to Screen impl like the others
         screens.push(screen);
     }
-    lua.globals().set(SCREENS_HANDLE, screens.to_lua(lua)?)?;
+    lua.set_named_registry_value(SCREENS_HANDLE, screens.to_lua(lua)?)?;
     Ok(res)
 }
 
@@ -179,7 +179,7 @@ fn get_workarea<'lua>(lua: &'lua Lua, object: AnyUserData<'lua>) -> rlua::Result
 fn iterate_over_screens<'lua>(lua: &'lua Lua,
                               (_, prev): (Value<'lua>, Value<'lua>))
                               -> rlua::Result<Value<'lua>> {
-    let mut screens: Vec<Screen> = lua.globals().get::<_, Vec<AnyUserData>>(SCREENS_HANDLE)?
+    let mut screens: Vec<Screen> = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?
         .into_iter().map(|obj| Screen::cast(obj.into()).unwrap())
         .collect();
     let index = match prev {
@@ -206,7 +206,7 @@ fn index<'lua>(lua: &'lua Lua,
                (data, index): (AnyUserData<'lua>, Value<'lua>))
                -> rlua::Result<Value<'lua>> {
     let obj: Object = data.clone().into();
-    let screens: Vec<Screen> = lua.globals().get::<_, Vec<AnyUserData>>(SCREENS_HANDLE)?
+    let screens: Vec<Screen> = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?
         .into_iter().map(|obj| Screen::cast(obj.into()).unwrap())
         .collect();
     match index {

--- a/src/awesome/signal.rs
+++ b/src/awesome/signal.rs
@@ -87,19 +87,19 @@ fn emit_signals<'lua, A>(_: &'lua Lua,
 /// Connect the function to the named signal in the global signal list.
 pub fn global_connect_signal<'lua>(lua: &'lua Lua, (name, func): (String, rlua::Function<'lua>))
                         -> rlua::Result<()> {
-    let global_signals = lua.globals().get::<_, Table>(GLOBAL_SIGNALS)?;
+    let global_signals = lua.named_registry_value::<Table>(GLOBAL_SIGNALS)?;
     connect_signals(lua, global_signals, name, &[func])
 }
 
 /// Disconnect the function from the named signal in the global signal list.
 pub fn global_disconnect_signal<'lua>(lua: &'lua Lua, name: String) -> rlua::Result<()> {
-    let global_signals = lua.globals().get::<_, Table>(GLOBAL_SIGNALS)?;
+    let global_signals = lua.named_registry_value::<Table>(GLOBAL_SIGNALS)?;
     disconnect_signals(lua, global_signals, name)
 }
 
 /// Emit the signal with the given name from the global signal list.
 pub fn global_emit_signal<'lua>(lua: &'lua Lua, (name, args): (String, Value))
                      -> rlua::Result<()> {
-    let global_signals = lua.globals().get::<_, Table>(GLOBAL_SIGNALS)?;
+    let global_signals = lua.named_registry_value::<Table>(GLOBAL_SIGNALS)?;
     emit_signals(lua, global_signals, name, args)
 }


### PR DESCRIPTION
This moves some way-cooler internals into the registry, e.g. the list of screens, where it is a lot harder for Lua to mess with it than as globals.