### PR TITLE
Render xdg popups

### DIFF
--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -171,7 +171,6 @@ fn focus_under_pointer<'view, V>(seat: &mut compositor::Seat,
                                       (keyboard: {keyboard})] => {
                     match shell.state() {
                         Some(&mut TopLevel(ref mut toplevel)) => {
-                            // TODO Don't send this for each keyboard!
                             toplevel.set_activated(true);
                         },
                         _ => unimplemented!()

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,16 +1,18 @@
+use compositor::seat::Seat;
 use compositor::{self, Action, Server, Shell, View};
 use std::time::Duration;
-use compositor::seat::Seat;
 use wlroots::types::Cursor;
-use wlroots::{CompositorHandle, HandleResult, KeyboardHandle, Origin, PointerHandle,
-              PointerHandler, pointer_events::*, WLR_BUTTON_RELEASED, SurfaceHandle};
+use wlroots::{pointer_events::*, CompositorHandle, HandleResult, KeyboardHandle, Origin,
+              PointerHandle, PointerHandler, SurfaceHandle, WLR_BUTTON_RELEASED};
 
 #[derive(Debug, Default)]
 pub struct Pointer;
 
 impl PointerHandler for Pointer {
-
-    fn on_motion_absolute(&mut self, compositor: CompositorHandle, _: PointerHandle, event: &AbsoluteMotionEvent) {
+    fn on_motion_absolute(&mut self,
+                          compositor: CompositorHandle,
+                          _: PointerHandle,
+                          event: &AbsoluteMotionEvent) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut Server = compositor.data.downcast_mut().unwrap();
             let Server { ref mut cursor,
@@ -74,9 +76,9 @@ impl PointerHandler for Pointer {
     }
 }
 
-/// After the cursor has been warped, send pointer motion events to the view under the pointer or
-/// update the position of a view that might have been affected by an ongoing interactive
-/// move/resize operation
+/// After the cursor has been warped, send pointer motion events to the view
+/// under the pointer or update the position of a view that might have been
+/// affected by an ongoing interactive move/resize operation
 fn update_view_position(cursor: &mut Cursor, seat: &mut Seat, views: &mut [View], time_msec: u32) {
     match seat.action {
         Some(Action::Moving { start }) => {
@@ -87,7 +89,7 @@ fn update_view_position(cursor: &mut Cursor, seat: &mut Seat, views: &mut [View]
                     if meta_held_down {
                         move_view(seat, cursor, &mut view, start);
                     }
-                },
+                }
                 None => ()
             }
         }
@@ -100,14 +102,14 @@ fn update_view_position(cursor: &mut Cursor, seat: &mut Seat, views: &mut [View]
                         seat.pointer_notify_enter(surface, sx, sy);
                         seat.pointer_notify_motion(Duration::from_millis(time_msec as u64), sx, sy);
                     }).unwrap();
-                },
+                }
                 None => {
                     with_handles!([(seat: {seat})] => {
                         seat.pointer_clear_focus();
                     }).unwrap();
                 }
             }
-		}
+        }
     }
 }
 
@@ -125,7 +127,7 @@ fn view_at_pointer<'view>(views: &'view mut [View],
                     shell.surface_at(view_sx, view_sy, &mut sx, &mut sy)
                 }).unwrap();
                 if surface.is_some() {
-                    return (Some(view), surface, sx, sy);
+                    return (Some(view), surface, sx, sy)
                 }
             }
         }
@@ -170,20 +172,17 @@ fn focus_under_pointer<'view, V>(seat: &mut compositor::Seat,
 ///
 /// Otherwise, update the view position relative to where the move started,
 /// which is provided by Action::Moving.
