### PR TITLE
Force no warnings in test phase

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -33,5 +33,4 @@ tasks:
       git submodule update --init --recursive
   - build: |
       cd way-cooler
-      cargo build --all --verbose
-      cargo test --all --verbose
+      cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aster"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,9 +55,9 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "exec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk-pixbuf 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,6 +169,9 @@ dependencies = [
 name = "cc"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cexpr"
@@ -209,6 +220,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dlib"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +274,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "dtoa"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -538,6 +585,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "meson"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +619,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "nom"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +643,14 @@ dependencies = [
 name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -693,6 +758,27 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +860,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -1174,6 +1265,7 @@ dependencies = [
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
@@ -1193,10 +1285,14 @@ dependencies = [
 "checksum clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "611ec2e3a7623afd8a8c0d027887b6b55759d894abbf5fe11b9dc11b50d5b49a"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
@@ -1231,12 +1327,15 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum meson 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de6e688268407ad0a7c589bf2d7313db6c2079dae5c96df0f2d5903bc6343a91"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
 "checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
 "checksum phf_codegen 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "7d187f00cd98d5afbcd8898f6cf181743a449162aeb329dcd2f3849009e605ad"
@@ -1250,6 +1349,8 @@ dependencies = [
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
+"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
@@ -1261,6 +1362,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,5 @@
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -56,13 +48,13 @@ dependencies = [
  "cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "exec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk-pixbuf 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -283,20 +275,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -476,6 +471,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,14 +559,6 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -725,6 +720,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,18 +793,6 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -816,13 +804,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.3.9"
+name = "regex"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "regex-syntax"
 version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,6 +983,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,23 +1006,6 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1049,11 +1043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "utf8-ranges"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1077,9 +1066,9 @@ name = "way-cooler"
 version = "0.8.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wlroots 0.0.0",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1195,9 +1184,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wlroots"
@@ -1262,7 +1268,6 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
@@ -1293,8 +1298,8 @@ dependencies = [
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-"checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum exec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615"
@@ -1313,6 +1318,7 @@ dependencies = [
 "checksum glib-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615bef979b5838526aee99241afc80cfb2e34a8735d4bcb8ec6072598c18a408"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum gobject-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70409d6405db8b1591602fcd0cbe8af52cd9976dd39194442b4c149ba343f86d"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a08e2a31d665af8f1ca437eab6d00a93c9d62a549f73f9ed8fc2e55b5a91a7"
@@ -1324,7 +1330,6 @@ dependencies = [
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -1345,6 +1350,7 @@ dependencies = [
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
@@ -1353,10 +1359,10 @@ dependencies = [
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum rlua 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4d6a9d2d1da31dd5cb4878789b924e46a600bdca4895b30f2efd6370d0dfc80e"
 "checksum rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a654c5bda722c699be6b0fe4c0d90de218928da5b724c3e467fc48865c37263"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
@@ -1376,17 +1382,15 @@ dependencies = [
 "checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
 "checksum target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
@@ -1404,7 +1408,9 @@ dependencies = [
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
 "checksum xkbcommon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac975d685d902d49d5ae9b52dbd217b2accb40ae17ee6e62beec95fafe8c856"
 "checksum xml-rs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1945e12e16b951721d7976520b0832496ef79c31602c7a29d950de79ba74621"

--- a/awesome/Cargo.toml
+++ b/awesome/Cargo.toml
@@ -12,8 +12,8 @@ publish = false
 [dependencies]
 wlroots = { path = "../wlroots-rs" }
 lazy_static = "0.2"
-log = "0.3"
-env_logger = "0.3"
+log = "0.4"
+env_logger = "0.5"
 exec = "0.3"
 rlua = { version = "0.12.0", default-features = false }
 bitflags = "0.7"

--- a/awesome/Cargo.toml
+++ b/awesome/Cargo.toml
@@ -28,7 +28,7 @@ xcb = { version = "0.8.1", features = ["xkb"] }
 wayland-client = "0.20.11"
 
 [build-dependencies]
-gcc = "0.3.*"
+cc = { version = "1.0", features = ["parallel"] }
 pkg-config = "0.3.*"
 
 

--- a/awesome/build.rs
+++ b/awesome/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 extern crate pkg_config;
 
 use std::{env, fs, io::Write, path::Path, process::Command};
@@ -49,7 +49,7 @@ fn in_release_commit() -> bool {
 /// Build the wayland-glib interface as a static library
 fn build_wayland_glib_interface() {
     let lib = pkg_config::Config::new().probe("glib-2.0").unwrap();
-    let mut builder = gcc::Build::new();
+    let mut builder = cc::Build::new();
 
     for i in &lib.include_paths {
         builder.include(i);

--- a/awesome/src/awesome.rs
+++ b/awesome/src/awesome.rs
@@ -61,7 +61,7 @@ impl UserData for AwesomeState {
     fn add_methods(methods: &mut UserDataMethods<Self>) {
         fn index<'lua>(_: &'lua Lua,
                        (awesome, index): (AnyUserData<'lua>, Value<'lua>))
-                       -> rlua::Result<rlua::Value<'lua>> {
+                       -> rlua::Result<Value<'lua>> {
             let table = awesome.get_user_value::<Table>()?;
             table.get::<_, Value>(index)
         };
@@ -248,7 +248,7 @@ fn load_image<'lua>(lua: &'lua Lua, file_path: String) -> rlua::Result<Value<'lu
     // surface.
     let surface_ptr = surface.to_glib_none().0;
     ::std::mem::forget(surface);
-    rlua::LightUserData(surface_ptr as _).to_lua(lua)
+    LightUserData(surface_ptr as _).to_lua(lua)
 }
 
 /// Convert a pixbuf to a cairo image surface.
@@ -261,7 +261,7 @@ fn pixbuf_to_surface<'lua>(lua: &'lua Lua, pixbuf: LightUserData) -> rlua::Resul
     // surface.
     let surface_ptr = surface.to_glib_none().0;
     ::std::mem::forget(surface);
-    rlua::LightUserData(surface_ptr as _).to_lua(lua)
+    LightUserData(surface_ptr as _).to_lua(lua)
 }
 
 fn exec(_: &Lua, command: String) -> rlua::Result<()> {

--- a/awesome/src/awesome.rs
+++ b/awesome/src/awesome.rs
@@ -199,16 +199,17 @@ fn xkb_get_group_names<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>>
             return Ok(Value::Nil)
         }
         let mut names_list: ffi::xkb::xcb_xkb_get_names_value_list_t = mem::uninitialized();
-        xcb_xkb_get_names_value_list_unpack(buffer,
-                                            (*names_r_ptr).nTypes,
-                                            (*names_r_ptr).indicators,
-                                            (*names_r_ptr).virtualMods,
-                                            (*names_r_ptr).groupNames,
-                                            (*names_r_ptr).nKeys,
-                                            (*names_r_ptr).nKeyAliases,
-                                            (*names_r_ptr).nRadioGroups,
-                                            (*names_r_ptr).which,
-                                            &mut names_list);
+
+        let _ = xcb_xkb_get_names_value_list_unpack(buffer,
+                                                    (*names_r_ptr).nTypes,
+                                                    (*names_r_ptr).indicators,
+                                                    (*names_r_ptr).virtualMods,
+                                                    (*names_r_ptr).groupNames,
+                                                    (*names_r_ptr).nKeys,
+                                                    (*names_r_ptr).nKeyAliases,
+                                                    (*names_r_ptr).nRadioGroups,
+                                                    (*names_r_ptr).which,
+                                                    &mut names_list);
         let atom_name_c = ffi::xproto::xcb_get_atom_name_unchecked(raw_con, names_list.symbolsName);
         let atom_name_r =
             ffi::xproto::xcb_get_atom_name_reply(raw_con, atom_name_c, ptr::null_mut());
@@ -266,14 +267,14 @@ fn pixbuf_to_surface<'lua>(lua: &'lua Lua, pixbuf: LightUserData) -> rlua::Resul
 
 fn exec(_: &Lua, command: String) -> rlua::Result<()> {
     trace!("exec: \"{}\"", command);
-    thread::Builder::new().name(command.clone())
-        .spawn(|| {
-            Command::new(command).stdout(Stdio::null())
-                .spawn()
-                .expect("Could not spawn command")
-                .wait()
-        })
-        .expect("Unable to spawn thread");
+    let _ = thread::Builder::new().name(command.clone())
+            .spawn(|| {
+                Command::new(command).stdout(Stdio::null())
+                    .spawn()
+                    .expect("Could not spawn command")
+                    .wait()
+            })
+            .expect("Unable to spawn thread");
     Ok(())
 }
 

--- a/awesome/src/common/class.rs
+++ b/awesome/src/common/class.rs
@@ -63,13 +63,8 @@ impl<'lua, S: ObjectStateType> ClassBuilder<'lua, S> {
         Ok(self)
     }
 
-    pub fn save_class(self, name: &str) -> rlua::Result<Self> {
-        self.lua.globals().set(name, self.class.class.clone())?;
-        Ok(self)
-    }
-
-    pub fn build(self) -> rlua::Result<Class<'lua, S>> {
-        Ok(self.class)
+    pub fn save_class(self, name: &str) -> rlua::Result<()> {
+        self.lua.globals().set(name, self.class.class.clone())
     }
 }
 

--- a/awesome/src/common/class.rs
+++ b/awesome/src/common/class.rs
@@ -39,7 +39,7 @@ pub struct ClassBuilder<'lua, S: ObjectStateType> {
 }
 
 impl<'lua, S: ObjectStateType> ClassBuilder<'lua, S> {
-    pub fn method(self, name: String, meth: rlua::Function) -> rlua::Result<Self> {
+    pub fn method(self, name: String, meth: Function) -> rlua::Result<Self> {
         let table = self.class.class.get_user_value::<Table>()?;
         let meta = table.get_metatable().expect("Class had no meta table!");
         meta.set(name, meth)?;
@@ -56,7 +56,7 @@ impl<'lua, S: ObjectStateType> ClassBuilder<'lua, S> {
 
     // TODO remove, do right
     #[allow(dead_code)]
-    pub fn dummy_property(self, key: String, val: rlua::Value<'lua>) -> rlua::Result<Self> {
+    pub fn dummy_property(self, key: String, val: Value<'lua>) -> rlua::Result<Self> {
         let table = self.class.class.get_user_value::<Table>()?;
         let meta = table.get_metatable().expect("Class had no meta table!");
         meta.set(key, val)?;

--- a/awesome/src/common/object.rs
+++ b/awesome/src/common/object.rs
@@ -52,7 +52,7 @@ impl<'lua, S: ObjectStateType> ObjectBuilder<'lua, S> {
     pub fn add_to_meta(self, new_meta: Table<'lua>) -> rlua::Result<Self> {
         let meta = self.object.get_metatable()?
                        .expect("Object had no meta table");
-        for entry in new_meta.pairs::<rlua::Value, rlua::Value>() {
+        for entry in new_meta.pairs::<Value, Value>() {
             let (key, value) = entry?;
             meta.set(key, value)?;
         }
@@ -61,7 +61,7 @@ impl<'lua, S: ObjectStateType> ObjectBuilder<'lua, S> {
     }
 
     #[allow(dead_code)]
-    pub fn add_to_signals(self, name: String, func: rlua::Function) -> rlua::Result<Self> {
+    pub fn add_to_signals(self, name: String, func: Function) -> rlua::Result<Self> {
         signal::connect_signal(self.lua, self.object.clone(), name, &[func])?;
         Ok(self)
     }
@@ -127,7 +127,7 @@ impl<'lua, S: ObjectStateType> Object<'lua, S> {
     }
 
     /// Get the signals of the for this object
-    pub fn signals(&self) -> rlua::Result<rlua::Table<'lua>> {
+    pub fn signals(&self) -> rlua::Result<Table<'lua>> {
         self.get_associated_data::<Table>("signals")
     }
 

--- a/awesome/src/common/signal.rs
+++ b/awesome/src/common/signal.rs
@@ -92,7 +92,7 @@ fn emit_signals<'lua, A>(_: &'lua Lua,
 
 /// Connect the function to the named signal in the global signal list.
 pub fn global_connect_signal<'lua>(lua: &'lua Lua,
-                                   (name, func): (String, rlua::Function<'lua>))
+                                   (name, func): (String, Function<'lua>))
                                    -> rlua::Result<()> {
     let global_signals = lua.named_registry_value::<Table>(GLOBAL_SIGNALS)?;
     connect_signals(lua, global_signals, name, &[func])

--- a/awesome/src/keygrabber.rs
+++ b/awesome/src/keygrabber.rs
@@ -31,7 +31,7 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
 pub fn keygrabber_handle(mods: Vec<Key>, sym: Key, state: wlr_key_state) -> rlua::Result<()> {
     LUA.with(|lua| {
                  let lua = lua.borrow();
-                 let lua_state = if state == wlr_key_state::WLR_KEY_PRESSED {
+                 let lua_state = if state == WLR_KEY_PRESSED {
                                      "press"
                                  } else {
                                      "release"
@@ -59,7 +59,7 @@ pub fn call_keygrabber(lua: &Lua, (mods, key, event): (Table, String, String)) -
     lua_callback.call((mods, key, event))
 }
 
-fn run(lua: &Lua, function: rlua::Function) -> rlua::Result<()> {
+fn run(lua: &Lua, function: Function) -> rlua::Result<()> {
     match lua.named_registry_value::<Value>(KEYGRABBER_CALLBACK)? {
         Value::Function(_) => {
             Err(rlua::Error::RuntimeError("keygrabber callback already set!".into()))

--- a/awesome/src/lua/config.rs
+++ b/awesome/src/lua/config.rs
@@ -38,8 +38,8 @@ pub fn load_config(mut lua: &mut Lua) {
                     .expect("Failed to set package.path");
             }
             let mut init_contents = String::new();
-            init_file.read_to_string(&mut init_contents)
-                .expect("Could not read contents");
+            let _ = init_file.read_to_string(&mut init_contents)
+                             .expect("Could not read contents");
             lua.exec(init_contents.as_str(), Some("init.lua".into()))
                 .map(|_:()| info!("Read init.lua successfully"))
                 .or_else(|err| {

--- a/awesome/src/lua/utils.rs
+++ b/awesome/src/lua/utils.rs
@@ -98,7 +98,7 @@ pub fn mods_to_rust(mods_table: Table) -> rlua::Result<Vec<Key>> {
 }
 
 /// Convert a mouse event from Wayland to the representation Lua expcets
-pub fn mouse_events_to_lua(_: &rlua::Lua,
+pub fn mouse_events_to_lua(_: &Lua,
                            button: u32,
                            button_state: wlr_button_state)
                            -> rlua::Result<Vec<bool>> {

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -1,5 +1,38 @@
 //! Awesome compatibility modules
 
+#![cfg_attr(test, deny(bad_style,
+       const_err,
+       dead_code,
+       improper_ctypes,
+       legacy_directory_ownership,
+       non_shorthand_field_patterns,
+       no_mangle_generic_items,
+       overflowing_literals,
+       path_statements ,
+       patterns_in_fns_without_body,
+       plugin_as_library,
+       private_in_public,
+       private_no_mangle_fns,
+       private_no_mangle_statics,
+       safe_extern_statics,
+       unconditional_recursion,
+       unions_with_drop_fields,
+       unused,
+       unused_allocation,
+       unused_comparisons,
+       unused_parens,
+       while_true))]
+
+// Allowed by default
+#![cfg_attr(test, deny(missing_docs,
+       trivial_numeric_casts,
+       unused_extern_crates,
+       unused_import_braces,
+       unused_qualifications))]
+
+// May be good to add
+// #![cfg_attr(test, warn(unused_results))]
+
 extern crate cairo;
 extern crate cairo_sys;
 extern crate env_logger;

--- a/awesome/src/objects/button.rs
+++ b/awesome/src/objects/button.rs
@@ -34,7 +34,7 @@ impl UserData for ButtonState {
 }
 
 impl<'lua> Button<'lua> {
-    fn new(lua: &'lua Lua, args: rlua::Table) -> rlua::Result<Button<'lua>> {
+    fn new(lua: &'lua Lua, args: Table) -> rlua::Result<Button<'lua>> {
         let class = class::class_setup(lua, "button")?;
         Ok(Button::allocate(lua, class)?.handle_constructor_argument(args)?
                                         .build())
@@ -67,7 +67,7 @@ impl<'lua> Button<'lua> {
 pub fn init(lua: &Lua) -> rlua::Result<Class<ButtonState>> {
     Class::builder(lua, "button", None)?
         .method("__call".into(),
-                lua.create_function(|lua, args: rlua::Table|
+                lua.create_function(|lua, args: Table|
                                     Button::new(lua, args))?)?
         .property(Property::new("button".into(),
                                 Some(lua.create_function(set_button)?),
@@ -91,7 +91,7 @@ fn set_button<'lua>(lua: &'lua Lua,
         _ => button.set_button(xcb_button_t::default())?
     }
     signal::emit_object_signal(lua, button, "property::button".into(), val)?;
-    Ok(Value::Nil)
+    Ok(Nil)
 }
 
 fn get_button<'lua>(_: &'lua Lua, button: Button<'lua>) -> rlua::Result<Value<'lua>> {

--- a/awesome/src/objects/button.rs
+++ b/awesome/src/objects/button.rs
@@ -64,8 +64,8 @@ impl<'lua> Button<'lua> {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<Class<ButtonState>> {
-    Class::builder(lua, "button", None)?
+pub fn init(lua: &Lua) -> rlua::Result<()> {
+    Class::<ButtonState>::builder(lua, "button", None)?
         .method("__call".into(),
                 lua.create_function(|lua, args: Table|
                                     Button::new(lua, args))?)?
@@ -77,8 +77,7 @@ pub fn init(lua: &Lua) -> rlua::Result<Class<ButtonState>> {
                                 Some(lua.create_function(set_modifiers)?),
                                 Some(lua.create_function(get_modifiers)?),
                                 Some(lua.create_function(set_modifiers)?)))?
-        .save_class("button")?
-        .build()
+        .save_class("button")
 }
 
 fn set_button<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/client.rs
+++ b/awesome/src/objects/client.rs
@@ -49,9 +49,8 @@ impl <'lua> Client<'lua> {
 
 impl UserData for ClientState {}
 
-pub fn init(lua: &Lua) -> rlua::Result<Class<ClientState>> {
-    method_setup(lua, Class::builder(lua, "client", None)?)?.save_class("client")?
-                                                            .build()
+pub fn init(lua: &Lua) -> rlua::Result<()> {
+    method_setup(lua, Class::builder(lua, "client", None)?)?.save_class("client")
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -59,7 +59,7 @@ impl<'lua> Drawable<'lua> {
                 //
                 // If there's a bug, worst case scenario there's a memory leak.
                 unsafe {
-                    ::cairo_sys::cairo_surface_reference(ptr);
+                    let _ = ::cairo_sys::cairo_surface_reference(ptr);
                 }
                 Value::LightUserData(LightUserData(ptr as _))
             }
@@ -101,15 +101,14 @@ impl UserData for DrawableState {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<Class<DrawableState>> {
-    Class::builder(lua, "drawable", None)?
+pub fn init(lua: &Lua) -> rlua::Result<()> {
+    Class::<DrawableState>::builder(lua, "drawable", None)?
         .method("geometry".into(), lua.create_function(geometry)?)?
         .property(Property::new("surface".into(),
                                 None,
                                 Some(lua.create_function(get_surface)?),
                                 None))?
-        .save_class("drawable")?
-        .build()
+        .save_class("drawable")
 }
 
 fn get_surface<'lua>(_: &'lua Lua, drawable: Drawable<'lua>) -> rlua::Result<Value<'lua>> {

--- a/awesome/src/objects/drawin.rs
+++ b/awesome/src/objects/drawin.rs
@@ -134,12 +134,11 @@ impl<'lua> Drawin<'lua> {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<Class<DrawinState>> {
+pub fn init(lua: &Lua) -> rlua::Result<()> {
     let drawins: Vec<Drawin> = Vec::new();
     lua.set_named_registry_value(DRAWINS_HANDLE, drawins.to_lua(lua)?)?;
     property_setup(lua, method_setup(lua, Class::builder(lua, "drawin", None)?)?)?
-        .save_class("drawin")?
-        .build()
+        .save_class("drawin")
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/key.rs
+++ b/awesome/src/objects/key.rs
@@ -68,9 +68,9 @@ impl UserData for KeyState {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<Class<KeyState>> {
-    property_setup(lua, method_setup(lua, Class::builder(lua, "key", None)?)?)?.save_class("key")?
-                                                                               .build()
+pub fn init(lua: &Lua) -> rlua::Result<()> {
+    property_setup(lua, method_setup(lua, Class::builder(lua, "key", None)?)?)?
+      .save_class("key")
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/key.rs
+++ b/awesome/src/objects/key.rs
@@ -126,7 +126,7 @@ fn set_key<'lua>(_: &'lua Lua,
             .map_err(|err| rlua::Error::RuntimeError(format!("Parse error: {:?}", err)))?;
         // the - 8 is because of xcb conventions, where "#10" is the keysim for 1,
         // and the keycode of 1 is 0x02 (obviously)
-        key.set_keycode(number - 8 as xkb::Keycode)?;
+        key.set_keycode(number - 8)?;
     } else {
         let keysym = xkb::keysym_from_name(key_name.as_str(), 0);
         key.set_keysym(keysym)?;

--- a/awesome/src/objects/mouse.rs
+++ b/awesome/src/objects/mouse.rs
@@ -53,7 +53,7 @@ fn method_setup(lua: &Lua, mouse_table: &Table) -> rlua::Result<()> {
 }
 
 fn coords<'lua>(_lua: &'lua Lua,
-                (_coords, _ignore_enter): (rlua::Value<'lua>, rlua::Value<'lua>))
+                (_coords, _ignore_enter): (Value<'lua>, Value<'lua>))
                 -> rlua::Result<Table<'lua>> {
     // TODO Get Cords
     unimplemented!()

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -108,14 +108,13 @@ impl<'lua> Screen<'lua> {
     }
 }
 
-pub fn init<'lua>(lua: &Lua) -> rlua::Result<Class<ScreenState>> {
-    let builder = Class::builder(lua, "screen", None)?;
-    let res = property_setup(lua, method_setup(lua, builder)?)?.save_class("screen")?
-                                                               .build()?;
+pub fn init<'lua>(lua: &Lua) -> rlua::Result<()> {
+    property_setup(lua, method_setup(lua, Class::builder(lua, "screen", None)?)?)?
+        .save_class("screen")?;
     let screens: &mut Vec<Screen> = &mut vec![];
     // TODO Get the list of outputs from Way Cooler
     //for output in server.outputs.iter() {
-    //    let mut screen = Screen::cast(Screen::new(lua)?)?;
+    //    let mut screen = Screen::new(lua)?;
     //    screen.init_screens(output.clone(), vec![output.clone()])?;
     //    // TODO Move to Screen impl like the others
     //    screens.push(screen);
@@ -132,8 +131,7 @@ pub fn init<'lua>(lua: &Lua) -> rlua::Result<Class<ScreenState>> {
         screens.push(screen);
     }
 
-    lua.set_named_registry_value(SCREENS_HANDLE, screens.clone().to_lua(lua)?)?;
-    Ok(res)
+    lua.set_named_registry_value(SCREENS_HANDLE, screens.clone().to_lua(lua)?)
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/root.rs
+++ b/awesome/src/root.rs
@@ -26,7 +26,7 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
     lua.globals().set("root", root)
 }
 
-fn dummy_double<'lua>(_: &'lua Lua, _: rlua::Value) -> rlua::Result<(i32, i32)> {
+fn dummy_double<'lua>(_: &'lua Lua, _: Value) -> rlua::Result<(i32, i32)> {
     Ok((0, 0))
 }
 
@@ -60,7 +60,7 @@ fn tags<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Table<'lua>> {
 /// Get or set global key bindings.
 ///
 /// These bindings will be available when you press keys on the root window.
-fn root_keys<'lua>(lua: &'lua Lua, key_array: rlua::Value<'lua>) -> rlua::Result<rlua::Value<'lua>> {
+fn root_keys<'lua>(lua: &'lua Lua, key_array: Value<'lua>) -> rlua::Result<Value<'lua>> {
     match key_array {
         // Set the global keys
         Value::Table(key_array) => {

--- a/way-cooler/Cargo.toml
+++ b/way-cooler/Cargo.toml
@@ -12,8 +12,8 @@ publish = false
 
 [dependencies]
 wlroots = { path = "../wlroots-rs" }
-log = "0.3"
-env_logger = "0.3"
+log = "0.4"
+env_logger = "0.5"
 bitflags = "0.7"
 nix = "0.6"
 getopts = "0.2"

--- a/way-cooler/src/input/keyboard.rs
+++ b/way-cooler/src/input/keyboard.rs
@@ -64,15 +64,13 @@ impl KeyboardHandler for Keyboard {
         with_handles!([(compositor: {compositor}), (keyboard: {keyboard})] => {
             let server: &mut ::Server = compositor.into();
             let weak_reference = keyboard.weak_reference();
-            if let Some(index) = server.keyboards.iter().position(|k| *k == weak_reference) {
-                server.keyboards.remove(index);
-                if server.keyboards.len() == 0 {
-                    with_handles!([(seat: {&mut server.seat.seat})] => {
-                        let mut capabilities = seat.capabilities();
-                        capabilities.remove(Capability::Keyboard);
-                        seat.set_capabilities(capabilities);
-                    }).expect("Seat was destroyed")
-                }
+            server.keyboards.retain(|k| *k != weak_reference);
+            if server.keyboards.is_empty() {
+                with_handles!([(seat: {&mut server.seat.seat})] => {
+                    let mut capabilities = seat.capabilities();
+                    capabilities.remove(Capability::Keyboard);
+                    seat.set_capabilities(capabilities);
+                }).expect("Seat was destroyed")
             }
         }).unwrap();
     }

--- a/way-cooler/src/input/keyboard.rs
+++ b/way-cooler/src/input/keyboard.rs
@@ -1,6 +1,5 @@
-use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R,
-              keysym_get_name}, Capability, CompositorHandle, KeyboardHandle, KeyboardHandler,
-              KeyboardModifier, WLR_KEY_PRESSED};
+use wlroots::{key_events::KeyEvent, xkbcommon::xkb::{KEY_Escape, KEY_Super_L, KEY_Super_R},
+              Capability, CompositorHandle, KeyboardHandle, KeyboardHandler, WLR_KEY_PRESSED};
 
 pub struct Keyboard;
 
@@ -11,7 +10,7 @@ fn key_is_meta(key: u32) -> bool {
 
 impl KeyboardHandler for Keyboard {
     fn on_key(&mut self, compositor: CompositorHandle, keyboard: KeyboardHandle, event: &KeyEvent) {
-        let modifiers = dehandle!(
+        let _modifiers = dehandle!(
             @compositor = {compositor};
             if event.key_state() == WLR_KEY_PRESSED {
                 for key in event.pressed_keys() {

--- a/way-cooler/src/main.rs
+++ b/way-cooler/src/main.rs
@@ -1,10 +1,39 @@
 //! Main module of way-cooler
 
-// TODO FIXME Remove
-#![allow(dead_code)]
-#![allow(non_upper_case_globals)]
+#![cfg_attr(test, deny(bad_style,
+       const_err,
+       dead_code,
+       improper_ctypes,
+       legacy_directory_ownership,
+       non_shorthand_field_patterns,
+       no_mangle_generic_items,
+       overflowing_literals,
+       path_statements ,
+       patterns_in_fns_without_body,
+       plugin_as_library,
+       private_in_public,
+       private_no_mangle_fns,
+       private_no_mangle_statics,
+       safe_extern_statics,
+       unconditional_recursion,
+       unions_with_drop_fields,
+       unused,
+       unused_allocation,
+       unused_comparisons,
+       unused_parens,
+       while_true))]
 
-extern crate bitflags;
+// Allowed by default
+#![cfg_attr(test, deny(missing_docs,
+       trivial_casts,
+       trivial_numeric_casts,
+       unused_extern_crates,
+       unused_import_braces,
+       unused_qualifications))]
+
+// May be good to add
+// #![cfg_attr(test, warn(unused_results))]
+
 extern crate env_logger;
 extern crate getopts;
 #[macro_use]
@@ -12,7 +41,6 @@ extern crate log;
 extern crate nix;
 #[macro_use]
 pub(crate) extern crate wlroots;
-extern crate xcb;
 
 mod cursor;
 mod input;

--- a/way-cooler/src/output/output.rs
+++ b/way-cooler/src/output/output.rs
@@ -25,6 +25,7 @@ impl OutputHandler for Output {
     }
 }
 
+#[allow(dead_code)]
 fn render_surface(renderer: &mut Renderer,
                   layout: &mut OutputLayoutHandle,
                   surface: &mut SurfaceHandle,

--- a/way-cooler/src/output/output.rs
+++ b/way-cooler/src/output/output.rs
@@ -47,7 +47,9 @@ fn render_surface(renderer: &mut Renderer,
                                      0.0,
                                      renderer.output
                                      .transform_matrix());
-            renderer.render_texture_with_matrix(&surface.texture(), matrix);
+            if !renderer.render_texture_with_matrix(&surface.texture(), matrix) {
+              warn!("Could not render a surface");
+            }
             surface.send_frame_done(current_time());
         }
 
@@ -79,7 +81,9 @@ fn render_views(renderer: &mut Renderer,
                                              0.0,
                                              renderer.output
                                              .transform_matrix());
-                    renderer.render_texture_with_matrix(&surface.texture(), matrix);
+                    if !renderer.render_texture_with_matrix(&surface.texture(), matrix) {
+                      warn!("Could not render a surface");
+                    }
                     surface.send_frame_done(current_time());
                 })
         });

--- a/way-cooler/src/seat.rs
+++ b/way-cooler/src/seat.rs
@@ -104,7 +104,7 @@ impl Seat {
             }
             Some(start) => {
                 let pos = Origin::new(lx as i32 - start.x, ly as i32 - start.y);
-                view.origin.replace(pos);
+                let _ = view.origin.replace(pos);
             }
         };
     }
@@ -246,7 +246,7 @@ impl wlroots::DragIconHandler for DragIconHandler {
     fn destroyed(&mut self, compositor: CompositorHandle, drag_icon: DragIconHandle) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut ::Server = compositor.into();
-            server.seat.drag_icons.remove(&DragIcon{ handle: drag_icon });
+            let _ = server.seat.drag_icons.remove(&DragIcon{ handle: drag_icon });
         }).unwrap();
     }
 }
@@ -278,7 +278,7 @@ impl SeatHandler for SeatManager {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut ::Server = compositor.into();
             let ::Server { ref mut seat, .. } = *server;
-            seat.drag_icons.insert(DragIcon { handle: drag_icon });
+            let _ = seat.drag_icons.insert(DragIcon { handle: drag_icon });
         }).unwrap();
         (Some(Box::new(DragIconHandler)), None)
     }

--- a/way-cooler/src/shells/xdg_v6.rs
+++ b/way-cooler/src/shells/xdg_v6.rs
@@ -141,9 +141,7 @@ impl XdgV6ShellHandler for XdgV6 {
                          ref mut xcursor_manager,
                          .. } = *server;
             let destroyed_shell = shell_surface.into();
-            if let Some(pos) = views.iter().position(|view| view.shell == destroyed_shell) {
-                views.remove(pos);
-            };
+            views.retain(|view| view.shell != destroyed_shell);
 
             if views.len() > 0 {
                 seat.focus_view(views[0].clone(), views);

--- a/way-cooler/src/view.rs
+++ b/way-cooler/src/view.rs
@@ -41,7 +41,7 @@ impl View {
                     @xdg_surface = {xdg_surface};
                     match xdg_surface.state() {
                         Some(&mut TopLevel(ref mut toplevel)) => {
-                            toplevel.set_activated(activate);
+                            let _ = toplevel.set_activated(activate);
                         },
                         _ => unimplemented!()
                     }


### PR DESCRIPTION
Add annotations to disallow warnings when testing, based upon https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md.
Also change the build script, as `test` already includes `build` and removing `--all` permits to leverage caching if it is ever implemented on the backend.
Fixed a dependency (gcc => cc) to remove warnings, and fixed the way-cooler part.

Related: #589