### PR TITLE
basic move resize

### DIFF
--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -1,6 +1,7 @@
 use rlua::{self, Lua};
-use wlroots::{Capability, key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R},
-              CompositorHandle, KeyboardHandle, KeyboardHandler, KeyboardModifier, WLR_KEY_PRESSED};
+use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R},
+              Capability, CompositorHandle, KeyboardHandle, KeyboardHandler, KeyboardModifier,
+              WLR_KEY_PRESSED};
 
 use awesome::{self, emit_object_signal, Objectable, LUA, ROOT_KEYS_HANDLE};
 use compositor::Server;

--- a/src/compositor/input/pointer.rs
+++ b/src/compositor/input/pointer.rs
@@ -1,4 +1,4 @@
-use wlroots::{Capability, pointer_events::*, CompositorHandle, PointerHandle, PointerHandler,
+use wlroots::{pointer_events::*, Capability, CompositorHandle, PointerHandle, PointerHandler,
               WLR_BUTTON_RELEASED};
 
 use compositor::{Seat, Server};

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use wlroots;
 use wlroots::events::seat_events::SetCursorEvent;
 use wlroots::pointer_events::ButtonEvent;
-use wlroots::utils::current_time;
+use wlroots::utils::{current_time, Edges};
 use wlroots::{Area, CompositorHandle, Cursor, CursorHandle, DragIconHandle, Origin, SeatHandle,
               SeatHandler, Size, SurfaceHandle, SurfaceHandler, XCursorManager};
 
@@ -22,7 +22,7 @@ pub enum Action {
         start: Origin,
         offset: Origin,
         original_size: Size,
-        edges: u32
+        edges: Edges
     }
 }
 
