### PR TITLE
Fix awesome.load_surface() in various ways

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -349,18 +349,18 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
                     // NOTE Four because of the alpha value we ignore
                     cairo_pixels_index2 += 4;
                 } else {
-                    let mut r = pixels[pix_pixels_index];
-                    let mut g = pixels[pix_pixels_index + 1];
-                    let mut b = pixels[pix_pixels_index + 2];
-                    let a = pixels[pix_pixels_index + 3];
+                    let mut r = pixels[pix_pixels_index2];
+                    let mut g = pixels[pix_pixels_index2 + 1];
+                    let mut b = pixels[pix_pixels_index2 + 2];
+                    let a = pixels[pix_pixels_index2 + 3];
                     let alpha = a as f64 / 255.0;
                     r *= alpha as u8;
                     g *= alpha as u8;
                     b *= alpha as u8;
-                    cairo_data[cairo_pixels_index] = b;
-                    cairo_data[cairo_pixels_index + 1] = g;
-                    cairo_data[cairo_pixels_index + 2] = r;
-                    cairo_data[cairo_pixels_index + 3] = a;
+                    cairo_data[cairo_pixels_index2] = b;
+                    cairo_data[cairo_pixels_index2 + 1] = g;
+                    cairo_data[cairo_pixels_index2 + 2] = r;
+                    cairo_data[cairo_pixels_index2 + 3] = a;
                     pix_pixels_index2 += 4;
                     cairo_pixels_index2 += 4;
                 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -354,9 +354,9 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
                     let mut b = pixels[pix_pixels_index2 + 2];
                     let a = pixels[pix_pixels_index2 + 3];
                     let alpha = a as f64 / 255.0;
-                    r *= alpha as u8;
-                    g *= alpha as u8;
-                    b *= alpha as u8;
+                    r = (r as f64 * alpha) as u8;
+                    g = (g as f64 * alpha) as u8;
+                    b = (b as f64 * alpha) as u8;
                     cairo_data[cairo_pixels_index2] = b;
                     cairo_data[cairo_pixels_index2 + 1] = g;
                     cairo_data[cairo_pixels_index2 + 2] = r;

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -348,29 +348,25 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
     let cairo_stride = surface.get_stride() as usize;
     {
         let mut cairo_data = surface.get_data().unwrap();
-        let mut pix_pixels_index = 0;
-        let mut cairo_pixels_index = 0;
-        for _ in 0..height {
-            let mut pix_pixels_index2 = pix_pixels_index;
-            let mut cairo_pixels_index2 = cairo_pixels_index;
+        for y in 0..height as usize {
+            let mut pix_pixels_index = y * pix_stride;
+            let mut cairo_pixels_index = y * cairo_stride;
             for _ in 0..width {
-                let mut r = pixels[pix_pixels_index2];
-                let mut g = pixels[pix_pixels_index2 + 1];
-                let mut b = pixels[pix_pixels_index2 + 2];
+                let mut r = pixels[pix_pixels_index];
+                let mut g = pixels[pix_pixels_index + 1];
+                let mut b = pixels[pix_pixels_index + 2];
                 let mut a = 1;
                 if channels == 4 {
-                    a = pixels[pix_pixels_index2 + 3];
+                    a = pixels[pix_pixels_index + 3];
                     let alpha = a as f64 / 255.0;
                     r = (r as f64 * alpha) as u8;
                     g = (g as f64 * alpha) as u8;
                     b = (b as f64 * alpha) as u8;
                 }
-                write_u32(&mut cairo_data, cairo_pixels_index2, b, g, r, a);
-                pix_pixels_index2 += channels;
-                cairo_pixels_index2 += 4;
+                write_u32(&mut cairo_data, cairo_pixels_index, b, g, r, a);
+                pix_pixels_index += channels;
+                cairo_pixels_index += 4;
             }
-            pix_pixels_index += pix_stride;
-            cairo_pixels_index += cairo_stride;
         }
     }
     surface


### PR DESCRIPTION
This fixes #518 and details are in the individual commits.

I wonder if it makes sense to add an unit test for this. Such a test would prepare a pixbuf with some specific content, call this function and then do some assertions on the contents of the returned ImageSurface. However, such a test would be relatively verbose, I fear.... Do you want me to write one?

On the various casts that this adds:
- `channels` is either 3 or 4, so safe to cast to usize
- The code in GdkPixbuf ensures that width/height are positive numbers (even though the interface uses signed integers for them...), so casting them to usize is okay (as long as usize is larger than i32, which I am fine with assuming)
- The rest of the added casts are bugfixes, so ought to be fine. :-)