### PR TITLE
client.get()

### DIFF
--- a/src/awesome/client.rs
+++ b/src/awesome/client.rs
@@ -1,36 +1,42 @@
 //! TODO Fill in
 use super::class::{Class, ClassBuilder};
 use super::object::{Object, Objectable};
-use rlua::{self, Lua, Table, ToLua, UserData, Value};
+use rlua::{self, Lua, Table, ToLua, UserData, Value, AnyUserData, UserDataMethods, MetaMethod};
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
-use wlroots::compositor_handle;
-use compositor::Server;
+use compositor::{Server, View};
+
+pub const CLIENTS_HANDLE: &'static str = "__clients";
 
 #[derive(Clone, Debug)]
 pub struct ClientState {
     // TODO Fill in
-    dummy: i32
+    pub lua_id: u32,
+    title: String,
 }
 
+#[derive(Clone, Debug)]
 pub struct Client<'lua>(Object<'lua>);
 
 impl Default for ClientState {
     fn default() -> Self {
-        ClientState { dummy: 0 }
+        ClientState { lua_id: 0, title: "".into() }
     }
 }
-
-/* This is currently unused.
- * TODO: Figure out if this will be needed later.
 
 impl <'lua> Client<'lua> {
-    fn new(lua: &Lua) -> rlua::Result<Object> {
-        let class = class::class_setup(lua, "client")?;
+    pub fn new(lua: &Lua) -> rlua::Result<Object> {
+        let class = super::class::class_setup(lua, "client")?;
         Ok(Client::allocate(lua, class)?.build())
     }
+
+    pub fn init_client(&mut self, view: &View) -> rlua::Result<()> {
+        let mut state = self.get_object_mut()?;
+        state.lua_id = view.lua_id;
+        state.title = view.title();
+        Ok(())
+    }
 }
-*/
 
 impl Display for ClientState {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -44,9 +50,35 @@ impl<'lua> ToLua<'lua> for Client<'lua> {
     }
 }
 
-impl UserData for ClientState {}
+impl UserData for ClientState {
+    fn add_methods(methods: &mut UserDataMethods<Self>) {
+        methods.add_meta_function(MetaMethod::Index, |lua, (class, index): (ClientState, Value)| {
+            match index {
+                Value::String(value) => {
+                    match value.to_str() {
+                        Ok("title") => {
+                            Ok(class.title.to_lua(lua))
+                        },
+                        _ => Ok(Value::Nil.to_lua(lua))
+                    }
+                },
+                _ => Ok(Value::Nil.to_lua(lua))
+            }
+        });
+    }
+}
 
-pub fn init(lua: &Lua) -> rlua::Result<Class> {
+pub fn init<'lua>(lua: &'lua Lua, server: &Server) -> rlua::Result<Class<'lua>> {
+    let clients: &mut Vec<Client> = &mut Vec::default();
+
+    for view in &server.views {
+        let mut client = Client::cast(Client::new(lua)?)?;
+        client.init_client(&view)?;
+        clients.push(client);
+    }
+
+    lua.set_named_registry_value(CLIENTS_HANDLE, clients.clone().to_lua(lua)?)?;
+
     method_setup(lua, Class::builder(lua, "client", None)?)?.save_class("client")?
                                                             .build()
 }
@@ -63,11 +95,45 @@ fn method_setup<'lua>(lua: &'lua Lua,
 impl_objectable!(Client, ClientState);
 
 fn get_clients<'lua>(lua: &'lua Lua, _: rlua::Value) -> rlua::Result<Table<'lua>> {
