### PR TITLE
use rlua builtin lua

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ wlroots = { path = "./wlroots-rs" }
 lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"
-rlua = { version = "0.12.0", default-features = false }
+rlua = "0.12.0"
 bitflags = "0.7"
 nix = "0.6"
 getopts = "0.2"
@@ -31,7 +31,6 @@ pkg-config = "0.3.*"
 
 [features]
 disable-debug = []
-builtin-lua= ["rlua/builtin-lua"]
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Without this change, I get:

```
 = note: /usr/bin/ld: cannot find -llua5.3
          collect2: error: ld returned 1 exit status
```

Full build output available on request.

I think it's looking for [this build artifact](https://github.com/chucklefish/rlua/blob/31fa9173ae67628df7b7eaad4610263220d3a2f6/build.rs#L63).

Maybe on your system, `-llua5.3` will pick up the system lua? Mine won't.

```
$ pkg-config --libs lua        
-llua -lm -ldl
```

If there's a better way to fix this let me know.