### PR TITLE
Trigger Awesome keybindings for key events

### DIFF
--- a/src/awesome/button.rs
+++ b/src/awesome/button.rs
@@ -112,11 +112,11 @@ fn get_button<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<
 
 fn set_modifiers<'lua>(lua: &'lua Lua,
                        (obj, modifiers): (AnyUserData<'lua>, Table<'lua>))
-                       -> rlua::Result<Value<'lua>> {
+                       -> rlua::Result<()> {
     let mut button = Button::cast(obj.clone().into())?;
     button.set_modifiers(modifiers.clone())?;
     signal::emit_object_signal(lua, obj.into(), "property::modifiers".into(), modifiers)?;
-    Ok(Value::Nil)
+    Ok(())
 }
 
 fn get_modifiers<'lua>(lua: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<'lua>> {

--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -28,7 +28,7 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 /// defined with the input.
 pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua::Result<()> {
     LUA.with(|lua| {
-                 let lua = lua.borrow_mut();
+                 let lua = lua.borrow();
                  let lua_state = if state == wlr_key_state::WLR_KEY_PRESSED {
                                      "press"
                                  } else {

--- a/src/awesome/lua/mod.rs
+++ b/src/awesome/lua/mod.rs
@@ -6,7 +6,7 @@ mod types;
 mod utils;
 
 pub use self::types::{LuaQuery, LuaResponse};
-pub use self::utils::{mods_to_lua, mods_to_rust, mouse_events_to_lua};
+pub use self::utils::*;
 
 use glib::MainLoop;
 use rlua;

--- a/src/awesome/lua/utils.rs
+++ b/src/awesome/lua/utils.rs
@@ -1,6 +1,7 @@
 //! Utilities to talk to Lua
 
-use wlroots::{events::{key_events::Key,
+use wlroots::{KeyboardModifier,
+              events::{key_events::Key,
                        pointer_events::{wlr_button_state, BTN_EXTRA, BTN_LEFT, BTN_MIDDLE,
                                         BTN_RIGHT, BTN_SIDE}},
               xkbcommon::xkb::keysyms::*};
@@ -27,6 +28,27 @@ pub fn mods_to_lua<'lua>(lua: &'lua Lua, mods: &[Key]) -> rlua::Result<Table<'lu
                        }.into());
     }
     lua.create_table_from(mods_list.into_iter().enumerate())
+}
+
+/// Convert a modifier list to a single number.
+pub fn mods_to_num(modifiers: Table) -> rlua::Result<KeyboardModifier> {
+    let mut res = KeyboardModifier::empty();
+    for modifier in mods_to_rust(modifiers)? {
+        res.insert(match modifier {
+                       KEY_Shift_L => KeyboardModifier::WLR_MODIFIER_SHIFT,
+                       KEY_Caps_Lock => KeyboardModifier::WLR_MODIFIER_CAPS,
+                       KEY_Control_L => KeyboardModifier::WLR_MODIFIER_CTRL,
+                       KEY_Alt_L => KeyboardModifier::WLR_MODIFIER_ALT,
+                       KEY_Meta_L => KeyboardModifier::WLR_MODIFIER_MOD2,
+                       KEY_Super_L => KeyboardModifier::WLR_MODIFIER_LOGO,
+                       KEY_Hyper_L => KeyboardModifier::WLR_MODIFIER_MOD5,
+                       k => {
+                           error!("Unknown modifier {:?}", k);
+                           panic!("Unknown mod");
+                       }
+                   });
+    }
+    Ok(res)
 }
 
 /// Convert a modifier to the Rust interpretation, from the Lua interpretation

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -26,9 +26,12 @@ mod xproperty;
 pub use self::lua::LUA;
 
 pub use self::drawin::{Drawin, DRAWINS_HANDLE};
+pub use self::key::Key;
 pub use self::keygrabber::keygrabber_handle;
 pub use self::mousegrabber::mousegrabber_handle;
 pub use self::object::{Object, Objectable};
+pub use self::root::ROOT_KEYS_HANDLE;
+pub use self::signal::*;
 
 use compositor::Server;
 

--- a/src/awesome/mousegrabber.rs
+++ b/src/awesome/mousegrabber.rs
@@ -23,7 +23,7 @@ pub fn mousegrabber_handle(x: i32,
                            button: Option<(u32, wlr_button_state)>)
                            -> rlua::Result<()> {
     LUA.with(|lua| {
-                 let lua = lua.borrow_mut();
+                 let lua = lua.borrow();
                  let button_events =
                      button.map(|(button, button_state)| {
                                     ::lua::mouse_events_to_lua(&*lua, button, button_state)

--- a/src/awesome/root.rs
+++ b/src/awesome/root.rs
@@ -7,7 +7,8 @@ use rlua::{self, LightUserData, Lua, Table, ToLua, UserData, UserDataMethods, Va
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
 
-const ROOT_KEYS_HANDLE: &'static str = "__ROOT_KEYS";
+/// Handle to the list of global key bindings
+pub const ROOT_KEYS_HANDLE: &'static str = "__ROOT_KEYS";
 
 #[derive(Clone, Debug)]
 pub struct RootState {
@@ -102,7 +103,7 @@ fn root_keys<'lua>(lua: &'lua Lua, key_array: rlua::Value) -> rlua::Result<rlua:
     match key_array {
         // Set the global keys
         Value::Table(key_array) => {
-            lua.globals().set(ROOT_KEYS_HANDLE, key_array)?;
+            lua.set_named_registry_value(ROOT_KEYS_HANDLE, key_array)?;
             Ok(Value::Nil)
         }
         // Get the global keys

--- a/src/awesome/root.rs
+++ b/src/awesome/root.rs
@@ -108,8 +108,13 @@ fn root_keys<'lua>(lua: &'lua Lua, key_array: rlua::Value) -> rlua::Result<rlua:
         }
         // Get the global keys
         Value::Nil => {
-            // TODO Make a deep clone
-            lua.globals().get(ROOT_KEYS_HANDLE)
+            // NOTE We make a deep clone so they can't modify references.
+            let res = lua.create_table()?;
+            for entry in lua.globals().get::<_, Table>(ROOT_KEYS_HANDLE)?.pairs() {
+                let (key, value) = entry?;
+                res.set::<Value, Value>(key, value)?;
+            }
+            Ok(Value::Table(res))
         }
         v => {
             Err(rlua::Error::RuntimeError(format!("Expected nil or array \

--- a/src/awesome/root.rs
+++ b/src/awesome/root.rs
@@ -7,6 +7,8 @@ use rlua::{self, LightUserData, Lua, Table, ToLua, UserData, UserDataMethods, Va
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
 
+const ROOT_KEYS_HANDLE: &'static str = "__ROOT_KEYS";
+
 #[derive(Clone, Debug)]
 pub struct RootState {
     // TODO Fill in
@@ -54,7 +56,7 @@ fn method_setup<'lua>(lua: &'lua Lua,
            .method("buttons".into(), lua.create_function(dummy)?)?
            .method("wallpaper".into(), lua.create_function(wallpaper)?)?
            .method("tags".into(), lua.create_function(tags)?)?
-           .method("keys".into(), lua.create_function(dummy)?)?
+           .method("keys".into(), lua.create_function(root_keys)?)?
            .method("size".into(), lua.create_function(dummy_double)?)?
            .method("size_mm".into(), lua.create_function(dummy_double)?)?
            .method("cursor".into(), lua.create_function(dummy)?)
@@ -91,6 +93,29 @@ fn tags<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Table<'lua>> {
         table.set(key, value)?;
     }
     Ok(table)
+}
+
+/// Get or set global key bindings.
+///
+/// These bindings will be available when you press keys on the root window.
+fn root_keys<'lua>(lua: &'lua Lua, key_array: rlua::Value) -> rlua::Result<rlua::Value<'lua>> {
+    match key_array {
+        // Set the global keys
+        Value::Table(key_array) => {
+            lua.globals().set(ROOT_KEYS_HANDLE, key_array)?;
+            Ok(Value::Nil)
+        }
+        // Get the global keys
+        Value::Nil => {
+            // TODO Make a deep clone
+            lua.globals().get(ROOT_KEYS_HANDLE)
+        }
+        v => {
+            Err(rlua::Error::RuntimeError(format!("Expected nil or array \
+                                                   of keys, got {:?}",
+                                                  v)))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -68,7 +68,7 @@ impl KeyboardHandler for Keyboard {
     }
 }
 
-/// Emits the Awesome keybindinsg.
+/// Emits the Awesome keybindings.
 fn emit_awesome_keybindings(lua: &Lua,
                             event: &KeyEvent,
                             event_modifiers: KeyboardModifier)

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -1,7 +1,11 @@
-use compositor::Server;
+use rlua;
 use wlroots::{key_events::KeyEvent,
               xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R}, CompositorHandle,
               KeyboardHandle, KeyboardHandler, WLR_KEY_PRESSED};
+
+use awesome::{self, emit_object_signal, Objectable, LUA, ROOT_KEYS_HANDLE};
+use compositor::Server;
+
 pub struct Keyboard;
 
 fn key_is_meta(key: u32) -> bool {
@@ -12,7 +16,7 @@ fn key_is_meta(key: u32) -> bool {
 impl KeyboardHandler for Keyboard {
     fn on_key(&mut self,
               compositor: CompositorHandle,
-              _keyboard: KeyboardHandle,
+              keyboard: KeyboardHandle,
               event: &KeyEvent) {
         with_handles!([(compositor: {compositor})] => {
             if event.key_state() == WLR_KEY_PRESSED {
@@ -35,10 +39,46 @@ impl KeyboardHandler for Keyboard {
                 }
             }
             let server: &mut Server = compositor.into();
-            with_handles!([(seat: {&mut server.seat.seat})] => {
+            with_handles!([(seat: {&mut server.seat.seat}),
+                           (keyboard: {keyboard})] => {
                 seat.keyboard_notify_key(event.time_msec(),
                                          event.keycode(),
                                          event.key_state() as u32);
+                seat.keyboard_send_modifiers(&mut keyboard.get_modifier_masks());
+                let modifiers = keyboard.get_modifiers();
+                LUA.with(|lua| {
+                    let lua = lua.borrow_mut();
+                    let state_string = if event.key_state() == WLR_KEY_PRESSED {
+                        "press"
+                    } else {
+                        "release"
+                    };
+                    // TODO Awesome uses xcb_key_symbols_get_keysym,
+                    // are we using the right function?
+
+
+                    // TODO Should also emit by current focused client so we can
+                    // do client based rules.
+
+                    // TODO This should really be a hash map instead.
+
+                    // TODO Error handling
+                    let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>
+                        (ROOT_KEYS_HANDLE).unwrap();
+                    for keysym in event.pressed_keys() {
+                        for binding in &keybindings {
+                            let obj: awesome::Object = binding.clone().into();
+                            let key = awesome::Key::cast(obj.clone()).unwrap();
+                            if key.keysym().unwrap() == keysym &&
+                                key.modifiers().unwrap() == modifiers.bits() {
+                                    emit_object_signal(&*lua,
+                                                       obj,
+                                                       state_string.into(),
+                                                       keysym).unwrap();
+                            }
+                        }
+                    }
+                });
             }).expect("Seat was destroyed");
         }).unwrap();
     }

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -50,7 +50,7 @@ impl KeyboardHandler for Keyboard {
             }).expect("Seat was destroyed")
         }).unwrap();
         LUA.with(|lua| {
-                     let lua = lua.borrow_mut();
+                     let lua = lua.borrow();
                      if let Err(err) = emit_awesome_keybindings(&*lua, event, modifiers) {
                          warn!("Could not emit binding for {}: {:?}", event.keycode(), err);
                      }

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -1,6 +1,6 @@
 use compositor::Server;
 use wlroots::{key_events::KeyEvent,
-              xkbcommon::xkb::{KEY_Escape, KEY_F1, KEY_Super_L, KEY_Super_R}, CompositorHandle,
+              xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R}, CompositorHandle,
               KeyboardHandle, KeyboardHandler, WLR_KEY_PRESSED};
 pub struct Keyboard;
 
@@ -20,12 +20,6 @@ impl KeyboardHandler for Keyboard {
                     if key == KEY_Escape {
                         compositor.terminate();
                         ::awesome::lua::terminate();
-                        // TODO Remove
-                    } else if key == KEY_F1 {
-                        ::std::thread::spawn(|| {
-                            ::std::process::Command::new("weston-terminal").output()
-                                .unwrap()
-                        });
                     }
                     if key_is_meta(key) {
                         let server: &mut Server = compositor.into();

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -60,8 +60,6 @@ impl KeyboardHandler for Keyboard {
                     // TODO Should also emit by current focused client so we can
                     // do client based rules.
 
-                    // TODO This should really be a hash map instead.
-
                     // TODO Error handling
                     let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>
                         (ROOT_KEYS_HANDLE).unwrap();

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,9 +1,10 @@
-use compositor::seat::Seat;
-use compositor::{self, Action, Server, Shell, View};
 use std::time::Duration;
+
 use wlroots::types::Cursor;
 use wlroots::{pointer_events::*, CompositorHandle, HandleResult, KeyboardHandle, Origin,
               PointerHandle, PointerHandler, SurfaceHandle, WLR_BUTTON_RELEASED};
+
+use compositor::{self, Action, Server, Shell, View, Seat};
 
 #[derive(Debug, Default)]
 pub struct Pointer;

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -24,8 +24,8 @@ impl OutputHandler for Output {
             renderer.clear([0.25, 0.25, 0.25, 1.0]);
             render_views(&mut renderer, layout, views);
             LUA.with(|lua| {
-                let mut lua = lua.borrow_mut();
-                match render_drawins(&mut *lua, &mut renderer) {
+                let lua = lua.borrow();
+                match render_drawins(&*lua, &mut renderer) {
                     Ok(_) => {},
                     Err(err) => {
                         warn!("Error rendering drawins: {:#?}", err);


### PR DESCRIPTION
With this patch keybindings work properly :tada:. Too bad they fail when you press them since nothing else is set up correctly ;).

# TODO
- [x] Error handling
- [x] ~Using a hashmap instead to store the global keybindings~ Can't do because this is part of the public API (you pass a "list", and we should return one in the same order).
- [x] Double checking the error handling used in `xcb` crate is correct for `xcb_key_symbols_get_keysym`
- [x] Make a deep clone of the getter for the root keybindings.
- [x] Parse numbers the same way awesome does it (e.g they handle `#[0-9]` in a specific way)