### PR TITLE
Restart now shuts down the compositor

### DIFF
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -19,6 +19,8 @@ local hotkeys_popup = require("awful.hotkeys_popup").widget
 -- when client with a matching name is opened:
 require("awful.hotkeys_popup.keys")
 
+gears.timer.start_new(1, function() print("I live") return true end)
+
 -- {{{ Error handling
 -- @DOC_ERROR_HANDLING@
 -- Check if awesome encountered an error during startup and fell back to
@@ -61,7 +63,7 @@ editor_cmd = terminal .. " -e " .. editor
 -- If you do not like this or do not have such a key,
 -- I suggest you to remap Mod4 to another key using xmodmap or other tools.
 -- However, you can use another modifier like Mod1, but it may interact with others.
-modkey = "Mod4"
+modkey = "Ctrl"
 
 -- @DOC_LAYOUT@
 -- Table of layouts to cover with awful.layout.inc, order matters.

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -2,7 +2,6 @@
 
 use super::xproperty::{XProperty, XPropertyType, PROPERTIES};
 use super::{signal, XCB_CONNECTION_HANDLE};
-use awesome::lua::NEXT_LUA;
 use cairo::{self, ImageSurface, ImageSurfaceData};
 use gdk_pixbuf::{Pixbuf, PixbufExt};
 use glib::translate::{ToGlibPtr, FromGlibPtrNone};
@@ -221,10 +220,10 @@ fn systray<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<(u32, Value)> {
 
 /// Restart Awesome by restarting the Lua thread
 fn restart<'lua>(_: &'lua Lua, _: ()) -> rlua::Result<()> {
-    info!("Lua thread restarting");
-    NEXT_LUA.with(|next_lua| {
-        next_lua.set(true);
-    });
+    error!("Lua thread cannot restart.");
+    error!("See https://github.com/way-cooler/way-cooler/issues/555 for more details.");
+    error!("Shutting down..");
+    super::lua::terminate();
     Ok(())
 }
 

--- a/src/awesome/lua/mod.rs
+++ b/src/awesome/lua/mod.rs
@@ -14,7 +14,6 @@ use wlroots::CompositorHandle;
 
 use std::cell::RefCell;
 use std::io::Read;
-use std::cell::Cell;
 
 use awesome::signal;
 
@@ -24,9 +23,6 @@ thread_local! {
 
     /// Global Lua state.
     pub static LUA: RefCell<rlua::Lua> = RefCell::new(unsafe { rlua::Lua::new_with_debug() });
-
-    /// If set then we have restarted the Lua thread. We need to replace LUA when it's not borrowed.
-    pub static NEXT_LUA: Cell<bool> = Cell::new(false);
 
     /// Main GLib loop
     static MAIN_LOOP: RefCell<MainLoop> = RefCell::new(MainLoop::new(None, false));

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -1,11 +1,9 @@
 //! Awesome compatibility modules
 
-use wlroots;
 
 use rlua::{self, LightUserData, Lua, Table};
 use std::{env, mem, path::PathBuf};
 use xcb::{xkb, Connection};
-use awesome::lua::setup_lua;
 
 mod awesome;
 mod button;
@@ -26,7 +24,7 @@ pub mod signal;
 mod tag;
 mod xproperty;
 
-pub use self::lua::{NEXT_LUA, LUA};
+pub use self::lua::LUA;
 
 pub use self::drawin::{Drawin, DRAWINS_HANDLE};
 pub use self::key::Key;
@@ -46,19 +44,7 @@ pub const XCB_CONNECTION_HANDLE: &'static str = "__xcb_connection";
 /// This restarts the Lua thread if there is a new one pending
 #[no_mangle]
 pub extern "C" fn refresh_awesome() {
-    NEXT_LUA.with(|new_lua_check| {
-        if new_lua_check.get() {
-            new_lua_check.set(false);
-            LUA.with(|lua| {
-                let mut lua = lua.borrow_mut();
-                unsafe {
-                    *lua = rlua::Lua::new_with_debug();
-                }
-            });
-            let compositor = wlroots::compositor_handle().unwrap();
-            setup_lua(compositor);
-        }
-    });
+    // TODO
 }
 
 pub fn init(lua: &Lua, server: &mut Server) -> rlua::Result<()> {


### PR DESCRIPTION
~Currently Way Cooler segfaults when Lua restarts because GLib has pointers into the old instance. The solution is to restart that GLib main loop as well.~

~In order to do that, we must make Wayland own the glib loop (e.g. it calls out to it). This will require doing some weird things with unsafe stuff.~

~The biggest problem with this patch right now is that we pass `glib::MainLoop` to C code when you need to pass the pointer. Unfortunately that library doesn't actually provide a way to get to the pointer, so even though it "works" now it's because of UB based on the ordering of Rust structs which can change. A patch should be sent to them.~

~The other big problem is we don't know if it works yet because we don't call `refresh_awesome` any more. The C code will need to be modified for that.~

~This patch has been fixed to work. Unfortunately it relies on UB.~

# TODO
- [ ] ~Clean up code~
- [ ] ~Remove the UB by patching glib-rs~

Gave up and now restarting shutsdown the compositor.

In the future there should be another attempt to fix this.