-    with_handles!([(compositor: {compositor_handle().unwrap()})] => {
-        let server: &mut Server = compositor.into();
-        for view in &server.views {
-            println!("TODO: add this view to the lua table: {:p}", view);
-        }
-    }).unwrap();
-    Ok(lua.create_table()?)
+    let clients: Vec<Client> = lua.named_registry_value::<Vec<AnyUserData>>(CLIENTS_HANDLE)?
+                                      .into_iter()
+                                      .map(|obj| Client::cast(obj.into()).unwrap())
+                                      .collect();
+    let table = lua.create_table()?;
+
+    for (i, client) in clients.iter().enumerate() {
+        let client = client.clone().to_lua(lua)?;
+        table.set(i + 1, client)?;
+    }
+
+    Ok(table)
+}
+
+pub fn notify_client_add<'lua>(lua: &'lua Lua, view: &View) -> rlua::Result<()> {
+    let mut clients: Vec<Client> = lua.named_registry_value::<Vec<AnyUserData>>(CLIENTS_HANDLE)?
+                                      .into_iter()
+                                      .map(|obj| Client::cast(obj.into()).unwrap())
+                                      .collect();
+    let mut client = Client::cast(Client::new(lua)?)?;
+    client.init_client(&view)?;
+    clients.push(client);
+
+    lua.set_named_registry_value(CLIENTS_HANDLE, clients.clone().to_lua(lua)?)?;
+
+    Ok(())
+}
+
+pub fn notify_client_remove<'lua>(lua: &'lua Lua, view: &View) -> rlua::Result<()> {
+    let mut clients: Vec<Client> = lua.named_registry_value::<Vec<AnyUserData>>(CLIENTS_HANDLE)?
+                                      .into_iter()
+                                      .map(|obj| Client::cast(obj.into()).unwrap())
+                                      .collect();
+
+    if let Some(idx) = clients.iter().position(|client| client.state().unwrap().lua_id == view.lua_id) {
+        clients.remove(idx);
+    }
+
+    lua.set_named_registry_value(CLIENTS_HANDLE, clients.clone().to_lua(lua)?)?;
+
+    Ok(())
 }

--- a/src/awesome/client.rs
+++ b/src/awesome/client.rs
@@ -4,6 +4,8 @@ use super::object::{Object, Objectable};
 use rlua::{self, Lua, Table, ToLua, UserData, Value};
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
+use wlroots::compositor_handle;
+use compositor::Server;
 
 #[derive(Clone, Debug)]
 pub struct ClientState {
@@ -55,11 +57,17 @@ fn method_setup<'lua>(lua: &'lua Lua,
     // TODO Do properly
     use super::dummy;
     builder.method("connect_signal".into(), lua.create_function(dummy)?)?
-           .method("get".into(), lua.create_function(dummy_table)?)
+           .method("get".into(), lua.create_function(get_clients)?)
 }
 
 impl_objectable!(Client, ClientState);
 
-fn dummy_table<'lua>(lua: &'lua Lua, _: rlua::Value) -> rlua::Result<Table<'lua>> {
+fn get_clients<'lua>(lua: &'lua Lua, _: rlua::Value) -> rlua::Result<Table<'lua>> {
+    with_handles!([(compositor: {compositor_handle().unwrap()})] => {
+        let server: &mut Server = compositor.into();
+        for view in &server.views {
+            println!("TODO: add this view to the lua table: {:p}", view);
+        }
+    }).unwrap();
     Ok(lua.create_table()?)
 }

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -35,6 +35,7 @@ pub use self::mousegrabber::mousegrabber_handle;
 pub use self::object::{Object, Objectable};
 pub use self::root::ROOT_KEYS_HANDLE;
 pub use self::signal::*;
+pub use self::client::{notify_client_add, notify_client_remove};
 
 use compositor::Server;
 
