### PR TITLE
Fix the include statements in awesome/root.rs

### DIFF
--- a/awesome/src/root.rs
+++ b/awesome/src/root.rs
@@ -135,9 +135,8 @@ fn root_keys<'lua>(lua: &'lua Lua, key_array: rlua::Value<'lua>) -> rlua::Result
 
 #[cfg(test)]
 mod test {
-    use super::super::root;
-    use super::super::tag;
-    use super::super::key;
+    use ::root;
+    use ::objects::{tag, key};
     use rlua::Lua;
 
     #[test]


### PR DESCRIPTION
The include statements in the tests in awesome/root.rs weren't using the latest code organisation, importing from super::super.
Now they import from ::root and ::objects.

Fix for: https://github.com/way-cooler/way-cooler/issues/574