### PR TITLE
awesome.set_preferred_icon_size: Modify state in place

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -236,10 +236,10 @@ fn kill(_: &Lua, (pid, sig): (libc::pid_t, libc::c_int)) -> rlua::Result<bool> {
 }
 
 fn set_preferred_icon_size(lua: &Lua, val: u32) -> rlua::Result<()> {
-    let mut awesome_state = lua.globals().get::<_, AwesomeState>("awesome")?;
+    let awesome_state = lua.globals().get::<_, AnyUserData>("awesome")?;
+    let mut awesome_state = awesome_state.borrow_mut::<AwesomeState>()?;
     awesome_state.preferred_icon_size = val;
-    lua.globals().set("awesome", awesome_state.to_lua(lua)?)
-
+    Ok(())
 }
 
 fn quit(_: &Lua, _: ()) -> rlua::Result<()> {


### PR DESCRIPTION
The old function tried to replace the "awesome" global and it did so in
a broken way. Instead, this just borrows the userdatum mutably and
modifies it in place.

Tested via adding the following in this function and checking that it
prints the expected old value when changing the preferred icon size
twice in a row:

  println!("Old preferred was {}, now {}",
  awesome_state.preferred_icon_size, val);

Fixes: https://github.com/way-cooler/way-cooler/issues/501
Signed-off-by: Uli Schlachter <psychon@znc.in>