### PR TITLE
Make `Object` a generic type rather than a type wrapped inside classes

### DIFF
--- a/awesome/src/common/class.rs
+++ b/awesome/src/common/class.rs
@@ -147,6 +147,7 @@ fn set_index_miss_handler<'lua>(_: &'lua Lua,
     meta.set("__index_miss_handler", func)?;
     Ok(())
 }
+
 fn set_newindex_miss_handler<'lua>(_: &'lua Lua,
                                    (class, func): (AnyUserData, Function))
                                    -> rlua::Result<()> {

--- a/awesome/src/common/object.rs
+++ b/awesome/src/common/object.rs
@@ -7,26 +7,39 @@ use rlua::{self, AnyUserData, FromLua, Function, Lua, MetaMethod, Table, ToLua, 
            UserDataMethods, Value};
 use std::convert::From;
 use std::fmt::Display;
+use std::cell;
+use std::marker::PhantomData;
+
+/// Define the traits for states
+pub trait State: UserData + Default + Display + Send {}
+impl<T> State for T where T: UserData + Default + Display + Send {}
 
 /// All Lua objects can be cast to this.
-#[derive(Clone, Debug)]
-pub struct Object<'lua> {
-    pub object: AnyUserData<'lua>
+#[derive(Debug)]
+pub struct Object<'lua, S: State>{
+    pub obj: AnyUserData<'lua>,
+    state: PhantomData<S>,
 }
 
-impl<'lua> From<AnyUserData<'lua>> for Object<'lua> {
-    fn from(object: AnyUserData<'lua>) -> Self {
-        Object { object }
+impl<'lua, S: State> Clone for Object<'lua, S> {
+    fn clone(&self) -> Self {
+        Object { obj: self.obj.clone(), state: PhantomData }
+    }
+}
+
+impl<'lua, S: State> From<AnyUserData<'lua>> for Object<'lua, S> {
+    fn from(obj: AnyUserData<'lua>) -> Self {
+        Object { obj, state: PhantomData }
     }
 }
 
 /// Construct a new object, used when using the default Objectable::new.
-pub struct ObjectBuilder<'lua> {
+pub struct ObjectBuilder<'lua, S: State> {
     lua: &'lua Lua,
-    object: Object<'lua>
+    object: Object<'lua, S>
 }
 
