### PR TITLE
Remove all the warnings

### DIFF
--- a/awesome/src/common/class.rs
+++ b/awesome/src/common/class.rs
@@ -55,6 +55,7 @@ impl<'lua, S: ObjectStateType> ClassBuilder<'lua, S> {
     }
 
     // TODO remove, do right
+    #[allow(dead_code)]
     pub fn dummy_property(self, key: String, val: rlua::Value<'lua>) -> rlua::Result<Self> {
         let table = self.class.class.get_user_value::<Table>()?;
         let meta = table.get_metatable().expect("Class had no meta table!");

--- a/awesome/src/keygrabber.rs
+++ b/awesome/src/keygrabber.rs
@@ -27,6 +27,7 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 
 /// Given the current input, handle calling the Lua defined callback if it is
 /// defined with the input.
+#[allow(dead_code)]
 pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua::Result<()> {
     LUA.with(|lua| {
                  let lua = lua.borrow();
@@ -46,11 +47,13 @@ pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua
 }
 
 /// Check is the Lua callback function is set
+#[allow(dead_code)]
 pub fn is_keygrabber_set(lua: &Lua) -> bool {
     lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK).is_ok()
 }
 
 /// Call the Lua callback function for when a key is pressed.
+#[allow(dead_code)]
 pub fn call_keygrabber(lua: &Lua, (mods, key, event): (Table, String, String)) -> rlua::Result<()> {
     let lua_callback = lua.named_registry_value::<Function>(KEYGRABBER_CALLBACK)?;
     lua_callback.call((mods, key, event))
@@ -86,6 +89,7 @@ fn new_index(lua: &Lua, args: Value) -> rlua::Result<()> {
 
 
 /// Emits the Awesome keybindinsg.
+#[allow(dead_code)]
 fn emit_awesome_keybindings(lua: &Lua,
                             event: &KeyEvent,
                             event_modifiers: KeyboardModifier)

--- a/awesome/src/lua/utils.rs
+++ b/awesome/src/lua/utils.rs
@@ -8,10 +8,13 @@ use wlroots::{events::{key_events::Key,
 use rlua::{self, Error::RuntimeError, Lua, Table, Value};
 
 /// Human readable versions of the standard modifier keys.
+#[allow(dead_code)]
 const MOD_NAMES: [&str; 8] = ["Shift", "Caps", "Control", "Alt", "Mod2", "Mod3", "Mod4", "Mod5"];
 /// Keycodes corresponding to various button events.
+#[allow(dead_code)]
 const MOUSE_EVENTS: [u32; 5] = [BTN_LEFT, BTN_RIGHT, BTN_MIDDLE, BTN_SIDE, BTN_EXTRA];
 
+#[allow(dead_code)]
 const MOD_TYPES: [(KeyboardModifier, Key); 7] = [
     (KeyboardModifier::WLR_MODIFIER_SHIFT, KEY_Shift_L),
     (KeyboardModifier::WLR_MODIFIER_CAPS,  KEY_Caps_Lock),

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -19,7 +19,6 @@ extern crate wayland_client;
 
 // TODO remove
 extern crate wlroots;
-use wlroots::{KeyboardModifier, key_events::KeyEvent, wlr_key_state::*};
 
 #[macro_use]
 mod macros;
@@ -37,7 +36,6 @@ mod lua;
 use std::{env, mem, path::PathBuf, process::exit};
 
 use exec::Command;
-use lua::setup_lua;
 use rlua::{LightUserData, Lua, Table};
 use log::LogLevel;
 use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet};
@@ -47,11 +45,6 @@ use wayland_client::protocol::{wl_output, wl_display::RequestsTrait};
 use wayland_client::sys::client::wl_display;
 
 use self::lua::{LUA, NEXT_LUA};
-
-
-use self::objects::key::Key;
-use self::common::{object::Object, signal::*};
-use self::root::ROOT_KEYS_HANDLE;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const GIT_VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/git-version.txt"));
@@ -111,7 +104,7 @@ fn main() {
 fn init_wayland() {
     let (display, mut event_queue) = match Display::connect_to_env() {
         Ok(res) => res,
-        Err(err) => {
+        Err(_) => {
             error!("Could not connect to Wayland server. Is it running?");
             exit(1);
         }

--- a/awesome/src/mousegrabber.rs
+++ b/awesome/src/mousegrabber.rs
@@ -18,6 +18,7 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
     globals.set(MOUSEGRABBER_TABLE, mousegrabber_table)
 }
 
+#[allow(dead_code)]
 pub fn mousegrabber_handle(x: i32,
                            y: i32,
                            button: Option<(u32, wlr_button_state)>)
@@ -33,6 +34,7 @@ pub fn mousegrabber_handle(x: i32,
              })
 }
 
+#[allow(dead_code)]
 fn call_mousegrabber(lua: &Lua, (x, y, button_events): (i32, i32, Vec<bool>)) -> rlua::Result<()> {
     let lua_callback = match lua.named_registry_value::<Function>(MOUSEGRABBER_CALLBACK) {
         Ok(function) => function,

--- a/awesome/src/objects/drawin.rs
+++ b/awesome/src/objects/drawin.rs
@@ -55,10 +55,12 @@ impl<'lua> Drawin<'lua> {
     /// Get the drawable associated with this drawin.
     ///
     /// It has the surface that is needed to render to the screen.
+    #[allow(dead_code)]
     pub fn drawable(&mut self) -> rlua::Result<Drawable> {
         self.get_associated_data::<Drawable>("drawable")
     }
 
+    #[allow(dead_code)]
     pub fn texture(&mut self) -> rlua::Result<RefMut<Option<Texture<'static>>>> {
         Ok(RefMut::map(self.state_mut()?, |state| &mut state.texture))
     }

--- a/awesome/src/objects/key.rs
+++ b/awesome/src/objects/key.rs
@@ -55,6 +55,7 @@ impl<'lua> Key<'lua> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn keycode(&self) -> rlua::Result<xkb::Keycode> {
         let state = self.state()?;
         Ok(state.keycode)

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 
 use rlua::{self, Lua, MetaMethod, Table, ToLua, UserData,
            UserDataMethods, Value};
-use wlroots::{Area, Origin, OutputHandle, Size};
+use wlroots::{Area, Origin, Size};
 
 use common::{class::{self, Class, ClassBuilder},
              object::{self, Object},
@@ -69,6 +69,7 @@ impl<'lua> Screen<'lua> {
         Ok(Screen::allocate(lua, class)?.build())
     }
 
+    #[allow(dead_code)]
     fn init_screens(&mut self,
                     output: Output,
                     outputs: Vec<Output>)

--- a/awesome/src/objects/tag.rs
+++ b/awesome/src/objects/tag.rs
@@ -51,11 +51,11 @@ impl<'lua> Tag<'lua> {
             let new_clients = clients.iter().cloned()
                                      .collect::<HashSet<_>>();
                 
-            for client in new_clients.difference(&prev_clients) {
+            for _client in new_clients.difference(&prev_clients) {
                 // emit signal
             };
 
-            for client in prev_clients.difference(&new_clients) {
+            for _client in prev_clients.difference(&new_clients) {
                 // TODO: emit signal and garbage if not referenced anymore
             };
         };
@@ -234,7 +234,7 @@ fn get_clients<'lua>(lua: &'lua Lua,  (mut tag, val): (Tag<'lua>, Value<'lua>)) 
 #[cfg(test)]
 mod test {
     use super::super::{tag::{self, Tag}, client::{self, Client}};
-    use rlua::{Lua, Value, ToLua};
+    use rlua::Lua;
 
     #[test]
     fn tag_name_empty() {


### PR DESCRIPTION
With all the methods that aren't used, the dead code warnings polute the output of compilation and obfuscate the valuable warnings during development.
This might be a bit controversial, but it it will be easier to grep for the different `allow` annotations after version 1.0 than to fix a lot of warnings which should be caught during the process.