### PR TITLE
Implement basic clients method for tag

### DIFF
--- a/awesome/src/objects/client.rs
+++ b/awesome/src/objects/client.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Display, Formatter};
 
 use rlua::{self, Lua, Table, ToLua, UserData, Value};
 
-use common::{class::{Class, ClassBuilder},
+use common::{class::{self, Class, ClassBuilder},
              object::{Object, Objectable}};
 
 #[derive(Clone, Debug)]
@@ -24,15 +24,16 @@ impl Default for ClientState {
 }
 
 /* This is currently unused.
- * TODO: Figure out if this will be needed later.
+ * TODO: Figure out if this will be needed later.*/
 
 impl <'lua> Client<'lua> {
-    fn new(lua: &Lua) -> rlua::Result<Object> {
+    fn new(lua: &'lua Lua, args: Table) -> rlua::Result<Object<'lua>> {
         let class = class::class_setup(lua, "client")?;
-        Ok(Client::allocate(lua, class)?.build())
+        Ok(Client::allocate(lua, class)?.handle_constructor_argument(args)?
+                                        .build())
     }
 }
-*/
+
 
 impl Display for ClientState {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -59,6 +60,8 @@ fn method_setup<'lua>(lua: &'lua Lua,
     // TODO Do properly
     use super::dummy;
     builder.method("connect_signal".into(), lua.create_function(dummy)?)?
+           .method("__call".into(),
+                   lua.create_function(|lua, args: Table| Client::new(lua, args))?)?
            .method("get".into(), lua.create_function(dummy_table)?)
 }
 


### PR DESCRIPTION
Create a clients method as well as a client initialization mecanism in the tag constructor to allow to set the clients.
A downside of this implementation is that clients are stored as values rather than references, so they are not the original Lua values.
Small changes were made in the clients file to allow tests while the root API is not finished.

I am fairly new to rust, so some code may not be optimal, sorry.
As said in the commit message, to keep TagState lifetime-free and keep the Tag object in the standard format, clones are stored instead of references. This in turn means that the clients are not the original lua values. If you see a workaround, please let me know, so I can improve the code (and my knowledge).

Related: https://github.com/way-cooler/way-cooler/issues/394