### PR TITLE
awesome/screen: Ensure there is always a screen

### DIFF
--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -128,6 +128,18 @@ pub fn init<'lua>(lua: &'lua Lua) -> rlua::Result<Class<'lua>> {
         // TODO Move to Screen impl like the others
         screens.push(screen);
     }
+
+    // If no screens exist, fake one.
+    if screens.is_empty() {
+        let mut screen = Screen::cast(Screen::new(lua)?)?;
+        {
+            let mut obj = screen.get_object_mut()?;
+            obj.geometry = Size::new(1024, 768).into();
+            obj.workarea = obj.geometry;
+        }
+        screens.push(screen);
+    }
+
     lua.set_named_registry_value(SCREENS_HANDLE, screens.clone().to_lua(lua)?)?;
     Ok(res)
 }


### PR DESCRIPTION
Currently, this code uses an empty list of outputs and turns that into
an empty list of awesome screens. Since awesome's Lua code reacts quite
badly if no screen exist, this commit adds some further code that just
fakes a static screen with size 1024x768.

This gets rid of some error that happens during startup.

Signed-off-by: Uli Schlachter <psychon@znc.in>