### PR TITLE
basic client cursors

### DIFF
--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,11 +1,7 @@
-use std::time::Duration;
+use wlroots::{pointer_events::*, CompositorHandle, PointerHandle, PointerHandler,
+              WLR_BUTTON_RELEASED};
 
-use wlroots::types::Cursor;
-use wlroots::{pointer_events::*, CompositorHandle, Origin, PointerHandle, PointerHandler,
-              SurfaceHandle, XCursorManager, WLR_BUTTON_RELEASED};
-
-use compositor::{self, Action, Seat, Server, Shell, View};
-use std::rc::Rc;
+use compositor::{Seat, Server};
 
 #[derive(Debug, Default)]
 pub struct Pointer;
@@ -25,7 +21,10 @@ impl PointerHandler for Pointer {
             with_handles!([(cursor: {&mut *cursor})] => {
                 let (x, y) = event.pos();
                 cursor.warp_absolute(event.device(), x, y);
-                update_view_position(cursor, xcursor_manager, seat, views, event.time_msec());
+                seat.update_cursor_position(cursor,
+                                            xcursor_manager,
+                                            views,
+                                            Some(event.time_msec()));
             }).expect("Cursor was destroyed");
         }).unwrap();
     }
@@ -41,7 +40,10 @@ impl PointerHandler for Pointer {
             with_handles!([(cursor: {&mut *cursor})] => {
                 let (x, y) = event.delta();
                 cursor.move_to(event.device(), x, y);
-                update_view_position(cursor, xcursor_manager, seat, views, event.time_msec());
+                seat.update_cursor_position(cursor,
+                                            xcursor_manager,
+                                            views,
+                                            Some(event.time_msec()));
             }).expect("Cursor was destroyed");
         }).unwrap();
     }
@@ -60,12 +62,12 @@ impl PointerHandler for Pointer {
                     return
                 }
 
-                if let (Some(view), _, _, _) = view_at_pointer(views, cursor) {
+                if let (Some(view), _, _, _) = Seat::view_at_pointer(views, cursor) {
                     seat.focus_view(view.clone(), views);
 
                     let meta_held_down = seat.meta;
                     if meta_held_down && event.button() == BTN_LEFT {
-                        move_view(seat, cursor, &view, None);
+                        seat.move_view(cursor, &view, None);
                     }
                     seat.send_button(event);
                 } else {
@@ -74,87 +76,4 @@ impl PointerHandler for Pointer {
             }).unwrap()
         }).unwrap()
     }
