### PR TITLE
Fix XDG_DATA_DIRS and XDG_CONFIG_DIRS handling

### DIFF
--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -2,10 +2,10 @@
 
 use wlroots;
 
+use awesome::lua::setup_lua;
 use rlua::{self, LightUserData, Lua, Table};
 use std::{env, mem, path::PathBuf};
 use xcb::{xkb, Connection};
-use awesome::lua::setup_lua;
 
 mod awesome;
 mod button;
@@ -26,7 +26,7 @@ pub mod signal;
 mod tag;
 mod xproperty;
 
-pub use self::lua::{NEXT_LUA, LUA};
+pub use self::lua::{LUA, NEXT_LUA};
 
 pub use self::drawin::{Drawin, DRAWINS_HANDLE};
 pub use self::key::Key;
@@ -41,24 +41,25 @@ use compositor::Server;
 pub const GLOBAL_SIGNALS: &'static str = "__awesome_global_signals";
 pub const XCB_CONNECTION_HANDLE: &'static str = "__xcb_connection";
 
-/// Called from `wayland_glib_interface.c` after every call back into the wayland event loop.
+/// Called from `wayland_glib_interface.c` after every call back into the
+/// wayland event loop.
 ///
 /// This restarts the Lua thread if there is a new one pending
 #[no_mangle]
 pub extern "C" fn refresh_awesome() {
     NEXT_LUA.with(|new_lua_check| {
-        if new_lua_check.get() {
-            new_lua_check.set(false);
-            LUA.with(|lua| {
-                let mut lua = lua.borrow_mut();
-                unsafe {
-                    *lua = rlua::Lua::new_with_debug();
-                }
-            });
-            let compositor = wlroots::compositor_handle().unwrap();
-            setup_lua(compositor);
-        }
-    });
+                      if new_lua_check.get() {
+                          new_lua_check.set(false);
+                          LUA.with(|lua| {
+                                       let mut lua = lua.borrow_mut();
+                                       unsafe {
+                                           *lua = rlua::Lua::new_with_debug();
+                                       }
+                                   });
+                          let compositor = wlroots::compositor_handle().unwrap();
+                          setup_lua(compositor);
+                      }
+                  });
 }
 
 pub fn init(lua: &Lua, server: &mut Server) -> rlua::Result<()> {
@@ -86,9 +87,10 @@ fn setup_awesome_path(lua: &Lua) -> rlua::Result<()> {
     let mut path = package.get::<_, String>("path")?;
     let mut cpath = package.get::<_, String>("cpath")?;
 
-    for mut xdg_data_path in env::var("XDG_DATA_DIRS").unwrap_or("/usr/local/share:/usr/share".into())
-                                                      .split(':')
-                                                      .map(PathBuf::from)
+    for mut xdg_data_path in
+        env::var("XDG_DATA_DIRS").unwrap_or("/usr/local/share:/usr/share".into())
+                                 .split(':')
+                                 .map(PathBuf::from)
     {
         xdg_data_path.push("awesome/lib");
         path.push_str(&format!(";{0}/?.lua;{0}/?/init.lua",

--- a/src/awesome/mod.rs
+++ b/src/awesome/mod.rs
@@ -86,7 +86,7 @@ fn setup_awesome_path(lua: &Lua) -> rlua::Result<()> {
     let mut path = package.get::<_, String>("path")?;
     let mut cpath = package.get::<_, String>("cpath")?;
 
-    for mut xdg_data_path in env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".into())
+    for mut xdg_data_path in env::var("XDG_DATA_DIRS").unwrap_or("/usr/local/share:/usr/share".into())
                                                       .split(':')
                                                       .map(PathBuf::from)
     {


### PR DESCRIPTION
When using multiple directories in the `XDG_DATA_DIRS` or `XDG_CONFIG_DIRS` environment variables, as specified in the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html), these variables are currently interpreted as a single directory. This prevents Lua from finding the AwesomeWM modules.

This pull request fixes this problem by splitting the directories and handling each directory separately. In addition, it changes the default for `XDG_DATA_DIRS` to `/usr/local/share:/usr/share`, as specified.