### PR TITLE
Fix immediate issues from base rc.lua

### DIFF
--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -72,6 +72,12 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
     method_setup(lua, &awesome_table)?;
     property_setup(lua, &awesome_table)?;
     let globals = lua.globals();
+    
+    // Fixups: Add string.wlen
+    let global_string: Table = globals.get("string")?;
+    global_string.set("wlen", lua.create_function(wlen)?)?;
+    // TODO Add the rest of fixups
+
     let awesome = lua.create_userdata(AwesomeState::default())?;
     awesome.set_user_value(awesome_table)?;
     globals.set("awesome", awesome)
@@ -386,4 +392,9 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
         }
     }
     surface
+}
+
+/// UTF-8 aware string length computing
+pub fn wlen<'lua>(_: &'lua Lua, cmd: String) -> rlua::Result<Value<'lua>> {
+    Ok(Value::Integer(cmd.len() as i64))
 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -110,6 +110,7 @@ fn method_setup<'lua>(lua: &'lua Lua, awesome_table: &Table<'lua>) -> rlua::Resu
     awesome_table.set("pixbuf_to_surface", lua.create_function(pixbuf_to_surface)?)?;
     awesome_table.set("sync", lua.create_function(sync)?)?;
     awesome_table.set("exec", lua.create_function(exec)?)?;
+    awesome_table.set("spawn", lua.create_function(super::dummy)?)?;
     awesome_table.set("kill", lua.create_function(kill)?)?;
     awesome_table.set("quit", lua.create_function(quit)?)
 }

--- a/src/awesome/awesome.rs
+++ b/src/awesome/awesome.rs
@@ -396,5 +396,5 @@ pub fn load_surface_from_pixbuf(pixbuf: Pixbuf) -> ImageSurface {
 
 /// UTF-8 aware string length computing
 pub fn wlen<'lua>(_: &'lua Lua, cmd: String) -> rlua::Result<Value<'lua>> {
-    Ok(Value::Integer(cmd.len() as i64))
+    Ok(Value::Integer(cmd.chars().count() as i64))
 }

--- a/src/awesome/drawin.rs
+++ b/src/awesome/drawin.rs
@@ -201,6 +201,7 @@ fn object_setup<'lua>(lua: &'lua Lua,
     table.set("drawable", drawable_table)?;
     table.set("geometry", lua.create_function(drawin_geometry)?)?;
     table.set("struts", lua.create_function(drawin_struts)?)?;
+    table.set("buttons", lua.create_function(super::dummy)?)?;
     builder.add_to_meta(table)
 }
 

--- a/src/awesome/key.rs
+++ b/src/awesome/key.rs
@@ -138,7 +138,9 @@ fn set_key<'lua>(_: &'lua Lua,
     if key_name.starts_with('#') && key_name.len() >= 2 {
         let number = key_name[1..].parse::<xkb::Keycode>()
             .map_err(|err| rlua::Error::RuntimeError(format!("Parse error: {:?}", err)))?;
-        key.set_keycode(number-8 as xkb::Keycode)?;
+        // the - 8 is because of xcb conventions, where "#10" is the keysim for 1,
+        // and the keycode of 1 is 0x02 (obviously)
+        key.set_keycode(number - 8 as xkb::Keycode)?;
     } else {
         let keysym = xkb::keysym_from_name(key_name.as_str(), 0);
         key.set_keysym(keysym)?;

--- a/src/awesome/key.rs
+++ b/src/awesome/key.rs
@@ -134,13 +134,13 @@ fn get_key<'lua>(lua: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<'
 fn set_key<'lua>(_: &'lua Lua,
                  (obj, key_name): (AnyUserData<'lua>, String))
                  -> rlua::Result<Value<'lua>> {
-    let keysym = xkb::keysym_from_name(key_name.as_str(), 0);
     let mut key = Key::cast(obj.clone().into())?;
     if key_name.starts_with('#') && key_name.len() >= 2 {
         let number = key_name[1..].parse::<xkb::Keycode>()
             .map_err(|err| rlua::Error::RuntimeError(format!("Parse error: {:?}", err)))?;
-        key.set_keycode(number as xkb::Keycode)?;
+        key.set_keycode(number-8 as xkb::Keycode)?;
     } else {
+        let keysym = xkb::keysym_from_name(key_name.as_str(), 0);
         key.set_keysym(keysym)?;
     }
     Ok(rlua::Value::Nil)

--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -45,7 +45,7 @@ pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua
 }
 
 /// Check is the Lua callback function is set
-pub fn is_keygrabber_set(lua: &Lua) -> bool {
+pub fn is_ok(lua: &Lua) -> bool {
     match lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK) {
         Ok(_) => true,
         _ => false

--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -45,11 +45,8 @@ pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua
 }
 
 /// Check is the Lua callback function is set
-pub fn is_ok(lua: &Lua) -> bool {
-    match lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK) {
-        Ok(_) => true,
-        _ => false
-    }
+pub fn is_keygrabber_set(lua: &Lua) -> bool {
+    lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK).is_ok()
 }
 
 /// Call the Lua callback function for when a key is pressed.

--- a/src/awesome/keygrabber.rs
+++ b/src/awesome/keygrabber.rs
@@ -44,8 +44,16 @@ pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua
              })
 }
 