-}
-
-/// After the cursor has been warped, send pointer motion events to the view
-/// under the pointer or update the position of a view that might have been
-/// affected by an ongoing interactive move/resize operation
-fn update_view_position(cursor: &mut Cursor,
-                        xcursor_manager: &mut XCursorManager,
-                        seat: &mut Seat,
-                        views: &mut [Rc<View>],
-                        time_msec: u32) {
-    match seat.action {
-        Some(Action::Moving { start }) => {
-            seat.focused = seat.focused.take().map(|f| {
-                                                       move_view(seat, cursor, &f, start);
-                                                       f
-                                                   });
-        }
-        _ => {
-            let (_view, surface, sx, sy) = view_at_pointer(views, cursor);
-            match surface {
-                Some(surface) => {
-                    with_handles!([(surface: {surface}), (seat: {&mut seat.seat})] => {
-                        seat.pointer_notify_enter(surface, sx, sy);
-                        seat.pointer_notify_motion(Duration::from_millis(time_msec as u64), sx, sy);
-                    }).unwrap();
-                }
-                None => {
-                    if seat.has_client_cursor {
-                        xcursor_manager.set_cursor_image("left_ptr".to_string(), cursor);
-                        seat.has_client_cursor = false;
-                    }
-                    with_handles!([(seat: {&mut seat.seat})] => {
-                        seat.pointer_clear_focus();
-                    }).unwrap();
-                }
-            }
-        }
-    }
-}
-
-fn view_at_pointer(views: &mut [Rc<View>],
-                   cursor: &mut Cursor)
-                   -> (Option<Rc<View>>, Option<SurfaceHandle>, f64, f64) {
-    for view in views {
-        match view.shell {
-            Shell::XdgV6(ref shell) => {
-                let (mut sx, mut sy) = (0.0, 0.0);
-                let surface = with_handles!([(shell: {shell})] => {
-                    let (lx, ly) = cursor.coords();
-                    let Origin {x: shell_x, y: shell_y} = view.origin.get();
-                    let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
-                    shell.surface_at(view_sx, view_sy, &mut sx, &mut sy)
-                }).unwrap();
-                if surface.is_some() {
-                    return (Some(view.clone()), surface, sx, sy)
-                }
-            }
-        }
-    }
-    (None, None, 0.0, 0.0)
-}
-
-/// Start moving a view if you haven't already by passing `start: None`.
-///
-/// Otherwise, update the view position relative to where the move started,
-/// which is provided by Action::Moving.
-fn move_view<O>(seat: &mut compositor::Seat, cursor: &mut Cursor, view: &View, start: O)
-    where O: Into<Option<Origin>>
-{
-    let Origin { x: shell_x,
-                 y: shell_y } = view.origin.get();
-    let (lx, ly) = cursor.coords();
-    match start.into() {
-        None => {
-            let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
-            let start = Origin::new(view_sx as _, view_sy as _);
-            seat.action = Some(Action::Moving { start });
-        }
-        Some(start) => {
-            let pos = Origin::new(lx as i32 - start.x, ly as i32 - start.y);
-            view.origin.replace(pos);
-        }
-    };
 }

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -1,9 +1,9 @@
 use cairo::ImageSurface;
 use cairo_sys;
 use glib::translate::ToGlibPtr;
+use wlroots::utils::current_time;
 use wlroots::{project_box, Area, CompositorHandle, Origin, OutputHandle, OutputHandler,
               OutputLayoutHandle, Renderer, Size, SurfaceHandle, WL_SHM_FORMAT_ARGB8888};
-use wlroots::utils::current_time;
 
 use awesome::{Drawin, Objectable, DRAWINS_HANDLE, LUA};
 use compositor::{Server, View};

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -3,9 +3,9 @@ use std::rc::Rc;
 use std::time::Duration;
 use wlroots::events::seat_events::SetCursorEvent;
 use wlroots::pointer_events::ButtonEvent;
+use wlroots::utils::current_time;
 use wlroots::{CompositorHandle, Cursor, Origin, SeatHandle, SeatHandler, SurfaceHandle,
               XCursorManager};
-use wlroots::utils::current_time;
 
 #[derive(Debug, Default)]
 pub struct SeatManager;

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -5,6 +5,7 @@ use wlroots::events::seat_events::SetCursorEvent;
 use wlroots::pointer_events::ButtonEvent;
 use wlroots::{CompositorHandle, Cursor, Origin, SeatHandle, SeatHandler, SurfaceHandle,
               XCursorManager};
+use wlroots::utils::current_time;
 
 #[derive(Debug, Default)]
 pub struct SeatManager;
@@ -125,8 +126,7 @@ impl Seat {
         let time = if let Some(time_msec) = time_msec {
             Duration::from_millis(time_msec as u64)
         } else {
-            // TODO need clock_gettime with CLOCK_MONOTONIC
-            Duration::from_millis(0 as u64)
+            current_time()
         };
 
         match self.action {

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -54,17 +54,23 @@ impl XdgV6ShellHandler for XdgV6 {
             }
         }).unwrap();
 