@@ -68,7 +69,7 @@ pub fn init(lua: &Lua, server: &mut Server) -> rlua::Result<()> {
     button::init(lua)?;
     awesome::init(lua)?;
     key::init(lua)?;
-    client::init(lua)?;
+    client::init(lua, server)?;
     screen::init(lua, server)?;
     keygrabber::init(lua)?;
     root::init(lua)?;

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -17,7 +17,7 @@ pub use self::xwayland::*;
 use wlroots::{self, Compositor, CompositorBuilder, Cursor, CursorHandle, KeyboardHandle,
               OutputHandle, OutputLayout, OutputLayoutHandle, PointerHandle, XCursorManager};
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Server {
@@ -28,7 +28,7 @@ pub struct Server {
     pub keyboards: Vec<KeyboardHandle>,
     pub pointers: Vec<PointerHandle>,
     pub outputs: Vec<OutputHandle>,
-    pub views: Vec<Rc<View>>
+    pub views: Vec<Arc<View>>
 }
 
 impl Default for Server {

--- a/src/compositor/output/output.rs
+++ b/src/compositor/output/output.rs
@@ -8,7 +8,7 @@ use wlroots::{project_box, Area, CompositorHandle, Origin, OutputHandle, OutputH
 use awesome::{Drawin, Objectable, DRAWINS_HANDLE, LUA};
 use compositor::{Server, View};
 use rlua::{self, AnyUserData, Lua};
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub struct Output;
 
@@ -83,9 +83,9 @@ fn render_surface(renderer: &mut Renderer,
 /// Render all of the client views.
 fn render_views(renderer: &mut Renderer,
                 layout: &mut OutputLayoutHandle,
-                views: &mut Vec<Rc<View>>) {
+                views: &mut Vec<Arc<View>>) {
     for view in views.iter_mut().rev() {
-        let origin = view.origin.get();
+        let origin = *view.origin.lock().unwrap();
         view.for_each_surface(&mut |mut surface: SurfaceHandle, sx, sy| {
                                   render_surface(renderer,
                                                  layout,

--- a/src/compositor/shells/mod.rs
+++ b/src/compositor/shells/mod.rs
@@ -10,6 +10,13 @@ pub enum Shell {
                                     * TODO Xdg */
 }
 
+impl Default for Shell {
+    fn default() -> Self {
+        // The default shell is always invalid
+        Shell::XdgV6(XdgV6ShellSurfaceHandle::new())
+    }
+}
+
 impl Shell {
     /// Get a wlr surface from the shell.
     pub fn surface(&mut self) -> SurfaceHandle {

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -132,7 +132,7 @@ impl XdgV6ShellHandler for XdgV6 {
                 seat.focus_view(view.clone(), views);
                 LUA.with(|lua| {
                     let lua = lua.borrow();
-                    notify_client_add(&lua, &view.clone()).expect("could not add lua client");
+                    notify_client_add(&lua, view.clone()).expect("could not add lua client");
                 });
             }
 
@@ -157,7 +157,7 @@ impl XdgV6ShellHandler for XdgV6 {
             if let Some(pos) = views.iter().position(|view| view.shell == destroyed_shell) {
                 LUA.with(|lua| {
                     let lua = lua.borrow();
-                    notify_client_remove(&lua, &views[pos].clone()).expect("could not remove lua client");
+                    notify_client_remove(&lua, views[pos].clone()).expect("could not remove lua client");
                 });
                 views.remove(pos);
             }

--- a/src/compositor/shells/xdg_v6.rs
+++ b/src/compositor/shells/xdg_v6.rs
@@ -2,7 +2,7 @@ use compositor::{Action, Server, Shell, View};
 use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler, XdgV6ShellHandler,
               XdgV6ShellManagerHandler, XdgV6ShellState::*, XdgV6ShellSurfaceHandle};
 
-use std::rc::Rc;
+use std::sync::Arc;
 use awesome::{notify_client_add, notify_client_remove};
 use awesome::lua::LUA;
 use wlroots::xdg_shell_v6_events::{MoveEvent, ResizeEvent};
@@ -54,7 +54,7 @@ impl XdgV6ShellHandler for XdgV6 {
                 if view.shell == shell {
                     with_handles!([(cursor: {cursor})] => {
                         let (lx, ly) = cursor.coords();
-                        let Origin { x: shell_x, y: shell_y } = view.origin.get();
+                        let Origin { x: shell_x, y: shell_y } = *view.origin.lock().unwrap();
                         let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
                         let start = Origin::new(view_sx as _, view_sy as _);
                         *action = Some(Action::Moving { start: start });
@@ -83,9 +83,11 @@ impl XdgV6ShellHandler for XdgV6 {
                          .. } = *server;
 
             if let Some(view) = views.iter().find(|view| view.shell == surface).cloned() {
-                if let Some(move_resize) = view.pending_move_resize.get() {
+                let move_resize = *view.pending_move_resize.lock().unwrap();
+                if let Some(move_resize) = move_resize {
                     if move_resize.serial >= configure_serial {
-                        let Origin {mut x, mut y} = view.origin.get();
+                        let mut origin = *view.origin.lock().unwrap();
+                        let Origin { mut x, mut y } = origin;
                         if move_resize.update_x {
                             x  = move_resize.area.origin.x + move_resize.area.size.width -
                                  view.get_size().width;
@@ -95,10 +97,10 @@ impl XdgV6ShellHandler for XdgV6 {
                                  view.get_size().height;
                         }
 
-                        view.origin.set(Origin { x, y });
+                        *view.origin.lock().unwrap() = Origin { x, y };
 
                         if move_resize.serial == configure_serial {
-                            view.pending_move_resize.set(None);
+                            *view.pending_move_resize.lock().unwrap() = None;
                         }
                     }
                 }
@@ -125,7 +127,7 @@ impl XdgV6ShellHandler for XdgV6 {
                          ref mut xcursor_manager,
                          .. } = *server;
             if is_toplevel {
-                let view = Rc::new(View::new(Shell::XdgV6(shell_surface.into())));
+                let view = Arc::new(View::new(Shell::XdgV6(shell_surface.into())));
                 views.push(view.clone());
                 seat.focus_view(view.clone(), views);
                 LUA.with(|lua| {

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -6,13 +6,22 @@ use wlroots::{Origin, SurfaceHandle};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct View {
     pub shell: Shell,
-    pub origin: Cell<Origin>
+    pub origin: Cell<Origin>,
+    pub lua_id: u32
 }
+
+static mut lua_counter: u32 = 0;
 
 impl View {
     pub fn new(shell: Shell) -> View {
+        let lua_id = unsafe {
+            lua_counter += 1;
+            lua_counter
+        };
         View { shell: shell,
-               origin: Cell::new(Origin::default()) }
+               origin: Cell::new(Origin::default()),
+               lua_id
+        }
     }
 
     pub fn surface(&self) -> SurfaceHandle {
@@ -46,6 +55,21 @@ impl View {
                 with_handles!([(xdg_surface: {xdg_surface})] => {
                     xdg_surface.for_each_surface(f);
                 }).unwrap();
+            }
+        }
+    }
+
+    pub fn title(&self) -> String {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    match xdg_surface.state() {
+                        Some(&mut TopLevel(ref mut toplevel)) => {
+                            toplevel.title()
+                        },
+                        _ => unimplemented!()
+                    }
+                }).unwrap()
             }
         }
     }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -132,4 +132,14 @@ impl View {
             }
         }
     }
+
+    pub fn geometry(&self) -> Area {
+        match self.shell {
+            Shell::XdgV6(ref xdg_surface) => {
+                with_handles!([(xdg_surface: {xdg_surface})] => {
+                    xdg_surface.geometry()
+                }).unwrap()
+            }
+        }
+    }
 }

--- a/src/compositor/view.rs
+++ b/src/compositor/view.rs
@@ -11,13 +11,16 @@ pub struct PendingMoveResize {
     pub area: Area
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct View {
     pub shell: Shell,
     pub origin: Mutex<Origin>,
-    pub lua_id: u32,
     pub pending_move_resize: Mutex<Option<PendingMoveResize>>
 }
+
+unsafe impl Sync for View {}
+
+unsafe impl Send for View {}
 
 impl PartialEq for View {
     fn eq(&self, other: &View) -> bool {
@@ -27,18 +30,11 @@ impl PartialEq for View {
 
 impl Eq for View {}
 
-static mut lua_counter: u32 = 0;
-
 impl View {
     pub fn new(shell: Shell) -> View {
-        let lua_id = unsafe {
-            lua_counter += 1;
-            lua_counter
-        };
         View { shell: shell,
                origin: Mutex::new(Origin::default()),
                pending_move_resize: Mutex::new(None),
-               lua_id
         }
     }
 


### PR DESCRIPTION
Here's one way to do it.

Set the `CompositorHandle` in a lua `UserData` and set it to a named registry value. Now we can get the `Server` anytime we want it in the awesome code.

Now the `View` can have some kind of `to_lua()` function and we can just put them all in a table and then `client.get()` will be implemented.

What do you think?