### PR TITLE
Fix load_surface_from_pixbuf() messing up channel order

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -372,7 +372,7 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
                     g = (g as f64 * alpha) as u8;
                     b = (b as f64 * alpha) as u8;
                 }
-                write_u32(&mut cairo_data, cairo_pixels_index, b, g, r, a);
+                write_u32(&mut cairo_data, cairo_pixels_index, a, r, g, b);
                 pix_pixels_index += channels;
                 cairo_pixels_index += 4;
             }


### PR DESCRIPTION
The function write_u32() expects its arguments in the order argb, but
the caller passed in the arguments in the order bgra. I do not know how
I managed to do this, but I introduced this problem in commit
2cb203ff495.

Signed-off-by: Uli Schlachter <psychon@znc.in>

Tested in the same way as #547. With this change, the code from there now actually produces the expected result.