### PR TITLE
Removed the restart functionality

### DIFF
--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -1,11 +1,9 @@
 //! Awesome compatibility modules
 
-use wlroots;
 
 use rlua::{self, LightUserData, Lua, Table};
 use std::{env, mem, path::PathBuf};
 use xcb::{xkb, Connection};
-use awesome::lua::setup_lua;
 
 mod awesome;
 mod button;
@@ -40,26 +38,6 @@ use compositor::Server;
 
 pub const GLOBAL_SIGNALS: &'static str = "__awesome_global_signals";
 pub const XCB_CONNECTION_HANDLE: &'static str = "__xcb_connection";
-
-/// Called from `wayland_glib_interface.c` after every call back into the wayland event loop.
-///
-/// This restarts the Lua thread if there is a new one pending
-#[no_mangle]
-pub extern "C" fn refresh_awesome() {
-    NEXT_LUA.with(|new_lua_check| {
-        if new_lua_check.get() {
-            new_lua_check.set(false);
-            LUA.with(|lua| {
-                let mut lua = lua.borrow_mut();
-                unsafe {
-                    *lua = rlua::Lua::new_with_debug();
-                }
-            });
-            let compositor = wlroots::compositor_handle().unwrap();
-            setup_lua(compositor);
-        }
-    });
-}
 
 pub fn init(lua: &Lua, server: &mut Server) -> rlua::Result<()> {
     setup_awesome_path(lua)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod macros;
 mod awesome;
 mod compositor;
 
-pub use awesome::{refresh_awesome, lua};
+pub use awesome::lua;
 
 use std::{env, fs::File, io::{BufRead, BufReader}, os::raw::c_void, path::Path, process::exit};
 

--- a/src/wayland_glib_interface.c
+++ b/src/wayland_glib_interface.c
@@ -1,8 +1,6 @@
 #include <wayland-server-core.h>
 #include <glib.h>
 
-void refresh_awesome(void);
-
 /* Instance of an event source that we use to integrate the wayland event loop
  * with GLib's MainLoop.
  */
@@ -52,8 +50,6 @@ static gboolean interface_dispatch(GSource *base, GSourceFunc callback, gpointer
 		= wl_display_get_event_loop(interface_source->display);
 
 	wl_event_loop_dispatch(event_loop, 0);
-
-  refresh_awesome();
 
 	(void) callback;
 	(void) data;


### PR DESCRIPTION
It was causing segfaults, with no real way to get around them.

Basically glib will have pointers into Lua (I'm guessing?) due to LGI.
When we restart Lua (by creating a whole new Lua interpreter) it crashes
everything because those pointers are dangling.

Stopping the GLib mainloop causes the compositor to stop, which we
really don't want.

This is something we'll have to figure out at some point.