### PR TITLE
render and input fixes

### DIFF
--- a/src/awesome/lua/utils.rs
+++ b/src/awesome/lua/utils.rs
@@ -1,10 +1,9 @@
 //! Utilities to talk to Lua
 
-use wlroots::{KeyboardModifier,
-              events::{key_events::Key,
+use wlroots::{events::{key_events::Key,
                        pointer_events::{wlr_button_state, BTN_EXTRA, BTN_LEFT, BTN_MIDDLE,
                                         BTN_RIGHT, BTN_SIDE}},
-              xkbcommon::xkb::keysyms::*};
+              xkbcommon::xkb::keysyms::*, KeyboardModifier};
 
 use rlua::{self, Error::RuntimeError, Lua, Table, Value};
 

--- a/src/awesome/screen.rs
+++ b/src/awesome/screen.rs
@@ -68,7 +68,7 @@ impl<'lua> Screen<'lua> {
     }
 
     fn init_screens(&mut self,
-                    mut output: OutputHandle,
+                    output: OutputHandle,
                     outputs: Vec<OutputHandle>)
                     -> rlua::Result<()> {
         let mut state = self.get_object_mut()?;

--- a/src/compositor/input/input_manager.rs
+++ b/src/compositor/input/input_manager.rs
@@ -18,15 +18,13 @@ impl InputManagerHandler for InputManager {
         with_handles!([(compositor: {compositor}), (keyboard: {keyboard})] => {
             let server: &mut Server = compositor.into();
             server.keyboards.push(keyboard.weak_reference());
-            if server.keyboards.len() == 1 {
-                // Now that we have at least one keyboard, update the seat capabilities.
-                with_handles!([(seat: {&mut server.seat.seat})] => {
-                    let mut capabilities = seat.capabilities();
-                    capabilities.insert(Capability::Keyboard);
-                    seat.set_capabilities(capabilities);
-                    seat.set_keyboard(keyboard.input_device());
-                }).expect("Seat was destroyed");
-            }
+            // Now that we have at least one keyboard, update the seat capabilities.
+            with_handles!([(seat: {&mut server.seat.seat})] => {
+                let mut capabilities = seat.capabilities();
+                capabilities.insert(Capability::Keyboard);
+                seat.set_capabilities(capabilities);
+                seat.set_keyboard(keyboard.input_device());
+            }).expect("Seat was destroyed");
         }).unwrap();
         Some(Box::new(compositor::Keyboard))
     }

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -1,6 +1,6 @@
 use compositor::Server;
 use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_F1}, CompositorHandle,
-              KeyboardHandle, KeyboardHandler, WLR_KEY_PRESSED};
+              KeyboardHandle, KeyboardHandler, WLR_KEY_PRESSED, terminate};
 pub struct Keyboard;
 
 impl KeyboardHandler for Keyboard {
@@ -9,7 +9,7 @@ impl KeyboardHandler for Keyboard {
             if event.key_state() == WLR_KEY_PRESSED {
                 for key in event.pressed_keys() {
                     if key == KEY_Escape {
-                        compositor.terminate();
+                        terminate();
                         ::awesome::lua::terminate();
                         // TODO Remove
                     } else if key == KEY_F1 {
@@ -23,10 +23,11 @@ impl KeyboardHandler for Keyboard {
             let server: &mut Server = compositor.into();
             with_handles!([(seat: {&mut server.seat.seat}),
                            (keyboard: {keyboard})] => {
+                //seat.set_keyboard(keyboard.input_device());
                 seat.keyboard_notify_key(event.time_msec(),
                                          event.keycode(),
                                          event.key_state() as u32);
-                seat.keyboard_send_modifiers(&mut keyboard.get_modifier_masks());
+                seat.keyboard_notify_modifiers(&mut keyboard.get_modifier_masks());
             }).expect("Seat was destroyed");
         }).unwrap();
     }

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -160,7 +160,7 @@ fn focus_under_pointer<'view, V>(seat: &mut compositor::Seat,
         Some(view) => {
             if let Some(mut focused_view) = seat.focused.as_mut() {
                 if focused_view.shell == view.shell {
-                    return Ok(());
+                    return Ok(())
                 }
                 focused_view.activate(false);
             }

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -55,7 +55,7 @@ impl PointerHandler for Pointer {
             with_handles!([(cursor: {&mut *cursor})] => {
                 if event.state() == WLR_BUTTON_RELEASED {
                     seat.action = None;
-                    send_pointer_button(seat, event).expect("Could not send pointer button");
+                    seat.send_button(event);
                     return
                 }
                 let view = {
@@ -75,7 +75,7 @@ impl PointerHandler for Pointer {
                         if meta_held_down && event.button() == BTN_LEFT {
                             move_view(seat, cursor, view, None);
                         }
-                        send_pointer_button(seat, event).expect("Could not send pointer button");
+                        seat.send_button(event);
                     },
                     None => {
                         seat.clear_focus();
@@ -163,12 +163,4 @@ fn move_view<O>(seat: &mut compositor::Seat, cursor: &mut Cursor, view: Rc<View>
             view.origin.replace(pos);
         }
     };
-}
-
-fn send_pointer_button(seat: &mut compositor::Seat, event: &ButtonEvent) -> HandleResult<()> {
-    with_handles!([(seat: {&mut seat.seat})] => {
-        seat.pointer_notify_button(Duration::from_millis(event.time_msec() as _),
-                                   event.button(),
-                                   event.state() as u32);
-    })
 }

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use wlroots::types::Cursor;
-use wlroots::{pointer_events::*, CompositorHandle, HandleResult, KeyboardHandle, Origin,
-              PointerHandle, PointerHandler, SurfaceHandle, WLR_BUTTON_RELEASED};
+use wlroots::{pointer_events::*, CompositorHandle, Origin, PointerHandle, PointerHandler,
+              SurfaceHandle, WLR_BUTTON_RELEASED};
 
 use compositor::{self, Action, Seat, Server, Shell, View};
 use std::rc::Rc;
@@ -50,7 +50,6 @@ impl PointerHandler for Pointer {
             let Server { ref mut cursor,
                          ref mut views,
                          ref mut seat,
-                         ref mut keyboards,
                          .. } = *server;
             with_handles!([(cursor: {&mut *cursor})] => {
                 if event.state() == WLR_BUTTON_RELEASED {

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use wlroots::{CompositorHandle, HandleResult, KeyboardHandle, Origin, PointerHandle,
-              PointerHandler, SurfaceHandle, pointer_events::*, WLR_BUTTON_RELEASED};
 use wlroots::types::Cursor;
+use wlroots::{pointer_events::*, CompositorHandle, HandleResult, KeyboardHandle, Origin,
+              PointerHandle, PointerHandler, SurfaceHandle, WLR_BUTTON_RELEASED};
 
 use compositor::{self, Action, Seat, Server, Shell, View};
 

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -128,7 +128,7 @@ fn view_at_pointer<'view>(views: &'view mut [View],
                 let (mut sx, mut sy) = (0.0, 0.0);
                 let surface = with_handles!([(shell: {&mut *shell})] => {
                     let (lx, ly) = cursor.coords();
-                    let Origin {x: shell_x, y: shell_y} = view.origin;
+                    let Origin {x: shell_x, y: shell_y} = view.origin.get();
                     let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
                     shell.surface_at(view_sx, view_sy, &mut sx, &mut sy)
                 }).unwrap();
@@ -195,7 +195,7 @@ fn move_view<O>(seat: &mut compositor::Seat, cursor: &mut Cursor, view: &mut Vie
     where O: Into<Option<Origin>>
 {
     let Origin { x: shell_x,
-                 y: shell_y } = view.origin;
+                 y: shell_y } = view.origin.get();
     let (lx, ly) = cursor.coords();
     match start.into() {
         None => {
@@ -205,7 +205,7 @@ fn move_view<O>(seat: &mut compositor::Seat, cursor: &mut Cursor, view: &mut Vie
         }
         Some(start) => {
             let pos = Origin::new(lx as i32 - start.x, ly as i32 - start.y);
-            view.origin = pos;
+            view.origin.replace(pos);
         }
     };
 }

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -149,6 +149,12 @@ fn focus_under_pointer<'view, V>(seat: &mut compositor::Seat,
             })
         }
         Some(view) => {
+            if let Some(mut focused_view) = seat.focused.take() {
+                if focused_view.shell == view.shell {
+                    return Ok(());
+                }
+                focused_view.activate(false);
+            }
             seat.focused = Some(view.clone());
             view.activate(true);
             for keyboard in { &mut *keyboards } {

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -17,6 +17,8 @@ pub use self::xwayland::*;
 use wlroots::{self, Compositor, CompositorBuilder, Cursor, CursorHandle, KeyboardHandle,
               OutputHandle, OutputLayout, OutputLayoutHandle, PointerHandle, XCursorManager};
 
+use std::rc::Rc;
+
 #[derive(Debug)]
 pub struct Server {
     pub xcursor_manager: XCursorManager,
@@ -26,7 +28,7 @@ pub struct Server {
     pub keyboards: Vec<KeyboardHandle>,
     pub pointers: Vec<PointerHandle>,
     pub outputs: Vec<OutputHandle>,
-    pub views: Vec<View>
+    pub views: Vec<Rc<View>>
 }
 
 impl Default for Server {

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -49,7 +49,7 @@ impl Default for Server {
 }
 
 impl Server {
-    pub fn new(layout: OutputLayoutHandle, mut cursor: CursorHandle) -> Self {
+    pub fn new(layout: OutputLayoutHandle, cursor: CursorHandle) -> Self {
         let mut xcursor_manager =
             XCursorManager::create("default".to_string(), 24).expect("Could not create xcursor \
                                                                       manager");

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -38,7 +38,9 @@ impl OutputHandler for Output {
 }
 
 /// Render all of the client views.
-fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut Vec<Rc<View>>) {
+fn render_views(renderer: &mut Renderer,
+                layout: &mut OutputLayoutHandle,
+                views: &mut Vec<Rc<View>>) {
     for view in views.iter_mut().rev() {
         let origin = view.origin.get();
         view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -38,7 +38,7 @@ impl OutputHandler for Output {
 
 /// Render all of the client views.
 fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut [View]) {
-    for view in views {
+    for view in views.iter_mut().rev() {
         let origin = view.origin;
         view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {
             with_handles!([(surface: {surface}), (layout: {&mut *layout})] => {

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -39,7 +39,7 @@ impl OutputHandler for Output {
 /// Render all of the client views.
 fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut [View]) {
     for view in views.iter_mut().rev() {
-        let origin = view.origin;
+        let origin = view.origin.get();
         view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {
             with_handles!([(surface: {surface}), (layout: {&mut *layout})] => {
                 let (width, height) = surface.current_state().size();

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -9,6 +9,7 @@ use wlroots::{project_box, Area, CompositorHandle, Origin, OutputHandle, OutputH
 use awesome::{Drawin, Objectable, DRAWINS_HANDLE, LUA};
 use compositor::{Server, View};
 use rlua::{self, AnyUserData, Lua};
+use std::rc::Rc;
 
 pub struct Output;
 
@@ -37,7 +38,7 @@ impl OutputHandler for Output {
 }
 
 /// Render all of the client views.
-fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut [View]) {
+fn render_views(renderer: &mut Renderer, layout: &mut OutputLayoutHandle, views: &mut Vec<Rc<View>>) {
     for view in views.iter_mut().rev() {
         let origin = view.origin.get();
         view.for_each_surface(&mut |surface: SurfaceHandle, sx, sy| {

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -1,5 +1,6 @@
 use compositor::View;
 use wlroots::{Origin, SeatHandle, SeatHandler};
+use std::rc::Rc;
 
 #[derive(Debug, Default)]
 pub struct SeatManager;
@@ -15,7 +16,7 @@ pub enum Action {
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Seat {
     pub seat: SeatHandle,
-    pub focused: Option<View>,
+    pub focused: Option<Rc<View>>,
     pub action: Option<Action>,
     pub meta: bool
 }

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -1,8 +1,8 @@
 use compositor::View;
 use std::rc::Rc;
-use wlroots::{Origin, SeatHandle, SeatHandler};
-use wlroots::pointer_events::ButtonEvent;
 use std::time::Duration;
+use wlroots::pointer_events::ButtonEvent;
+use wlroots::{Origin, SeatHandle, SeatHandler};
 
 #[derive(Debug, Default)]
 pub struct SeatManager;
@@ -31,7 +31,7 @@ impl Seat {
     }
 
     pub fn clear_focus(&mut self) {
-        if let Some(mut focused_view) = self.focused.take() {
+        if let Some(focused_view) = self.focused.take() {
             focused_view.activate(false);
         }
         with_handles!([(seat: {&mut self.seat})] => {

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -1,6 +1,8 @@
 use compositor::View;
 use std::rc::Rc;
 use wlroots::{Origin, SeatHandle, SeatHandler};
+use wlroots::pointer_events::ButtonEvent;
+use std::time::Duration;
 
 #[derive(Debug, Default)]
 pub struct SeatManager;
@@ -60,6 +62,14 @@ impl Seat {
                                                &mut keyboard.get_modifier_masks());
                 }).unwrap();
             }
+        }).unwrap();
+    }
+
+    pub fn send_button(&self, event: &ButtonEvent) {
+        with_handles!([(seat: {&self.seat})] => {
+            seat.pointer_notify_button(Duration::from_millis(event.time_msec() as _),
+            event.button(),
+            event.state() as u32);
         }).unwrap();
     }
 }

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -1,6 +1,6 @@
 use compositor::View;
-use wlroots::{Origin, SeatHandle, SeatHandler};
 use std::rc::Rc;
+use wlroots::{Origin, SeatHandle, SeatHandler};
 
 #[derive(Debug, Default)]
 pub struct SeatManager;
@@ -26,6 +26,41 @@ impl Seat {
         Seat { seat,
                meta: false,
                ..Seat::default() }
+    }
+
+    pub fn clear_focus(&mut self) {
+        if let Some(mut focused_view) = self.focused.take() {
+            focused_view.activate(false);
+        }
+        with_handles!([(seat: {&mut self.seat})] => {
+            seat.keyboard_clear_focus();
+        }).unwrap();
+    }
+
+    pub fn focus_view(&mut self, view: Rc<View>, views: &mut Vec<Rc<View>>) {
+        if let Some(ref focused) = self.focused {
+            if focused == &view {
+                return
+            }
+            focused.activate(false);
+        }
+        self.focused = Some(view.clone());
+        view.activate(true);
+
+        if let Some(idx) = views.iter().position(|v| *v == view) {
+            let v = views.remove(idx);
+            views.insert(0, v);
+        }
+
+        with_handles!([(seat: {&mut self.seat})] => {
+            if let Some(keyboard) = seat.get_keyboard() {
+                with_handles!([(keyboard: {keyboard}), (surface: {view.surface()})] => {
+                    seat.keyboard_notify_enter(surface,
+                                               &mut keyboard.keycodes(),
+                                               &mut keyboard.get_modifier_masks());
+                }).unwrap();
+            }
+        }).unwrap();
     }
 }
 

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -41,7 +41,7 @@ impl Seat {
 
     pub fn focus_view(&mut self, view: Rc<View>, views: &mut Vec<Rc<View>>) {
         if let Some(ref focused) = self.focused {
-            if focused == &view {
+            if *focused == view {
                 return
             }
             focused.activate(false);

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -64,11 +64,12 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
                              ref mut views,
                              .. } = *server;
                 views.insert(0, View::new(Shell::XdgV6(shell_surface.into())));
+                seat.focused = Some(views[0].clone());
 
                 with_handles!([(seat: {&mut seat.seat})] => {
                     if let Some(keyboard) = seat.get_keyboard() {
                         with_handles!([(keyboard: {keyboard}),
-                                       (surface: {views[0].surface()})] => {
+                                       (surface: {views[0].shell.surface()})] => {
                                            seat.keyboard_notify_enter(surface,
                                                                       &mut keyboard.keycodes(),
                                                                       &mut keyboard.get_modifier_masks());

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -61,7 +61,7 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
             with_handles!([(compositor: {compositor})] => {
                 let server: &mut Server = compositor.into();
                 server.views
-                    .push(View::new(Shell::XdgV6(shell_surface.into())));
+                    .insert(0, View::new(Shell::XdgV6(shell_surface.into())));
             }).unwrap();
         }
 

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -72,8 +72,8 @@ impl XdgV6ShellHandler for XdgV6 {
                         with_handles!([(keyboard: {keyboard}),
                                        (surface: {views[0].shell.surface()})] => {
                                            seat.keyboard_notify_enter(surface,
-                                                                      &mut keyboard.keycodes(),
-                                                                      &mut keyboard.get_modifier_masks());
+                                                              &mut keyboard.keycodes(),
+                                                              &mut keyboard.get_modifier_masks());
                         }).unwrap();
                     }
                     views[0].activate(true);
@@ -83,9 +83,9 @@ impl XdgV6ShellHandler for XdgV6 {
     }
 
     fn unmap_request(&mut self,
-                   compositor: CompositorHandle,
-                   _surface: SurfaceHandle,
-                   shell_surface: XdgV6ShellSurfaceHandle) {
+                     compositor: CompositorHandle,
+                     _surface: SurfaceHandle,
+                     shell_surface: XdgV6ShellSurfaceHandle) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut Server = compositor.into();
             let Server { ref mut seat,
@@ -121,7 +121,6 @@ impl XdgV6ShellHandler for XdgV6 {
             });
 
         }).unwrap();
-
     }
 }
 

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -32,7 +32,7 @@ impl XdgV6ShellHandler for XdgV6 {
                 if view.shell == shell {
                     with_handles!([(cursor: {cursor})] => {
                         let (lx, ly) = cursor.coords();
-                        let Origin { x: shell_x, y: shell_y } = view.origin;
+                        let Origin { x: shell_x, y: shell_y } = view.origin.get();
                         let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
                         let start = Origin::new(view_sx as _, view_sy as _);
                         *action = Some(Action::Moving { start: start });

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -19,9 +19,9 @@ impl XdgV6 {
 impl XdgV6ShellHandler for XdgV6 {
     fn move_request(&mut self,
                     compositor: CompositorHandle,
-                    _surface: SurfaceHandle,
+                    _: SurfaceHandle,
                     shell_surface: XdgV6ShellSurfaceHandle,
-                    _event: &MoveEvent) {
+                    _: &MoveEvent) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut Server = compositor.into();
             let ref mut seat = server.seat;
@@ -45,7 +45,7 @@ impl XdgV6ShellHandler for XdgV6 {
 
     fn map_request(&mut self,
                    compositor: CompositorHandle,
-                   _surface: SurfaceHandle,
+                   _: SurfaceHandle,
                    mut shell_surface: XdgV6ShellSurfaceHandle) {
         let is_toplevel = with_handles!([(shell_surface: {&mut shell_surface})] => {
             match shell_surface.state().unwrap() {
@@ -69,7 +69,7 @@ impl XdgV6ShellHandler for XdgV6 {
 
     fn unmap_request(&mut self,
                      compositor: CompositorHandle,
-                     _surface: SurfaceHandle,
+                     _: SurfaceHandle,
                      shell_surface: XdgV6ShellSurfaceHandle) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut Server = compositor.into();
@@ -94,14 +94,14 @@ pub struct XdgV6ShellManager;
 
 impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
-                   _compositor: CompositorHandle,
-                   _shell_surface: XdgV6ShellSurfaceHandle)
+                   _: CompositorHandle,
+                   _: XdgV6ShellSurfaceHandle)
                    -> Option<Box<XdgV6ShellHandler>> {
         Some(Box::new(XdgV6::new()))
     }
 
     fn surface_destroyed(&mut self,
-                         _compositor: CompositorHandle,
-                         _shell_surface: XdgV6ShellSurfaceHandle) {
+                         _: CompositorHandle,
+                         _: XdgV6ShellSurfaceHandle) {
     }
 }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -11,13 +11,13 @@ pub struct View {
 
 impl View {
     pub fn new(shell: Shell) -> View {
-        View { shell,
+        View { shell: shell,
                origin: Cell::new(Origin::default()) }
     }
 
-    pub fn surface(&mut self) -> SurfaceHandle {
-        match &mut self.shell {
-            &mut Shell::XdgV6(ref mut xdg_surface) => {
+    pub fn surface(&self) -> SurfaceHandle {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
                 with_handles!([(xdg_surface: {xdg_surface})] => {
                     xdg_surface.surface()
                 }).unwrap()
@@ -25,9 +25,9 @@ impl View {
         }
     }
 
-    pub fn activate(&mut self, activate: bool) {
-        match &mut self.shell {
-            &mut Shell::XdgV6(ref mut xdg_surface) => {
+    pub fn activate(&self, activate: bool) {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
                 with_handles!([(xdg_surface: {xdg_surface})] => {
                     match xdg_surface.state() {
                         Some(&mut TopLevel(ref mut toplevel)) => {
@@ -40,9 +40,9 @@ impl View {
         }
     }
 
-    pub fn for_each_surface(&mut self, f: &mut FnMut(SurfaceHandle, i32, i32)) {
-        match &mut self.shell {
-            &mut Shell::XdgV6(ref mut xdg_surface) => {
+    pub fn for_each_surface(&self, f: &mut FnMut(SurfaceHandle, i32, i32)) {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
                 with_handles!([(xdg_surface: {xdg_surface})] => {
                     xdg_surface.for_each_surface(f);
                 }).unwrap();

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,17 +1,18 @@
 use compositor::Shell;
 use wlroots::XdgV6ShellState::*;
 use wlroots::{Origin, SurfaceHandle};
+use std::cell::Cell;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {
     pub shell: Shell,
-    pub origin: Origin
+    pub origin: Cell<Origin>
 }
 
 impl View {
     pub fn new(shell: Shell) -> View {
         View { shell,
-               origin: Origin::default() }
+               origin: Cell::new(Origin::default()) }
     }
 
     pub fn surface(&mut self) -> SurfaceHandle {

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,7 +1,7 @@
 use compositor::Shell;
+use std::cell::Cell;
 use wlroots::XdgV6ShellState::*;
 use wlroots::{Origin, SurfaceHandle};
-use std::cell::Cell;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,6 +1,6 @@
 use compositor::Shell;
-use wlroots::{Origin, SurfaceHandle};
 use wlroots::XdgV6ShellState::*;
+use wlroots::{Origin, SurfaceHandle};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn detect_raspi() {
 
 /// Initializes the logging system.
 pub fn init_logs() {
-    //wlroots::utils::init_logging(wlroots::utils::L_DEBUG, None);
+    wlroots::utils::init_logging(wlroots::utils::L_DEBUG, None);
     let mut builder = env_logger::LogBuilder::new();
     builder.format(log_format);
     builder.filter(None, log::LogLevelFilter::Trace);

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,7 @@ fn detect_raspi() {
 
 /// Initializes the logging system.
 pub fn init_logs() {
+    //wlroots::utils::init_logging(wlroots::utils::L_DEBUG, None);
     let mut builder = env_logger::LogBuilder::new();
     builder.format(log_format);
     builder.filter(None, log::LogLevelFilter::Trace);


### PR DESCRIPTION
Trying to get mostly usable shell surfaces.

* [x] Render focused view on top of the other views
* [x] Revert the focus to the next one in the list when a focused shell surface closes
* [x] Set the focus to a newly created shell surface
* [x] General keyboard fixes
* [x] Add view on map, not create
* [x] reference count the views
* [x] make nicer view abstractions
* [x] Update to latest wlroots-rs