+/// Check is the Lua callback function is set
+pub fn is_keygrabber_set(lua: &Lua) -> bool {
+    match lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK) {
+        Ok(_) => true,
+        _ => false
+    }
+}
+
 /// Call the Lua callback function for when a key is pressed.
-fn call_keygrabber(lua: &Lua, (mods, key, event): (Table, String, String)) -> rlua::Result<()> {
+pub fn call_keygrabber(lua: &Lua, (mods, key, event): (Table, String, String)) -> rlua::Result<()> {
     let lua_callback = lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK)?;
     lua_callback.call((mods, key, event))
 }

--- a/src/awesome/lua/utils.rs
+++ b/src/awesome/lua/utils.rs
@@ -12,6 +12,16 @@ const MOD_NAMES: [&str; 8] = ["Shift", "Caps", "Control", "Alt", "Mod2", "Mod3",
 /// Keycodes corresponding to various button events.
 const MOUSE_EVENTS: [u32; 5] = [BTN_LEFT, BTN_RIGHT, BTN_MIDDLE, BTN_SIDE, BTN_EXTRA];
 
+const MOD_TYPES: [(KeyboardModifier, Key); 7] = [
+    (KeyboardModifier::WLR_MODIFIER_SHIFT, KEY_Shift_L),
+    (KeyboardModifier::WLR_MODIFIER_CAPS,  KEY_Caps_Lock),
+    (KeyboardModifier::WLR_MODIFIER_CTRL,  KEY_Control_L),
+    (KeyboardModifier::WLR_MODIFIER_ALT,   KEY_Alt_L),
+    (KeyboardModifier::WLR_MODIFIER_MOD2,  KEY_Meta_L),
+    (KeyboardModifier::WLR_MODIFIER_LOGO,  KEY_Super_L),
+    (KeyboardModifier::WLR_MODIFIER_MOD5,  KEY_Hyper_L)
+];
+
 /// Convert a modifier to the Lua interpretation
 pub fn mods_to_lua<'lua>(lua: &'lua Lua, mods: &[Key]) -> rlua::Result<Table<'lua>> {
     let mut mods_list: Vec<String> = Vec::with_capacity(MOD_NAMES.len());
@@ -32,14 +42,7 @@ pub fn mods_to_lua<'lua>(lua: &'lua Lua, mods: &[Key]) -> rlua::Result<Table<'lu
 /// Convert a single number to a modifier list.
 pub fn num_to_mods(modifiers: KeyboardModifier) -> Vec<Key> {
     let mut res = vec![];
-    let mod_types = [(KeyboardModifier::WLR_MODIFIER_SHIFT, KEY_Shift_L),
-                     (KeyboardModifier::WLR_MODIFIER_CAPS, KEY_Caps_Lock),
-                     (KeyboardModifier::WLR_MODIFIER_CTRL, KEY_Control_L),
-                     (KeyboardModifier::WLR_MODIFIER_ALT, KEY_Alt_L),
-                     (KeyboardModifier::WLR_MODIFIER_MOD2, KEY_Meta_L),
-                     (KeyboardModifier::WLR_MODIFIER_LOGO, KEY_Super_L),
-                     (KeyboardModifier::WLR_MODIFIER_MOD5, KEY_Hyper_L)];
-    for (mod_km, mod_k) in mod_types.iter() {
+    for (mod_km, mod_k) in MOD_TYPES.iter() {
         if (mod_km.clone() & modifiers) != KeyboardModifier::empty() {
             res.push(mod_k.clone());
         }

--- a/src/awesome/lua/utils.rs
+++ b/src/awesome/lua/utils.rs
@@ -29,6 +29,24 @@ pub fn mods_to_lua<'lua>(lua: &'lua Lua, mods: &[Key]) -> rlua::Result<Table<'lu
     lua.create_table_from(mods_list.into_iter().enumerate())
 }
 
+/// Convert a single number to a modifier list.
+pub fn num_to_mods(modifiers: KeyboardModifier) -> Vec<Key> {
+    let mut res = vec![];
+    let mod_types = [(KeyboardModifier::WLR_MODIFIER_SHIFT, KEY_Shift_L),
+                     (KeyboardModifier::WLR_MODIFIER_CAPS, KEY_Caps_Lock),
+                     (KeyboardModifier::WLR_MODIFIER_CTRL, KEY_Control_L),
+                     (KeyboardModifier::WLR_MODIFIER_ALT, KEY_Alt_L),
+                     (KeyboardModifier::WLR_MODIFIER_MOD2, KEY_Meta_L),
+                     (KeyboardModifier::WLR_MODIFIER_LOGO, KEY_Super_L),
+                     (KeyboardModifier::WLR_MODIFIER_MOD5, KEY_Hyper_L)];
+    for (mod_km, mod_k) in mod_types.iter() {
+        if (mod_km.clone() & modifiers) != KeyboardModifier::empty() {
+            res.push(mod_k.clone());
+        }
+    };
+    res
+}
+
 /// Convert a modifier list to a single number.
 pub fn mods_to_num(modifiers: Table) -> rlua::Result<KeyboardModifier> {
     let mut res = KeyboardModifier::empty();

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -103,12 +103,12 @@ fn emit_awesome_keybindings(lua: &Lua,
             let keycode = key.keycode()?;
             let keysym = key.keysym()?;
             let modifiers = key.modifiers()?;
-            let binding_match = (keysym != 0 && keysym == event_keysym
-                                 || keycode != 0 && keycode == event.keycode())
-                                && modifiers == 0
-                                || modifiers == event_modifiers.bits();
+            let binding_match = ((keysym != 0 && keysym == event_keysym)
+                                 || (keycode != 0 && keycode == event.keycode()))
+                                && (modifiers == 0
+                                || modifiers == event_modifiers.bits());
             if binding_match {
-                emit_object_signal(&*lua, obj, state_string.into(), event_keysym)?;
+                emit_object_signal(&*lua, obj, state_string.into(), ())?;
             }
         }
     }

--- a/src/compositor/input/keyboard.rs
+++ b/src/compositor/input/keyboard.rs
@@ -1,7 +1,7 @@
 use rlua::{self, Lua};
-use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R},
-              Capability, CompositorHandle, KeyboardHandle, KeyboardHandler, KeyboardModifier,
-              WLR_KEY_PRESSED};
+use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R,
+              keysym_get_name}, Capability, CompositorHandle, KeyboardHandle, KeyboardHandler,
+              KeyboardModifier, WLR_KEY_PRESSED};
 
 use awesome::{self, emit_object_signal, Objectable, LUA, ROOT_KEYS_HANDLE};
 use compositor::Server;
