### PR TITLE
Implemented dehandle! everywhere it makes sense

### DIFF
--- a/src/awesome/lua/rust_interop.rs
+++ b/src/awesome/lua/rust_interop.rs
@@ -14,10 +14,11 @@ pub fn register_libraries(lua: &rlua::Lua, compositor: &mut CompositorHandle) ->
     lua.exec::<()>(init_code, Some("init.lua"))?;
     let globals = lua.globals();
     globals.set("type", lua.create_function(type_override)?)?;
-    with_handles!([(compositor: {compositor})] => {
+    dehandle!(
+        @compositor = {compositor};
         let server: &mut Server = compositor.into();
-        awesome::init(&lua, server).expect("Could not initialize awesome compatibility modules");
-    }).unwrap();
+        awesome::init(&lua, server).expect("Could not initialize awesome compatibility modules")
+    );
     Ok(())
 }
 

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -11,70 +11,67 @@ impl PointerHandler for Pointer {
                           compositor: CompositorHandle,
                           _: PointerHandle,
                           event: &AbsoluteMotionEvent) {
-        with_handles!([(compositor: {compositor})] => {
+        dehandle!(
+            @compositor = {compositor};
             let server: &mut Server = compositor.data.downcast_mut().unwrap();
-            let Server { ref mut cursor,
+            let Server { ref cursor,
                          ref mut xcursor_manager,
                          ref mut seat,
                          ref mut views,
                          .. } = *server;
-            with_handles!([(cursor: {&mut *cursor})] => {
-                let (x, y) = event.pos();
-                cursor.warp_absolute(event.device(), x, y);
-                seat.update_cursor_position(cursor,
-                                            xcursor_manager,
-                                            views,
-                                            Some(event.time_msec()));
-            }).expect("Cursor was destroyed");
-        }).unwrap();
+            @cursor = {cursor};
+            let (x, y) = event.pos();
+            cursor.warp_absolute(event.device(), x, y);
+            seat.update_cursor_position(cursor,
+                                        xcursor_manager,
+                                        views,
+                                        Some(event.time_msec())));
     }
 
     fn on_motion(&mut self, compositor: CompositorHandle, _: PointerHandle, event: &MotionEvent) {
-        with_handles!([(compositor: {compositor})] => {
+        dehandle!(
+            @compositor = {compositor};
             let server: &mut Server = compositor.into();
-            let Server { ref mut cursor,
+            let Server { ref cursor,
                          ref mut xcursor_manager,
                          ref mut seat,
                          ref mut views,
                          .. } = *server;
-            with_handles!([(cursor: {&mut *cursor})] => {
-                let (x, y) = event.delta();
-                cursor.move_to(event.device(), x, y);
-                seat.update_cursor_position(cursor,
-                                            xcursor_manager,
-                                            views,
-                                            Some(event.time_msec()));
-            }).expect("Cursor was destroyed");
-        }).unwrap();
+            @cursor = {cursor};
+            let (x, y) = event.delta();
+            cursor.move_to(event.device(), x, y);
+            seat.update_cursor_position(cursor,
+                                        xcursor_manager,
+                                        views,
+                                        Some(event.time_msec())));
     }
 
     fn on_button(&mut self, compositor: CompositorHandle, _: PointerHandle, event: &ButtonEvent) {
-        with_handles!([(compositor: {compositor})] => {
+        dehandle!(
+            @compositor = {compositor};
             let server: &mut Server = compositor.into();
-            let Server { ref mut cursor,
+            let Server { ref cursor,
                          ref mut views,
                          ref mut seat,
                          .. } = *server;
-            with_handles!([(cursor: {&mut *cursor})] => {
-                if event.state() == WLR_BUTTON_RELEASED {
-                    seat.action = None;
-                    seat.send_button(event);
-                    return
-                }
+            @cursor = {cursor};
+            if event.state() == WLR_BUTTON_RELEASED {
+                seat.action = None;
+                seat.send_button(event);
+                return
+            };
 
-                if let (Some(view), _, _, _) = Seat::view_at_pointer(views, cursor) {
-                    seat.focus_view(view.clone(), views);
+            if let (Some(view), _, _, _) = Seat::view_at_pointer(views, cursor) {
+                seat.focus_view(view.clone(), views);
 
-                    let meta_held_down = seat.meta;
-                    if meta_held_down && event.button() == BTN_LEFT {
-                        seat.move_view(cursor, &view, None);
-                    }
-                    seat.send_button(event);
-                } else {
-                    seat.clear_focus();
+                let meta_held_down = seat.meta;
+                if meta_held_down && event.button() == BTN_LEFT {
+                    seat.move_view(cursor, &view, None);
                 }
-            }).unwrap()
-        }).unwrap()
+                seat.send_button(event);
+            } else {
+                seat.clear_focus();
+            });
     }
 
     fn destroyed(&mut self, compositor: CompositorHandle, pointer: PointerHandle) {

--- a/src/compositor/output/output_manager.rs
+++ b/src/compositor/output/output_manager.rs
@@ -14,25 +14,27 @@ impl OutputManagerHandler for OutputManager {
                              compositor: CompositorHandle,
                              builder: OutputBuilder<'output>)
                              -> Option<OutputBuilderResult<'output>> {
-        with_handles!([(compositor: {compositor})] => {
+        dehandle!(
+            @compositor = {compositor};
             let server: &mut Server = compositor.into();
-            let mut res = builder.build_best_mode(Output);
+            let res = builder.build_best_mode(Output);
             server.outputs.push(res.output.clone());
             let Server { ref mut cursor,
                          ref mut layout,
                          ref mut xcursor_manager,
                          .. } = *server;
-            with_handles!([(layout: {layout}),
-                           (cursor: {cursor}),
-                           (output: {&mut res.output})] => {
+            @layout = {layout};
+            @cursor = {cursor};
+            {
+                @output = {&res.output};
                 layout.add_auto(output);
                 cursor.attach_output_layout(layout);
                 xcursor_manager.load(output.scale());
                 xcursor_manager.set_cursor_image("left_ptr".to_string(), cursor);
                 let (x, y) = cursor.coords();
-                cursor.warp(None, x, y);
-            }).expect("Could not setup output with cursor and layout");
+                cursor.warp(None, x, y)
+            }
             Some(res)
-        }).unwrap()
+        )
     }
 }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -38,14 +38,15 @@ impl View {
     pub fn activate(&self, activate: bool) {
         match self.shell {
             Shell::XdgV6(ref xdg_surface) => {
-                with_handles!([(xdg_surface: {xdg_surface})] => {
+                dehandle! (
+                    @xdg_surface = {xdg_surface};
                     match xdg_surface.state() {
                         Some(&mut TopLevel(ref mut toplevel)) => {
                             toplevel.set_activated(activate);
                         },
                         _ => unimplemented!()
                     }
-                }).unwrap();
+                );
             }
         }
     }


### PR DESCRIPTION
Look how much sexier that is...

\*cough\* \*cough*

Excuse me.

Implement `dehandle!` everywhere we used to use `with_handles!`. Should not be merged until wlroots-rs is and we fix the removal of the input manager callbacks.