### PR TITLE
Add man pages

### DIFF
--- a/makedocs.sh
+++ b/makedocs.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+man() {
+  file=$1
+  dir=$2
+
+  lang="$(dirname $file)"
+  basename=$(basename $file .md)
+  section=${basename##*.}
+
+  mkdir -p "$dir/$lang/man$section"
+  echo "$file > $dir/$lang/man$section/$basename.gz"
+  asciidoctor -d manpage -b manpage -o - "$file" | gzip > "$dir/$lang/man$section/$basename.gz"
+}
+
+html() {
+  file=$1
+  dir=$2
+  basename=$(basename $file .md)
+
+  lang="$(dirname $file)"
+  out="$dir/$lang/$basename.html"
+
+  mkdir -p "$dir/$lang"
+  echo "$file > $out"
+  asciidoctor -o - "$file" > "$out"
+}
+
+# defaults, do all
+do_man=true
+do_html=true
+
+for i in "$@"; do
+  case $i in
+    -m|--manualonly)
+      do_html=false
+    ;;
+    -h|--htmlonly)
+      do_man=false
+    ;;
+    *)
+      if [ -z "$input" ]; then
+        input=$i
+      else
+        output="$PWD/$i"
+      fi
+    ;;
+  esac
+done
+
+which "asciidoctor" > /dev/null
+if [ "$?" -eq 1 ]; then
+  echo "The asciidoctor executable is required to build man files"
+  exit 1
+fi
+
+if [ -z "$output" -o -z "$input" ]; then
+  echo "Way-cooler's documentation maker\nUsage: ./makedocs.sh [-m|--manualonly] [-h|--htmlonly] input output"
+  exit 1
+fi
+
+cd $input
+for file in */*.md *.md; do
+  [ "$do_html" = true ] && html $file $output
+  [ "$do_man" = true ] && man $file $output
+done
+cd - > /dev/null

--- a/makefile
+++ b/makefile
@@ -10,3 +10,11 @@ awesome:
 
 way_cooler:
 	./target/debug/way-cooler
+
+man:
+	./makedocs.sh -m manpages target/man
+
+html:
+	./makedocs.sh -h manpages target/html
+
+docs: man html

--- a/manpages/awesome.1.md
+++ b/manpages/awesome.1.md
@@ -4,7 +4,7 @@ awesome(1)
 NAME
 ----
 
-awesome - Lua controller for Way-Cooler
+awesome - a clone of AwesomeWM as a Wayland client.
 
 SYNOPSIS
 --------
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-*way-cooler* is a tiling window manager for WayLand based on AwesomeWM.
+*way-cooler* is a tiling window manager for Wayland based on AwesomeWM.
 
 *awesome* controls *way-cooler*'s behavior by exposing Lua and DBUS APIs. At startup, it reads an RC file and configure *way-cooler* accordingly.
 

--- a/manpages/awesome.1.md
+++ b/manpages/awesome.1.md
@@ -1,0 +1,46 @@
+awesome(1)
+==========
+
+NAME
+----
+
+awesome - Lua controller for Way-Cooler
+
+SYNOPSIS
+--------
+
+*awesome* [*--version*]
+
+DESCRIPTION
+-----------
+
+*way-cooler* is a tiling window manager for WayLand based on AwesomeWM.
+
+*awesome* controls *way-cooler*'s behavior by exposing Lua and DBUS APIs. At startup, it reads an RC file and configure *way-cooler* accordingly.
+
+The Lua API is (will be) the same as AwesomeWM, so any documentation should be interchangeable. The configuration options are discussed more in length in the *awesomerc* man page.
+
+OPTIONS
+-------
+*--version*:
+    Print version information to standard output, then exit.
+
+CUSTOMIZATION
+-------------
+Create a rc file in '$HOME/.config/way-cooler/rc.lua'. It will be read on launch and will perform all the specified customization.
+
+SEE ALSO
+--------
+*way-cooler*(1) *awesomerc*(5)
+
+BUGS
+----
+Please feel free to report them to https://github.com/way-cooler/way-cooler
+
+AUTHORS
+-------
+Preston Carpenter (a.k.a. Timidger) and others.
+
+WWW
+---
+https://way-cooler.org

--- a/manpages/fr/awesome.1.md
+++ b/manpages/fr/awesome.1.md
@@ -1,0 +1,46 @@
+awesome(1)
+==========
+
+NOM
+----
+
+awesome - Gestionnaire de Way-Cooler
+
+SYNOPSIS
+--------
+
+*awesome* [*--version*]
+
+DESCRIPTION
+-----------
+
+*way-cooler* est un gestionnaire de fenêtres par tuile pour WayLand basé sur AwesomeWM.
+
+*awesome* contrôle *way-cooler* en exposant des APIs Lua et DBUS. Lors du lancement, il exécute son fichier de configuration et configure du même coup *way-cooler*.
+
+L'API Lua est (presque) celui d'AwesomeWM. Ainsi, la documentation devrait être interchangeable. Pour une discussion plus complète sur l'API Lua, veuillez consulter la documentation *awesomerc*.
+
+OPTIONS
+-------
+*--version*:
+    Affiche la version dans la sortie standard, puis termine l'exécution.
+
+PERSONNALISATION
+----------------
+Créer le fichier de configuration '$HOME/.config/way-cooler/rc.lua'. Lors du lancement, il s'exécutera et aura accès à l'API Lua pour configurer adéquatement way-cooler.
+
+À VOIR
+------
+*way-cooler*(1) *awesomerc*(5)
+
+BUGS
+----
+Tous les rapports d'erreur sont les bienvenues. Voir https://github.com/way-cooler/way-cooler
+
+AUTEURS
+-------
+Preston Carpenter (a.k.a. Timidger) et autres.
+
+WWW
+---
+https://way-cooler.org

--- a/manpages/fr/awesome.1.md
+++ b/manpages/fr/awesome.1.md
@@ -4,7 +4,7 @@ awesome(1)
 NOM
 ----
 
-awesome - Gestionnaire de Way-Cooler
+awesome - client Wayland clone de AwesomeWM.
 
 SYNOPSIS
 --------
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-*way-cooler* est un gestionnaire de fenêtres par tuile pour WayLand basé sur AwesomeWM.
+*way-cooler* est un gestionnaire de fenêtres par tuile pour Wayland basé sur AwesomeWM.
 
 *awesome* contrôle *way-cooler* en exposant des APIs Lua et DBUS. Lors du lancement, il exécute son fichier de configuration et configure du même coup *way-cooler*.
 

--- a/manpages/fr/way-cooler.1.md
+++ b/manpages/fr/way-cooler.1.md
@@ -1,0 +1,44 @@
+way-cooler(1)
+=============
+
+NOM
+----
+
+way-cooler - Compositeur Wayland hautement configurable basé sur AwesomeWM
+
+SYNOPSIS
+--------
+
+*way-cooler* [*--version*]
+
+DESCRIPTION
+-----------
+
+*way-cooler* est un gestionnaire de fenêtres par tuile pour WayLand basé sur AwesomeWM. Les fenêtres sont disposées selon des dispositions dynamiques par l'entremise de l'exécutable *awesome*.
+
+L'utilisateur a accès à plusieurs vues de bureau grâce à des **tags**, auxquels sont assignées des fenêtres et qui dictent (en général) leur disposition.
+
+OPTIONS
+-------
+*--version*:
+    Affiche la version dans la sortie standard, puis termine l'exécution.
+
+PERSONNALISATION
+----------------
+*way-cooler* peut (et devrait) être personnalisé en lançant l'exécutable *awesome* (attention, pas l'exécutable de AwesomeWM) avec une configuration située à '.config/way-cooler/rc.lua'.
+
+À VOIR
+------
+*awesome*(1) *awesomerc*(5)
+
+BUGS
+----
+Tous les rapports d'erreur sont les bienvenues. Voir https://github.com/way-cooler/way-cooler
+
+AUTEURS
+-------
+Preston Carpenter (a.k.a. Timidger) et autres.
+
+WWW
+---
+https://way-cooler.org

--- a/manpages/way-cooler.1.md
+++ b/manpages/way-cooler.1.md
@@ -1,0 +1,44 @@
+way-cooler(1)
+=============
+
+NAME
+----
+
+way-cooler - AwesomeWM-based customizable Wayland compositor (window manager)
+
+SYNOPSIS
+--------
+
+*way-cooler* [*--version*]
+
+DESCRIPTION
+-----------
+
+*way-cooler* is a tiling window manager for WayLand based on AwesomeWM. It handles windows based on dynamic layouts with the help of the *awesome* utilitary.
+
+It provides the user with multiple desktop views by the means of tags. Each window is assigned one or more tags, which dictates (in most cases) the layout it will use.
+
+OPTIONS
+-------
+*--version*:
+    Print version information to standard output, then exit.
+
+CUSTOMIZATION
+-------------
+*way-cooler* can (and should) be customized by launching the *awesome* command (not the original AwesomeWM one) with a custom '.config/way-cooler/rc.lua' file.
+
+SEE ALSO
+--------
+*awesome*(1) *awesomerc*(5)
+
+BUGS
+----
+Please feel free to report them to https://github.com/way-cooler/way-cooler
+
+AUTHORS
+-------
+Preston Carpenter (a.k.a. Timidger) and others.
+
+WWW
+---
+https://way-cooler.org


### PR DESCRIPTION
Add man and html targets to the makefile, responsible for generating two versions of the content of the manpages directory, one for man per se and one for the web.
The man pages are a basic introduction to the window manager.
They are fairly short, as only one flag is supported and the specifications are already done by Awesome.
They are translated in french and english.

Issue: https://github.com/way-cooler/way-cooler/issues/335