### PR TITLE
Keep a list of tags and implement root.tags()

### DIFF
--- a/src/awesome/root.rs
+++ b/src/awesome/root.rs
@@ -137,4 +137,19 @@ assert(t[1] == first)
 assert(t[2] == second)
 "#, None).unwrap()
     }
+
+    #[test]
+    fn tags_removal() {
+        let lua = Lua::new();
+        tag::init(&lua).unwrap();
+        root::init(&lua).unwrap();
+        lua.eval(r#"
+local first = tag{ activated = true }
+local second = tag{ activated = true }
+first.activated = false
+local t = root.tags()
+assert(t[1] == second)
+assert(type(t[2]) == "nil")
+"#, None).unwrap()
+    }
 }

--- a/src/awesome/tag.rs
+++ b/src/awesome/tag.rs
@@ -154,10 +154,11 @@ fn set_activated<'lua>(lua: &'lua Lua, (obj, val): (AnyUserData<'lua>, bool))
                 if tag_ref == &*value.borrow::<TagState>()? as *const _ {
                     found = true;
                     // Now remove this by shifting everything down...
-                    for index in key .. activated_tags_count-1 {
+                    for index in key .. activated_tags_count {
                         activated_tags.set(index,
                                            activated_tags.get::<_, Value>(index + 1)?)?;
                     }
+                    activated_tags.set(activated_tags_count, Value::Nil)?;
                     break;
                 }
             }

--- a/src/awesome/tag.rs
+++ b/src/awesome/tag.rs
@@ -79,7 +79,11 @@ fn method_setup<'lua>(lua: &'lua Lua, builder: ClassBuilder<'lua>) -> rlua::Resu
            .property(Property::new("activated".into(),
                                    Some(lua.create_function(set_activated)?),
                                    Some(lua.create_function(get_activated)?),
-                                   Some(lua.create_function(set_activated)?)))
+                                   Some(lua.create_function(set_activated)?)))?
+           .property(Property::new("clients".into(),
+                                   None,
+                                   Some(lua.create_function(get_clients)?),
+                                   None))
 }
 
 impl_objectable!(Tag, TagState);
@@ -171,6 +175,15 @@ fn set_activated<'lua>(lua: &'lua Lua, (obj, val): (AnyUserData<'lua>, bool))
 fn get_activated<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>)
                        -> rlua::Result<Value<'lua>> {
     Ok(Value::Boolean(obj.borrow::<TagState>()?.activated))
+}
+
+fn get_clients<'lua>(lua: &'lua Lua, _obj: AnyUserData<'lua>)
+                    -> rlua::Result<Value<'lua>> {
+    // TODO / FIXME: Do this properly.
+    // - Actually return clients.
+    // - Right now this is a property that returns a function. Can we get rid of some of this
+    //   indirection?
+    Ok(Value::Function(lua.create_function(|lua, _: ()| lua.create_table())?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Active tags are now saved in a table in the registry. Adding is easy,
but removing is a bit complicated...

root.tags() is implemented by returning a copy of exactly this table.

Signed-off-by: Uli Schlachter <psychon@znc.in>
