### PR TITLE
Remove left-over import statements from root.rs

### DIFF
--- a/awesome/src/root.rs
+++ b/awesome/src/root.rs
@@ -1,15 +1,9 @@
 //! API for root resources, such as wallpapers and keybindings.
 //! Awesome's equivalent of globalconf's properties are accessible via registry keys
 
-use std::default::Default;
-use std::fmt::{self, Display, Formatter};
-
 use cairo_sys::cairo_pattern_t;
-use rlua::{self, LightUserData, Lua, Table, ToLua, UserData,
-           UserDataMethods, Value};
+use rlua::{self, LightUserData, Lua, Table, ToLua, Value};
 
-use common::{class::{Class, ClassBuilder},
-             object::{self, Object, Objectable}};
 use objects::tag;
 
 /// Handle to the list of global key bindings


### PR DESCRIPTION
`root.rs` had import statements not removed when it cease to be an object. Fix that.