-impl<'lua> ObjectBuilder<'lua> {
+impl<'lua, S: State> ObjectBuilder<'lua, S> {
     pub fn add_to_meta(self, new_meta: Table<'lua>) -> rlua::Result<Self> {
         let meta = self.object
                        .table()?
@@ -77,7 +90,7 @@ impl<'lua> ObjectBuilder<'lua> {
         Ok(self)
     }
 
-    pub fn build(self) -> Object<'lua> {
+    pub fn build(self) -> Object<'lua, S> {
         self.object
     }
 }
@@ -89,35 +102,40 @@ impl<'lua> ObjectBuilder<'lua> {
 ///
 /// You can't do anything to the object until it has been converted into a
 /// canonical form using this trait.
-pub trait Objectable<'lua, T, S: UserData + Default + Display + Send> {
-    fn cast(obj: Object<'lua>) -> rlua::Result<T> {
-        if obj.object.is::<S>()? {
-            Ok(Self::_wrap(obj))
+impl<'lua, S: State> Object<'lua, S> {
+    pub fn cast(obj: AnyUserData<'lua>) -> rlua::Result<Self> {
+        if obj.is::<S>()? {
+            Ok(obj.into())
         } else {
             use rlua::Error::RuntimeError;
             Err(RuntimeError("Could not cast object to concrete type".into()))
         }
     }
 
-    /// Given the internal object table, constructs a concrete object out
-    /// of it.
-    ///
-    /// This is only used internally, which is why it's prefixed with a "_"
-    /// Please do not use it outside of object.rs.
-    fn _wrap(table: Object<'lua>) -> T;
-
-    fn state(&self) -> rlua::Result<::std::cell::Ref<S>>;
+    pub fn state(&self) -> rlua::Result<cell::Ref<S>> {
+        Ok(self.obj.borrow::<S>()?)
+    }
 
     /// Gets a mutable reference to the internal state for the concrete object.
-    fn get_object_mut(&mut self) -> rlua::Result<::std::cell::RefMut<S>>;
+    pub fn get_object_mut(&mut self) -> rlua::Result<cell::RefMut<S>> {
+        Ok(self.obj.borrow_mut::<S>()?)
+    }
+
+    pub fn signals(&self) -> rlua::Result<rlua::Table<'lua>> {
+        self.table()?.get::<_, Table>("signals")
+    }
+
+    pub fn table(&self) -> rlua::Result<Table<'lua>> {
+        self.obj.get_user_value::<Table<'lua>>()
+    }
 
     /// Lua objects in Way Cooler are just how they are in Awesome:
     /// * We expose the user data directly.
     /// * State for the object is stored using set_user_value in a "wrapper"
     /// table. * The wrapper table has a data field which hosts the data.
     /// * Class methods/attributes are on the meta table of the wrapper table.
-    fn allocate(lua: &'lua Lua, class: Class) -> rlua::Result<ObjectBuilder<'lua>> {
-        let object = lua.create_userdata(S::default())?;
+    pub fn allocate(lua: &'lua Lua, class: Class<S>) -> rlua::Result<ObjectBuilder<'lua, S>> {
+        let obj = lua.create_userdata(S::default())?;
         // TODO Increment the instance count
         let wrapper_table = lua.create_table()?;
         let data_table = lua.create_table()?;
@@ -126,57 +144,56 @@ pub trait Objectable<'lua, T, S: UserData + Default + Display + Send> {
         meta.set("__class", class)?;
         meta.set("properties", Vec::<Property>::new().to_lua(lua)?)?;
         meta.set("signals", lua.create_table()?)?;
-        meta.set("connect_signal", lua.create_function(connect_signal)?)?;
-        meta.set("disconnect_signal", lua.create_function(disconnect_signal)?)?;
-        meta.set("emit_signal", lua.create_function(emit_signal)?)?;
+        meta.set("connect_signal", lua.create_function(connect_signal::<S>)?)?;
+        meta.set("disconnect_signal", lua.create_function(disconnect_signal::<S>)?)?;
+        meta.set("emit_signal", lua.create_function(emit_signal::<S>)?)?;
         meta.set("__index", meta.clone())?;
         meta.set("__tostring",
                   lua.create_function(|_, data: AnyUserData| {
                                            Ok(format!("{}", data.borrow::<S>()?))
                                        })?)?;
         wrapper_table.set_metatable(Some(meta));
-        object.set_user_value(wrapper_table)?;
+        obj.set_user_value(wrapper_table)?;
         // TODO Emit new signal event
-        let object = Object { object };
+        let object = Object { obj, state: PhantomData };
         Ok(ObjectBuilder { object, lua })
     }
 }
 
-impl<'lua> ToLua<'lua> for Object<'lua> {
+impl<'lua, S: State> ToLua<'lua> for Object<'lua, S> {
     fn to_lua(self, _: &'lua Lua) -> rlua::Result<Value<'lua>> {
-        Ok(Value::UserData(self.object))
+        Ok(Value::UserData(self.obj))
     }
 }
 
-impl<'lua> Object<'lua> {
-    pub fn signals(&self) -> rlua::Result<rlua::Table<'lua>> {
-        self.table()?.get::<_, Table>("signals")
-    }
-
-    pub fn table(&self) -> rlua::Result<Table<'lua>> {
-        self.object.get_user_value::<Table<'lua>>()
+impl<'lua, S: State> FromLua<'lua> for Object<'lua, S> {
+    fn from_lua(val: Value<'lua>, _lua: &'lua Lua) -> rlua::Result<Self> {
+        if let Value::UserData(obj) = val {
+            Object::cast(obj)
+        } else {
+            Err(rlua::Error::RuntimeError("Invalid data supplied".into()))
+        }
     }
 }
 
 /// Can be used for implementing UserData for Lua objects. This provides some
 /// default metafunctions.
 pub fn default_add_methods<S>(methods: &mut UserDataMethods<S>)
-    where S: UserData
+    where S: State
 {
-    methods.add_meta_function(MetaMethod::Index, default_index);
-    methods.add_meta_function(MetaMethod::NewIndex, default_newindex);
-    methods.add_meta_function(MetaMethod::ToString, default_tostring);
+    methods.add_meta_function(MetaMethod::Index, default_index::<S>);
+    methods.add_meta_function(MetaMethod::NewIndex, default_newindex::<S>);
+    methods.add_meta_function(MetaMethod::ToString, default_tostring::<S>);
 }
 
 /// Default indexing of an Awesome object.
 ///
 /// Automatically looks up contents in meta table, so instead of overriding this
 /// it's easier to just add the required data in the meta table.
-pub fn default_index<'lua>(lua: &'lua Lua,
-                           (obj, index): (AnyUserData<'lua>, Value<'lua>))
-                           -> rlua::Result<Value<'lua>> {
+pub fn default_index<'lua, S: State>(lua: &'lua Lua,
+                                    (obj, index): (Object<'lua, S>, Value<'lua>))
+                                    -> rlua::Result<Value<'lua>> {
     // Look up in metatable first
-    let obj: Object<'lua> = obj.into();
     let obj_table = obj.table()?;
     let meta = obj_table.get_metatable().expect("Object had no metatable");
     if meta.get::<_, AnyUserData>("__class").is_ok() {
@@ -194,7 +211,7 @@ pub fn default_index<'lua>(lua: &'lua Lua,
     match index.as_str() {
         "valid" => {
             Ok(Value::Boolean(if let Ok(class) = meta.get::<_, AnyUserData>("__class") {
-                                  let class: Class = class.into();
+                                  let class: Class<S> = class.into();
                                   class.checker()?.map(|checker| checker(obj)).unwrap_or(true)
                               } else {
                                   false
@@ -231,11 +248,11 @@ pub fn default_index<'lua>(lua: &'lua Lua,
 ///
 /// Automatically looks up contents in meta table, so instead of overriding this
 /// it's easier to just add the required data in the meta table.
-pub fn default_newindex<'lua>(_: &'lua Lua,
-                              (obj, index, val): (AnyUserData<'lua>, String, Value<'lua>))
-                              -> rlua::Result<Value<'lua>> {
+pub fn default_newindex<'lua, S: State>(
+                _: &'lua Lua,
+                (obj, index, val): (Object<'lua, S>, String, Value<'lua>))
+                -> rlua::Result<Value<'lua>> {
     // Look up in metatable first
-    let obj: Object<'lua> = obj.into();
     let obj_table = obj.table()?;
     if let Some(meta) = obj_table.get_metatable() {
         if let Ok(val) = meta.raw_get::<_, Value>(index.clone()) {
@@ -266,28 +283,33 @@ pub fn default_newindex<'lua>(_: &'lua Lua,
     Ok(Value::Nil)
 }
 
-pub fn default_tostring<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<String> {
-    let obj: Object<'lua> = obj.into();
+pub fn default_tostring<'lua, S>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<String>
+        where S: State {
+    let obj: Object<'lua, S> = obj.into();
     let obj_table = obj.table()?;
     if let Some(meta) = obj_table.get_metatable() {
         let class = meta.get::<_, AnyUserData>("__class")?;
         let class_table = class.get_user_value::<Table>()?;
         let name = class_table.get::<_, String>("name")?;
-        return Ok(format!("{}: {:p}", name, &obj.object as *const _))
+        return Ok(format!("{}: {:p}", name, &obj.obj as *const _))
     }
     Err(rlua::Error::UserDataTypeMismatch)
 }
 
-fn connect_signal(lua: &Lua,
-                  (obj, signal, func): (AnyUserData, String, Function))
-                  -> rlua::Result<()> {
+fn connect_signal<S: State>(lua: &Lua,
+                            (obj, signal, func): (Object<S>, String, Function))
+                            -> rlua::Result<()> {
     signal::connect_signal(lua, obj.into(), signal, &[func])
 }
 
-fn disconnect_signal(lua: &Lua, (obj, signal): (AnyUserData, String)) -> rlua::Result<()> {
+fn disconnect_signal<S: State>(lua: &Lua,
+                               (obj, signal): (Object<S>, String))
+                               -> rlua::Result<()> {
     signal::disconnect_signal(lua, obj.into(), signal)
 }
 
-fn emit_signal(lua: &Lua, (obj, signal, args): (AnyUserData, String, Value)) -> rlua::Result<()> {
+fn emit_signal<S: State>(lua: &Lua,
+                        (obj, signal, args): (Object<S>, String, Value))
+                        -> rlua::Result<()> {
     signal::emit_object_signal(lua, obj.into(), signal, args)
 }

--- a/awesome/src/common/signal.rs
+++ b/awesome/src/common/signal.rs
@@ -7,15 +7,15 @@
 use rlua::{self, Function, Lua, Table, ToLua, ToLuaMulti, Value};
 
 use ::GLOBAL_SIGNALS;
-use common::object::Object;
+use common::object::{Object, State};
 
 /// Connects functions to a signal. Creates a new entry in the table if it
 /// doesn't exist.
-pub fn connect_signal(lua: &Lua,
-                      obj: Object,
-                      name: String,
-                      funcs: &[Function])
-                      -> rlua::Result<()> {
+pub fn connect_signal<S: State>(lua: &Lua,
+                                obj: Object<S>,
+                                name: String,
+                                funcs: &[Function])
+                                -> rlua::Result<()> {
     let signals = obj.signals()?;
     connect_signals(lua, signals, name, funcs)
 }
@@ -41,7 +41,10 @@ fn connect_signals<'lua>(lua: &'lua Lua,
     }
 }
 
-pub fn disconnect_signal(lua: &Lua, obj: Object, name: String) -> rlua::Result<()> {
+pub fn disconnect_signal<S: State>(lua: &Lua,
+                                   obj: Object<S>,
+                                   name: String)
+                                   -> rlua::Result<()> {
     let signals = obj.signals()?;
     disconnect_signals(lua, signals, name)
 }
@@ -51,12 +54,13 @@ fn disconnect_signals(_: &Lua, signals: Table, name: String) -> rlua::Result<()>
 }
 
 /// Evaluate the functions associated with a signal.
-pub fn emit_object_signal<'lua, A>(lua: &'lua Lua,
-                                   obj: Object<'lua>,
-                                   name: String,
-                                   args: A)
-                                   -> rlua::Result<()>
-    where A: ToLuaMulti<'lua> + Clone
+pub fn emit_object_signal<'lua, A, S>(lua: &'lua Lua,
+                                      obj: Object<'lua, S>,
+                                      name: String,
+                                      args: A)
+                                      -> rlua::Result<()>
+    where A: ToLuaMulti<'lua> + Clone,
+          S: State
 {
     let signals = obj.signals()?;
     let mut args = args.to_lua_multi(lua)?;

--- a/awesome/src/keygrabber.rs
+++ b/awesome/src/keygrabber.rs
@@ -5,7 +5,7 @@ use wlroots::{events::key_events::{Key, KeyEvent}, wlr_key_state,
               xkbcommon::xkb::keysym_get_name, KeyboardModifier, WLR_KEY_PRESSED};
 
 use ::{LUA, lua, root::ROOT_KEYS_HANDLE};
-use common::{object::{Object, Objectable}, signal};
+use common::{object::Object, signal};
 use objects::key;
 
 pub const KEYGRABBER_TABLE: &str = "keygrabber";
@@ -111,11 +111,9 @@ fn emit_awesome_keybindings(lua: &Lua,
     } else {
         // TODO Should also emit by current focused client so we can
         // do client based rules.
-        let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>(ROOT_KEYS_HANDLE)?;
+        let keybindings = lua.named_registry_value::<Vec<key::Key>>(ROOT_KEYS_HANDLE)?;
         for event_keysym in event.pressed_keys() {
-            for binding in &keybindings {
-                let obj: Object = binding.clone().into();
-                let key = key::Key::cast(obj.clone()).unwrap();
+            for key in &keybindings {
                 let keycode = key.keycode()?;
                 let keysym = key.keysym()?;
                 let modifiers = key.modifiers()?;
@@ -124,7 +122,7 @@ fn emit_awesome_keybindings(lua: &Lua,
                                     && (modifiers == 0
                                     || modifiers == event_modifiers.bits());
                 if binding_match {
-                    if let Err(err) = signal::emit_object_signal(&*lua, obj, state_string.into(), ()) {
+                    if let Err(err) = signal::emit_object_signal(&*lua, key.clone(), state_string.into(), ()) {
                         warn!("Could not emit the signal for {}: {:?}", keysym, err);
                     }
                 }

--- a/awesome/src/macros.rs
+++ b/awesome/src/macros.rs
@@ -10,21 +10,3 @@ macro_rules! keypress {
                                             $modifier, " and ", $key))
     };
 }
-
-macro_rules! impl_objectable {
-    ($WrapperType:ident, $StateType:ty) => {
-        impl<'lua> Objectable<'lua, $WrapperType<'lua>, $StateType> for $WrapperType<'lua> {
-            fn _wrap(object: Object<'lua>) -> $WrapperType {
-                $WrapperType(object)
-            }
-
-            fn state(&self) -> $crate::rlua::Result<::std::cell::Ref<$StateType>> {
-                Ok(self.0.object.borrow::<$StateType>()?)
-            }
-
-            fn get_object_mut(&mut self) -> $crate::rlua::Result<::std::cell::RefMut<$StateType>> {
-                Ok(self.0.object.borrow_mut::<$StateType>()?)
-            }
-        }
-    };
-}

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -50,7 +50,7 @@ use self::lua::{LUA, NEXT_LUA};
 
 
 use self::objects::key::Key;
-use self::common::{object::{Object, Objectable}, signal::*};
+use self::common::{object::Object, signal::*};
 use self::root::ROOT_KEYS_HANDLE;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -217,8 +217,7 @@ fn emit_awesome_keybindings(lua: &Lua,
     let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>(ROOT_KEYS_HANDLE)?;
     for event_keysym in event.pressed_keys() {
         for binding in &keybindings {
-            let obj: Object = binding.clone().into();
-            let key = Key::cast(obj.clone()).unwrap();
+            let key = Key::cast(binding.clone().into()).unwrap();
             let keycode = key.keycode()?;
             let keysym = key.keysym()?;
             let modifiers = key.modifiers()?;
@@ -227,7 +226,7 @@ fn emit_awesome_keybindings(lua: &Lua,
                                 && modifiers == 0
                                 || modifiers == event_modifiers.bits();
             if binding_match {
-                emit_object_signal(&*lua, obj, state_string.into(), event_keysym)?;
+                emit_object_signal(&*lua, key, state_string.into(), event_keysym)?;
             }
         }
     }

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -214,10 +214,9 @@ fn emit_awesome_keybindings(lua: &Lua,
     };
     // TODO Should also emit by current focused client so we can
     // do client based rules.
-    let keybindings = lua.named_registry_value::<Vec<rlua::AnyUserData>>(ROOT_KEYS_HANDLE)?;
+    let keybindings = lua.named_registry_value::<Vec<Key>>(ROOT_KEYS_HANDLE)?;
     for event_keysym in event.pressed_keys() {
-        for binding in &keybindings {
-            let key = Key::cast(binding.clone().into()).unwrap();
+        for key in &keybindings {
             let keycode = key.keycode()?;
             let keysym = key.keysym()?;
             let modifiers = key.modifiers()?;
@@ -226,7 +225,7 @@ fn emit_awesome_keybindings(lua: &Lua,
                                 && modifiers == 0
                                 || modifiers == event_modifiers.bits();
             if binding_match {
-                emit_object_signal(&*lua, key, state_string.into(), event_keysym)?;
+                emit_object_signal(&*lua, key.clone(), state_string.into(), event_keysym)?;
             }
         }
     }

--- a/awesome/src/objects/button.rs
+++ b/awesome/src/objects/button.rs
@@ -5,7 +5,7 @@
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
 
-use rlua::{self, AnyUserData, Lua, Table, UserData, UserDataMethods, Value};
+use rlua::{self, Lua, Table, UserData, UserDataMethods, Value};
 use wlroots::events::key_events::Key;
 use xcb::ffi::xproto::xcb_button_t;
 
@@ -101,20 +101,19 @@ fn set_button<'lua>(lua: &'lua Lua,
     Ok(Value::Nil)
 }
 
-fn get_button<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<'lua>> {
-    Button::cast(obj.into())?.button()
+fn get_button<'lua>(_: &'lua Lua, mut button: Button<'lua>) -> rlua::Result<Value<'lua>> {
+    button.button()
 }
 
 fn set_modifiers<'lua>(lua: &'lua Lua,
-                       (obj, modifiers): (AnyUserData<'lua>, Table<'lua>))
+                       (mut button, modifiers): (Button<'lua>, Table<'lua>))
                        -> rlua::Result<()> {
-    let mut button = Button::cast(obj)?;
     button.set_modifiers(modifiers.clone())?;
     signal::emit_object_signal(lua, button, "property::modifiers".into(), modifiers)?;
     Ok(())
 }
 
-fn get_modifiers<'lua>(lua: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<'lua>> {
+fn get_modifiers<'lua>(lua: &'lua Lua, button: Button<'lua>) -> rlua::Result<Value<'lua>> {
     use lua::mods_to_lua;
-    mods_to_lua(lua, &Button::cast(obj.into())?.modifiers()?).map(Value::Table)
+    mods_to_lua(lua, &button.modifiers()?).map(Value::Table)
 }

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -10,7 +10,7 @@ use rlua::{self, AnyUserData, LightUserData, Lua, Table, ToLua,
 use wlroots::{Area, Origin, Size};
 
 use common::{class::{self, Class},
-             object::{self, Object, Objectable},
+             object::{self, Object},
              property::Property};
 
 #[derive(Clone, Debug)]
@@ -21,9 +21,7 @@ pub struct DrawableState {
     refreshed: bool
 }
 
-pub struct Drawable<'lua>(Object<'lua>);
-
-impl_objectable!(Drawable, DrawableState);
+pub type Drawable<'lua> = Object<'lua, DrawableState>;
 
 impl Default for DrawableState {
     fn default() -> Self {
@@ -34,7 +32,7 @@ impl Default for DrawableState {
 }
 
 impl<'lua> Drawable<'lua> {
-    pub fn new(lua: &Lua) -> rlua::Result<Object> {
+    pub fn new(lua: &Lua) -> rlua::Result<Drawable> {
         let class = class::class_setup(lua, "drawable")?;
         let builder = Drawable::allocate(lua, class)?;
         // TODO Do properly
@@ -104,19 +102,13 @@ impl Display for DrawableState {
     }
 }
 
-impl<'lua> ToLua<'lua> for Drawable<'lua> {
-    fn to_lua(self, lua: &'lua Lua) -> rlua::Result<Value<'lua>> {
-        self.0.to_lua(lua)
-    }
-}
-
 impl UserData for DrawableState {
     fn add_methods(methods: &mut UserDataMethods<Self>) {
         object::default_add_methods(methods);
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<Class> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<DrawableState>> {
     Class::builder(lua, "drawable", None)?
         .method("geometry".into(), lua.create_function(geometry)?)?
         .property(Property::new("surface".into(),

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display, Formatter};
 
 use cairo::{Format, ImageSurface};
 use glib::translate::ToGlibPtr;
-use rlua::{self, AnyUserData, LightUserData, Lua, Table,
+use rlua::{self, LightUserData, Lua, Table,
            UserData, UserDataMethods, Value};
 use wlroots::{Area, Origin, Size};
 
@@ -119,13 +119,11 @@ pub fn init(lua: &Lua) -> rlua::Result<Class<DrawableState>> {
         .build()
 }
 
-fn get_surface<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Value<'lua>> {
-    let drawable = Drawable::cast(obj.into())?;
+fn get_surface<'lua>(_: &'lua Lua, drawable: Drawable<'lua>) -> rlua::Result<Value<'lua>> {
     drawable.get_surface()
 }
 
-fn geometry<'lua>(lua: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Table<'lua>> {
-    let drawable = Drawable::cast(obj.into())?;
+fn geometry<'lua>(lua: &'lua Lua, drawable: Drawable<'lua>) -> rlua::Result<Table<'lua>> {
     let geometry = drawable.get_geometry()?;
     let Origin { x, y } = geometry.origin;
     let Size { width, height } = geometry.size;
@@ -137,6 +135,6 @@ fn geometry<'lua>(lua: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<Table<
     Ok(table)
 }
 
-fn refresh<'lua>(_: &'lua Lua, obj: AnyUserData<'lua>) -> rlua::Result<()> {
-    Drawable::cast(obj.into())?.refresh()
+fn refresh<'lua>(_: &'lua Lua, mut drawable: Drawable<'lua>) -> rlua::Result<()> {
+    drawable.refresh()
 }

--- a/awesome/src/objects/mouse.rs
+++ b/awesome/src/objects/mouse.rs
@@ -6,7 +6,7 @@
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
 
-use rlua::{self, AnyUserData, Lua, MetaMethod, Table,
+use rlua::{self, Lua, MetaMethod, Table, AnyUserData,
            ToLua, UserData, UserDataMethods, Value};
 
 use objects::screen::{Screen, SCREENS_HANDLE};
@@ -91,7 +91,7 @@ fn index<'lua>(lua: &'lua Lua,
             // TODO Get output
             let output = unimplemented!();
 
-            let mut screens: Vec<Screen> = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?
+            let mut screens: Vec<Screen> = lua.named_registry_value::<Vec<Screen>>(SCREENS_HANDLE)?
                 .into_iter()
                 .map(|obj| Screen::cast(obj.into()).unwrap())
                 .collect();

--- a/awesome/src/objects/mouse.rs
+++ b/awesome/src/objects/mouse.rs
@@ -9,7 +9,6 @@ use std::fmt::{self, Display, Formatter};
 use rlua::{self, AnyUserData, Lua, MetaMethod, Table,
            ToLua, UserData, UserDataMethods, Value};
 
-use common::object::Objectable;
 use objects::screen::{Screen, SCREENS_HANDLE};
 
 const INDEX_MISS_FUNCTION: &'static str = "__index_miss_function";

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -6,7 +6,7 @@
 use std::default::Default;
 use std::fmt::{self, Display, Formatter};
 
-use rlua::{self, AnyUserData, Lua, MetaMethod, Table, ToLua, UserData,
+use rlua::{self, Lua, MetaMethod, Table, ToLua, UserData,
            UserDataMethods, Value};
 use wlroots::{Area, Origin, OutputHandle, Size};
 
@@ -166,18 +166,16 @@ fn property_setup<'lua>(lua: &'lua Lua,
                                    None))
 }
 
-fn get_geometry<'lua>(lua: &'lua Lua, object: AnyUserData<'lua>) -> rlua::Result<Table<'lua>> {
-    let screen = Screen::cast(object.into())?;
+fn get_geometry<'lua>(lua: &'lua Lua, screen: Screen<'lua>) -> rlua::Result<Table<'lua>> {
     screen.get_geometry(lua)
 }
 
-fn get_workarea<'lua>(lua: &'lua Lua, object: AnyUserData<'lua>) -> rlua::Result<Table<'lua>> {
-    let screen = Screen::cast(object.into())?;
+fn get_workarea<'lua>(lua: &'lua Lua, screen: Screen<'lua>) -> rlua::Result<Table<'lua>> {
     screen.get_workarea(lua)
 }
 
 fn count<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>> {
-    let screens = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?;
+    let screens = lua.named_registry_value::<Vec<Screen>>(SCREENS_HANDLE)?;
     Ok(Value::Integer(screens.len() as _))
 }
 
@@ -191,10 +189,8 @@ fn count<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>> {
 fn iterate_over_screens<'lua>(lua: &'lua Lua,
                               (_, prev): (Value<'lua>, Value<'lua>))
                               -> rlua::Result<Value<'lua>> {
-    let mut screens: Vec<Screen> = lua.named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?
-                                      .into_iter()
-                                      .map(|obj| Screen::cast(obj.into()).unwrap())
-                                      .collect();
+    let mut screens = lua.named_registry_value::<Vec<Screen>>(SCREENS_HANDLE)?;
+
     let index = match prev {
         Value::Nil => 0,
         Value::UserData(ref object) => {

--- a/awesome/src/root.rs
+++ b/awesome/src/root.rs
@@ -9,7 +9,7 @@ use rlua::{self, LightUserData, Lua, Table, ToLua, UserData,
            UserDataMethods, Value};
 
 use common::{class::{Class, ClassBuilder},
-             object::{self, Object, Objectable}};
+             object::{self, Object}};
 use objects::tag;
 
 /// Handle to the list of global key bindings


### PR DESCRIPTION
By using a `PhantomData` on the `Object` type, one can then make the different awesome objects directly as `Object`s which accept different states
This remove the need to copy the traits definition in all objects (even if the macro call makes it easy) and remove the need for the `Objectable` trait.
This also means that most of the `AnyUserData` function parameters could be replaced by the concrete type using a common `FromLua` implementation, thus making the code more DRY by removing the need for explicit casting.