### PR TITLE
Send pointer motion

### DIFF
--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -171,7 +171,6 @@ fn focus_under_pointer<'view, V>(seat: &mut compositor::Seat,
                                       (keyboard: {keyboard})] => {
                     match shell.state() {
                         Some(&mut TopLevel(ref mut toplevel)) => {
-                            // TODO Don't send this for each keyboard!
                             toplevel.set_activated(true);
                         },
                         _ => unimplemented!()

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -23,7 +23,7 @@ pub struct Seat {
 impl Seat {
     pub fn new(seat: SeatHandle) -> Seat {
         Seat { seat,
-               meta: true,
+               meta: false,
                ..Seat::default() }
     }
 }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,5 +1,6 @@
 use compositor::Shell;
-use wlroots::Origin;
+use wlroots::{Origin, SurfaceHandle};
+use wlroots::XdgV6ShellState::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {
@@ -11,5 +12,30 @@ impl View {
     pub fn new(shell: Shell) -> View {
         View { shell,
                origin: Origin::default() }
+    }
+
+    pub fn surface(&mut self) -> SurfaceHandle {
+        match &mut self.shell {
+            &mut Shell::XdgV6(ref mut xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    xdg_surface.surface()
+                }).unwrap()
+            }
+        }
+    }
+
+    pub fn activate(&mut self, activate: bool) {
+        match &mut self.shell {
+            &mut Shell::XdgV6(ref mut xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    match xdg_surface.state() {
+                        Some(&mut TopLevel(ref mut toplevel)) => {
+                            toplevel.set_activated(activate);
+                        },
+                        _ => unimplemented!()
+                    }
+                }).unwrap();
+            }
+        }
     }
 }


### PR DESCRIPTION
Send pointer motion to the surface under the pointer.

Add the view `activate()` function.

Test by opening a window and clicking around to see it respond to pointer events.