-        if is_toplevel {
-            with_handles!([(compositor: {compositor})] => {
-                let server: &mut Server = compositor.into();
-                let Server { ref mut seat,
-                             ref mut views,
-                             .. } = *server;
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut Server = compositor.into();
+            let Server { ref mut seat,
+                         ref mut views,
+                         ref mut cursor,
+                         ref mut xcursor_manager,
+                         .. } = *server;
+            if is_toplevel {
                 let view = Rc::new(View::new(Shell::XdgV6(shell_surface.into())));
                 views.push(view.clone());
                 seat.focus_view(view, views);
+            }
+
+            with_handles!([(cursor: {cursor})] => {
+                seat.update_cursor_position(cursor, xcursor_manager, views, None);
             }).unwrap();
-        }
+        }).unwrap();
     }
 
     fn unmap_request(&mut self,
@@ -75,6 +81,8 @@ impl XdgV6ShellHandler for XdgV6 {
             let server: &mut Server = compositor.into();
             let Server { ref mut seat,
                          ref mut views,
+                         ref mut cursor,
+                         ref mut xcursor_manager,
                          .. } = *server;
             let destroyed_shell = shell_surface.into();
             if let Some(pos) = views.iter().position(|view| view.shell == destroyed_shell) {
@@ -86,6 +94,9 @@ impl XdgV6ShellHandler for XdgV6 {
             } else {
                 seat.clear_focus();
             }
+            with_handles!([(cursor: {cursor})] => {
+                seat.update_cursor_position(cursor, xcursor_manager, views, None);
+            }).unwrap();
         }).unwrap();
     }
 }
@@ -100,8 +111,5 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
         Some(Box::new(XdgV6::new()))
     }
 
-    fn surface_destroyed(&mut self,
-                         _: CompositorHandle,
-                         _: XdgV6ShellSurfaceHandle) {
-    }
+    fn surface_destroyed(&mut self, _: CompositorHandle, _: XdgV6ShellSurfaceHandle) {}
 }

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -1,5 +1,5 @@
 use compositor::{Action, Server, Shell, View};
-use wlroots::{CompositorHandle, Origin, SurfaceHandle, XdgV6ShellHandler,
+use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler, XdgV6ShellHandler,
               XdgV6ShellManagerHandler, XdgV6ShellState::*, XdgV6ShellSurfaceHandle};
 
 use std::rc::Rc;
@@ -107,9 +107,7 @@ impl XdgV6ShellManagerHandler for XdgV6ShellManager {
     fn new_surface(&mut self,
                    _: CompositorHandle,
                    _: XdgV6ShellSurfaceHandle)
-                   -> Option<Box<XdgV6ShellHandler>> {
-        Some(Box::new(XdgV6::new()))
+                   -> (Option<Box<XdgV6ShellHandler>>, Option<Box<SurfaceHandler>>) {
+        (Some(Box::new(XdgV6::new())), None)
     }
-
-    fn surface_destroyed(&mut self, _: CompositorHandle, _: XdgV6ShellSurfaceHandle) {}
 }

--- a/src/compositor/xwayland.rs
+++ b/src/compositor/xwayland.rs
@@ -2,7 +2,8 @@
 //! Way Cooler.
 
 use std::panic;
-use wlroots::{CompositorHandle, XWaylandManagerHandler};
+use wlroots::{CompositorHandle, SurfaceHandler, XWaylandManagerHandler, XWaylandSurfaceHandle,
+              XWaylandSurfaceHandler};
 
 use awesome;
 
@@ -25,5 +26,11 @@ impl XWaylandManagerHandler for XWaylandManager {
                 panic::resume_unwind(err)
             }
         }
+    }
+    fn new_surface(&mut self,
+                   _: CompositorHandle,
+                   _: XWaylandSurfaceHandle)
+                   -> (Option<Box<XWaylandSurfaceHandler>>, Option<Box<SurfaceHandler>>) {
+        (None, None)
     }
 }


### PR DESCRIPTION
This is the most basic implementation of client cursors. There's a lot of extra guarding and checking in rootston, but I don't know if it's necessary for now.

Needs the standalone-surface branch to work.

* [x] basic client cursor
* [x] set compositor cursor when view closes
* [x] update to latest wlroots-rs