### PR TITLE
remove seat focus on surface destroy

### DIFF
--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -52,6 +52,16 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
             {
                 server.views.remove(pos);
             }
+
+            let focused = if let Some(ref focused) = server.seat.focused {
+                focused.shell == destroyed_shell
+            } else {
+                false
+            };
+
+            if focused {
+                server.seat.focused = None;
+            }
         }).unwrap();
     }
 }

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -53,15 +53,14 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                 server.views.remove(pos);
             }
 
-            let focused = if let Some(ref focused) = server.seat.focused {
-                focused.shell == destroyed_shell
-            } else {
-                false
-            };
+            server.seat.focused = server.seat.focused.take().and_then(|focused| {
+                if focused.shell == destroyed_shell {
+                    None
+                } else {
+                    Some(focused)
+                }
+            });
 
-            if focused {
-                server.seat.focused = None;
-            }
         }).unwrap();
     }
 }


### PR DESCRIPTION
Fixes a crash when you click somewhere after the focused view has been destroyed. The seat focus is a copy of the view.

I would like to handle removing the focused view from the seat in the first block, but I can't access the seat there. Is there a better way to do that?