@@ -93,24 +93,45 @@ fn emit_awesome_keybindings(lua: &Lua,
     } else {
         "release"
     };
-    // TODO Should also emit by current focused client so we can
-    // do client based rules.
-    let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>(ROOT_KEYS_HANDLE)?;
-    for event_keysym in event.pressed_keys() {
-        for binding in &keybindings {
-            let obj: awesome::Object = binding.clone().into();
-            let key = awesome::Key::cast(obj.clone()).unwrap();
-            let keycode = key.keycode()?;
-            let keysym = key.keysym()?;
-            let modifiers = key.modifiers()?;
-            let binding_match = ((keysym != 0 && keysym == event_keysym)
-                                 || (keycode != 0 && keycode == event.keycode()))
-                                && (modifiers == 0
-                                || modifiers == event_modifiers.bits());
-            if binding_match {
-                emit_object_signal(&*lua, obj, state_string.into(), ())?;
+    let mut res = Ok(());
+    // If keygrabber is set, grab key
+    // TODO check behavior when event.pressed_keys() isn't a singleton
+    if awesome::keygrabber::is_keygrabber_set(&*lua) {
+        for event_keysym in event.pressed_keys() {
+            let nres = awesome::keygrabber::call_keygrabber(&*lua, (
+                    awesome::lua::mods_to_lua(&*lua,
+                                              &awesome::lua::num_to_mods(event_modifiers))?,
+                    keysym_get_name(event_keysym),
+                    state_string.into()
+            ));
+            res = match nres {
+                Ok(_) => res,
+                err => err
+            }
+        }
+    } else {
+        // TODO Should also emit by current focused client so we can
+        // do client based rules.
+        let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>(ROOT_KEYS_HANDLE)?;
+        for event_keysym in event.pressed_keys() {
+            for binding in &keybindings {
+                let obj: awesome::Object = binding.clone().into();
+                let key = awesome::Key::cast(obj.clone()).unwrap();
+                let keycode = key.keycode()?;
+                let keysym = key.keysym()?;
+                let modifiers = key.modifiers()?;
+                let binding_match = ((keysym != 0 && keysym == event_keysym)
+                                     || (keycode != 0 && keycode == event.keycode()))
+                                    && (modifiers == 0
+                                    || modifiers == event_modifiers.bits());
+                if binding_match {
+                    res = match emit_object_signal(&*lua, obj, state_string.into(), ()) {
+                        Ok(_) => res,
+                        err => err
+                    }
+                }
             }
         }
     }
-    Ok(())
+    res
 }


### PR DESCRIPTION
This allows the base rc.lua to be executed without errors, and for the bindings defined in it to be used.
Adds two dummies for `awesome.spawn` and `drawin.buttons`