-fn move_view<O>(seat: &mut compositor::Seat,
-                cursor: &mut Cursor,
-                view: &mut View,
-                start: O)
+fn move_view<O>(seat: &mut compositor::Seat, cursor: &mut Cursor, view: &mut View, start: O)
     where O: Into<Option<Origin>>
 {
     let Origin { x: shell_x,
-    y: shell_y } = view.origin;
+                 y: shell_y } = view.origin;
     let (lx, ly) = cursor.coords();
     match start.into() {
         None => {
             let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
             let start = Origin::new(view_sx as _, view_sy as _);
-            seat.action = Some(Action::Moving{start});
+            seat.action = Some(Action::Moving { start });
         }
         Some(start) => {
             let pos = Origin::new(lx as i32 - start.x, ly as i32 - start.y);

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -42,7 +42,7 @@ fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views:
     with_handles!([(layout: {&mut *layout})] => {
     for view in views {
         let origin = view.origin;
-        view.for_each_surface(&|surface: SurfaceHandle, sx, sy| {
+        view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {
             with_handles!([(surface: {surface})] => {
                 let (width, height) = surface.current_state().size();
                 let (render_width, render_height) =

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -9,7 +9,6 @@ use wlroots::{project_box, Area, CompositorHandle, OutputHandle, OutputHandler,
 use awesome::{Drawin, Objectable, DRAWINS_HANDLE, LUA};
 use compositor::{Server, View};
 use rlua::{self, AnyUserData, Lua};
-use std::cell::Cell;
 
 pub struct Output;
 

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -38,11 +38,10 @@ impl OutputHandler for Output {
 
 /// Render all of the client views.
 fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut [View]) {
-    with_handles!([(layout: {&mut *layout})] => {
     for view in views {
         let origin = view.origin;
         view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {
-            with_handles!([(surface: {surface})] => {
+            with_handles!([(surface: {surface}), (layout: {&mut *layout})] => {
                 let (width, height) = surface.current_state().size();
                 let (render_width, render_height) =
                     (width * renderer.output.scale() as i32,
@@ -68,7 +67,6 @@ fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views:
             }).expect("Could not render views")
         });
     }
-    }).unwrap();
 }
 
 /// Render all of the drawins provided by Lua.

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -3,8 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use cairo::ImageSurface;
 use cairo_sys;
 use glib::translate::ToGlibPtr;
-use wlroots::{project_box, Area, CompositorHandle, OutputHandle, OutputHandler,
-              OutputLayoutHandle, Renderer, Size, WL_SHM_FORMAT_ARGB8888, SurfaceHandle, Origin};
+use wlroots::{project_box, Area, CompositorHandle, Origin, OutputHandle, OutputHandler,
+              OutputLayoutHandle, Renderer, Size, SurfaceHandle, WL_SHM_FORMAT_ARGB8888};
 
 use awesome::{Drawin, Objectable, DRAWINS_HANDLE, LUA};
 use compositor::{Server, View};
@@ -57,8 +57,7 @@ fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views:
                                              0.0,
                                              renderer.output
                                              .transform_matrix());
-                    renderer.render_texture_with_matrix(&surface.texture(),
-                    matrix);
+                    renderer.render_texture_with_matrix(&surface.texture(), matrix);
                     let start = SystemTime::now();
                     let now = start.duration_since(UNIX_EPOCH)
                         .expect("Time went backwards");

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -23,7 +23,7 @@ pub struct Seat {
 impl Seat {
     pub fn new(seat: SeatHandle) -> Seat {
         Seat { seat,
-               meta: true,
+               meta: false,
                ..Seat::default() }
     }
 }

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -1,6 +1,6 @@
 use compositor::{Server, Shell, View};
-use wlroots::{CompositorHandle, XdgV6ShellHandler, XdgV6ShellManagerHandler,
-              XdgV6ShellSurfaceHandle, XdgV6ShellState::*};
+use wlroots::{CompositorHandle, XdgV6ShellHandler, XdgV6ShellManagerHandler, XdgV6ShellState::*,
+              XdgV6ShellSurfaceHandle};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct XdgV6 {
@@ -22,7 +22,6 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                    compositor: CompositorHandle,
                    mut shell_surface: XdgV6ShellSurfaceHandle)
                    -> Option<Box<XdgV6ShellHandler>> {
-
         let is_toplevel = with_handles!([(shell_surface: {&mut shell_surface})] => {
             match shell_surface.state().unwrap() {
                 TopLevel(_) => true,

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -1,6 +1,6 @@
 use compositor::{Server, Shell, View};
 use wlroots::{CompositorHandle, XdgV6ShellHandler, XdgV6ShellManagerHandler,
-              XdgV6ShellSurfaceHandle};
+              XdgV6ShellSurfaceHandle, XdgV6ShellState::*};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct XdgV6 {
@@ -20,13 +20,24 @@ pub struct XdgV6ShellManager;
 impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    compositor: CompositorHandle,
-                   shell_surface: XdgV6ShellSurfaceHandle)
+                   mut shell_surface: XdgV6ShellSurfaceHandle)
                    -> Option<Box<XdgV6ShellHandler>> {
-        with_handles!([(compositor: {compositor})] => {
-            let server: &mut Server = compositor.into();
-            server.views
-                .push(View::new(Shell::XdgV6(shell_surface.into())));
+
+        let is_toplevel = with_handles!([(shell_surface: {&mut shell_surface})] => {
+            match shell_surface.state().unwrap() {
+                TopLevel(_) => true,
+                _ => false
+            }
         }).unwrap();
+
+        if is_toplevel {
+            with_handles!([(compositor: {compositor})] => {
+                let server: &mut Server = compositor.into();
+                server.views
+                    .push(View::new(Shell::XdgV6(shell_surface.into())));
+            }).unwrap();
+        }
+
         Some(Box::new(XdgV6::new()))
     }
 

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,5 +1,6 @@
 use compositor::Shell;
-use wlroots::Origin;
+use wlroots::{Origin, SurfaceHandle};
+use wlroots::XdgV6ShellState::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {
@@ -11,5 +12,30 @@ impl View {
     pub fn new(shell: Shell) -> View {
         View { shell,
                origin: Origin::default() }
+    }
+
+    pub fn surface(&mut self) -> SurfaceHandle {
+        match &mut self.shell {
+            &mut Shell::XdgV6(ref mut xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    xdg_surface.surface()
+                }).unwrap()
+            }
+        }
+    }
+
+    pub fn activate(&mut self, activate: bool) {
+        match &mut self.shell {
+            &mut Shell::XdgV6(ref mut xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    match xdg_surface.state() {
+                        Some(&mut TopLevel(ref mut toplevel)) => {
+                            toplevel.set_activated(activate);
+                        },
+                        _ => unimplemented!()
+                    }
+                }).unwrap();
+            }
+        }
     }
 }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -39,7 +39,7 @@ impl View {
         }
     }
 
-    pub fn for_each_surface(&mut self, f: &FnMut(SurfaceHandle, i32, i32)) {
+    pub fn for_each_surface(&mut self, f: &mut FnMut(SurfaceHandle, i32, i32)) {
         match &mut self.shell {
             &mut Shell::XdgV6(ref mut xdg_surface) => {
                 with_handles!([(xdg_surface: {xdg_surface})] => {

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,5 +1,5 @@
 use compositor::Shell;
-use wlroots::{Origin, SurfaceHandle, Surface};
+use wlroots::{Origin, SurfaceHandle};
 use wlroots::XdgV6ShellState::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,5 +1,5 @@
 use compositor::Shell;
-use wlroots::{Origin, SurfaceHandle};
+use wlroots::{Origin, SurfaceHandle, Surface};
 use wlroots::XdgV6ShellState::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -34,6 +34,16 @@ impl View {
                         },
                         _ => unimplemented!()
                     }
+                }).unwrap();
+            }
+        }
+    }
+
+    pub fn for_each_surface(&mut self, f: &FnMut(SurfaceHandle, i32, i32)) {
+        match &mut self.shell {
+            &mut Shell::XdgV6(ref mut xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    xdg_surface.for_each_surface(f);
                 }).unwrap();
             }
         }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,6 +1,6 @@
 use compositor::Shell;
-use wlroots::{Origin, SurfaceHandle};
 use wlroots::XdgV6ShellState::*;
+use wlroots::{Origin, SurfaceHandle};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {


### PR DESCRIPTION
Includes #532 needed to test the popups.

Requires [wlroots-rs#156](https://github.com/swaywm/wlroots-rs/pull/156).

To test: open weston-terminal and right click.

There is a bug with input for the popups that I think is related to sending pointer motion over an area of the surface that is not in the surface input region.