@@ -115,7 +115,7 @@ impl Seat {
                         cursor: &mut CursorHandle,
                         view: Rc<View>,
                         views: &mut [Rc<View>],
-                        edges: u32) {
+                        edges: Edges) {
         self.focus_view(view.clone(), views);
         with_handles!([(cursor: {cursor})] => {
             let Origin { x: view_x, y: view_y } = view.origin.get();
@@ -185,23 +185,17 @@ impl Seat {
                     let Size { mut width,
                                mut height } = original_size;
 
-                    let EDGE_NONE = 0;
-                    let EDGE_TOP = 1;
-                    let EDGE_BOTTOM = 2;
-                    let EDGE_LEFT = 4;
-                    let EDGE_RIGHT = 8;
-
-                    if edges & EDGE_BOTTOM != 0 {
+                    if edges & Edges::WLR_EDGE_BOTTOM != Edges::empty() {
                         height += dy;
-                    } else if edges & EDGE_TOP != 0 {
+                    } else if edges & Edges::WLR_EDGE_TOP != Edges::empty() {
                         view_y += dy;
                         height -= dy;
                     }
 
-                    if edges & EDGE_LEFT != 0 {
+                    if edges & Edges::WLR_EDGE_LEFT != Edges::empty() {
                         view_x += dx;
                         width -= dx;
-                    } else if edges & EDGE_RIGHT != 0 {
+                    } else if edges & Edges::WLR_EDGE_RIGHT != Edges::empty() {
                         width += dx;
                     }
 

--- a/src/compositor/seat.rs
+++ b/src/compositor/seat.rs
@@ -57,8 +57,7 @@ impl Seat {
         }).unwrap();
     }
 
-    pub fn focus_view(&mut self, view: Rc<View>, views: &mut [Rc<View>]) {
-        let mut views: Vec<Rc<View>> = views.to_vec();
+    pub fn focus_view(&mut self, view: Rc<View>, views: &mut Vec<Rc<View>>) {
         if let Some(ref focused) = self.focused {
             if *focused == view {
                 return
@@ -114,7 +113,7 @@ impl Seat {
     pub fn begin_resize(&mut self,
                         cursor: &mut CursorHandle,
                         view: Rc<View>,
-                        views: &mut [Rc<View>],
+                        views: &mut Vec<Rc<View>>,
                         edges: Edges) {
         self.focus_view(view.clone(), views);
         with_handles!([(cursor: {cursor})] => {
@@ -125,7 +124,8 @@ impl Seat {
             self.action = Some(Action::Resizing {
                 start: Origin { x: view_x, y: view_y },
                 offset,
-                original_size: view.get_size(), edges
+                original_size: view.get_size(),
+                edges
             });
         }).unwrap();
     }
@@ -185,17 +185,17 @@ impl Seat {
                     let Size { mut width,
                                mut height } = original_size;
 
-                    if edges & Edges::WLR_EDGE_BOTTOM != Edges::empty() {
+                    if edges.contains(Edges::WLR_EDGE_BOTTOM) {
                         height += dy;
-                    } else if edges & Edges::WLR_EDGE_TOP != Edges::empty() {
+                    } else if edges.contains(Edges::WLR_EDGE_TOP) {
                         view_y += dy;
                         height -= dy;
                     }
 
-                    if edges & Edges::WLR_EDGE_LEFT != Edges::empty() {
+                    if edges.contains(Edges::WLR_EDGE_LEFT) {
                         view_x += dx;
                         width -= dx;
-                    } else if edges & Edges::WLR_EDGE_RIGHT != Edges::empty() {
+                    } else if edges.contains(Edges::WLR_EDGE_RIGHT) {
                         width += dx;
                     }
 

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -3,7 +3,7 @@ use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler, XdgV6Shel
               XdgV6ShellManagerHandler, XdgV6ShellState::*, XdgV6ShellSurfaceHandle};
 
 use std::rc::Rc;
-use wlroots::xdg_shell_v6_events::MoveEvent;
+use wlroots::xdg_shell_v6_events::{MoveEvent, ResizeEvent};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct XdgV6 {
@@ -17,6 +17,27 @@ impl XdgV6 {
 }
 
 impl XdgV6ShellHandler for XdgV6 {
+    fn resize_request(&mut self,
+                      compositor: CompositorHandle,
+                      _: SurfaceHandle,
+                      shell_surface: XdgV6ShellSurfaceHandle,
+                      event: &ResizeEvent) {
+        println!("got a resize event: {:?}", event);
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut Server = compositor.into();
+            let Server { ref mut seat,
+                         ref mut views,
+                         ref mut cursor,
+                         .. } = *server;
+            let resizing_shell = shell_surface.into();
+            let idx = views.iter().position(|view| view.shell == resizing_shell);
+            if let Some(idx) = idx {
+                let view = views.get(idx).unwrap().clone();
+                seat.begin_resize(cursor, view, views, event.edges());
+            }
+        }).unwrap();
+    }
+
     fn move_request(&mut self,
                     compositor: CompositorHandle,
                     _: SurfaceHandle,
@@ -38,6 +59,49 @@ impl XdgV6ShellHandler for XdgV6 {
                         let start = Origin::new(view_sx as _, view_sy as _);
                         *action = Some(Action::Moving { start: start });
                     }).unwrap();
+                }
+            }
+        }).unwrap();
+    }
+
+    fn on_commit(&mut self,
+                 compositor: CompositorHandle,
+                 _: SurfaceHandle,
+                 shell_surface: XdgV6ShellSurfaceHandle) {
+        let configure_serial = {
+            with_handles!([(shell_surface: {shell_surface.clone()})] => {
+                shell_surface.configure_serial()
+            }).unwrap()
+        };
+
+        let surface = shell_surface.into();
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut Server = compositor.into();
+            let Server { ref mut seat,
+                         ref mut views,
+                         ref mut cursor,
+                         .. } = *server;
+            let idx = views.iter().position(|view| view.shell == surface);
+            if let Some(idx) = idx {
+                let view = views.get(idx).unwrap().clone();
+                if let Some(move_resize) = view.pending_move_resize.get() {
+                    if move_resize.serial > 0 && move_resize.serial >= configure_serial {
+                        let Origin {mut x, mut y} = view.origin.get();
+                        if move_resize.update_x {
+                            x  = move_resize.area.origin.x + move_resize.area.size.width -
+                                 view.get_size().width;
+                        }
+                        if move_resize.update_y {
+                            y  = move_resize.area.origin.y + move_resize.area.size.height -
+                                 view.get_size().height;
+                        }
+
+                        view.origin.set(Origin { x, y });
+
+                        if move_resize.serial == configure_serial {
+                            view.pending_move_resize.set(None);
+                        }
+                    }
                 }
             }
         }).unwrap();

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -1,18 +1,28 @@
 use compositor::Shell;
 use std::cell::Cell;
 use wlroots::XdgV6ShellState::*;
-use wlroots::{Origin, SurfaceHandle};
+use wlroots::{Area, Origin, Size, SurfaceHandle};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PendingMoveResize {
+    pub update_x: bool,
+    pub update_y: bool,
+    pub serial: u32,
+    pub area: Area
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {
     pub shell: Shell,
-    pub origin: Cell<Origin>
+    pub origin: Cell<Origin>,
+    pub pending_move_resize: Cell<Option<PendingMoveResize>>
 }
 
 impl View {
     pub fn new(shell: Shell) -> View {
         View { shell: shell,
-               origin: Cell::new(Origin::default()) }
+               origin: Cell::new(Origin::default()),
+               pending_move_resize: Cell::new(None) }
     }
 
     pub fn surface(&self) -> SurfaceHandle {
@@ -37,6 +47,55 @@ impl View {
                     }
                 }).unwrap();
             }
+        }
+    }
+
+    pub fn get_size(&self) -> Size {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    let Area { origin: _, size } = xdg_surface.geometry();
+                    size
+                }).unwrap()
+            }
+        }
+    }
+
+    pub fn move_resize(&self, area: Area) {
+        let Area { origin: Origin { x, y },
+                   size: Size { width, height } } = area;
+        let width = width as u32;
+        let height = height as u32;
+
+        let Origin { x: view_x,
+                     y: view_y } = self.origin.get();
+
+        let update_x = x != view_x;
+        let update_y = y != view_y;
+        let mut serial = 0;
+
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    match xdg_surface.state() {
+                        Some(&mut TopLevel(ref mut toplevel)) => {
+                            // TODO apply size constraints
+                            serial = toplevel.set_size(width, height);
+                        },
+                        _ => unimplemented!()
+                    }
+                }).unwrap();
+            }
+        }
+
+        if serial == 0 {
+            // size didn't change
+            self.origin.set(Origin { x, y });
+        } else {
+            self.pending_move_resize.set(Some(PendingMoveResize { update_x,
+                                              update_y,
+                                              area,
+                                              serial }));
         }
     }
 


### PR DESCRIPTION
A move-resize operation must be handled asynchronously because it is done with a request to the shell surface and we need to wait for it to update its buffer before we can update the view size. Sometimes, updating the size of the view must be done at the same time as updating one of the view x/y coordinates so that must be kept in sync.

That's what the view `move_resize` function does. It takes an `Area` of the new position of the view, makes a `set_size` request on the toplevel, and then does both the x/y position change and the width/height update at the same time. Without that, you would update x/y first and width/height at some later time causing a flash of partially rendered content.

The view now has a `PendingMoveResize` struct which is set in the `view.move_resize` function and read in the surface `commit` handler. On commit, if the configure serial matches the `PendingMoveResize` serial, it does the update.

The seat got a new mode called `Resizing`. Here we store the offset of the cursor on the surface, and the original position of the view. We calculate how much the cursor has moved from the original spot and adjust the final view position based on that.

TODO:

* [x] async move/resize
* [x] seat resize state
* [ ] bug: jitter in the bottom corner on draging the top-left corner and moving rapidly (exists in rootston as well) that sort of looks like a rounding issue.
* [x] put the `WLR_EDGE` enum somewhere (maybe in wlroots-rs).
* [ ] can this be simpler? (maybe not).