### PR TITLE
Awesome top bar as xdg shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,6 @@ name = "awesome"
 version = "0.8.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -133,11 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "byteorder"
-version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1294,7 +1288,6 @@ dependencies = [
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum c_vec 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c32b15e95ce816aaf991a41420854e6ba772a2679a9296d906eab1114f1b4e9"
 "checksum cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a110f269c2fd382df5fe8bd46dfa5f1b83608aa717fecb6e7a28c08c202f0e13"
 "checksum cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0395175ecba60accac076a02c31d143b9dcd9d5eb5316d7163a3273803b765c7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -44,7 +44,7 @@ dependencies = [
 name = "awesome"
 version = "0.8.0"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,11 +54,14 @@ dependencies = [
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "wlroots 0.0.0",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -228,7 +231,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -289,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -336,10 +339,10 @@ name = "failure_derive"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -406,7 +409,7 @@ dependencies = [
  "glib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gobject-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -430,7 +433,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gobject-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -489,11 +492,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
@@ -517,7 +517,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -535,12 +535,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -678,7 +678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -711,10 +711,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -758,7 +758,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -781,11 +781,11 @@ name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -793,11 +793,11 @@ name = "regex"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ name = "regex-syntax"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,7 +813,7 @@ name = "regex-syntax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -887,22 +887,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.13"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -998,7 +998,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1008,7 +1008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1028,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1062,7 +1062,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wlroots 0.0.0",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1232,7 +1232,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
@@ -1306,15 +1306,15 @@ dependencies = [
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a020ac941774eb37e9d13d418c37b522e76899bfc4e7b1a600d529a53f83a66"
 "checksum libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
+"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum meson 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de6e688268407ad0a7c589bf2d7313db6c2079dae5c96df0f2d5903bc6343a91"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
@@ -1330,11 +1330,11 @@ dependencies = [
 "checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2fc21ba78ac73e4ff6b3818ece00be4e175ffbef4d0a717d978b48b24150c4"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
@@ -1357,8 +1357,8 @@ dependencies = [
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
-"checksum synstructure 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec37f4fab4bafaf6b5621c1d54e6aa5d4d059a8f84929e87abfdd7f9f04c6db2"
+"checksum syn 0.15.19 (registry+https://github.com/rust-lang/crates.io-index)" = "39054bb43f2c5e4f3aef47718a391bf397c1b820fefc86f467d4d354f67bf7ef"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f5e3aaa79319573d19938ea38d068056b826db9883a5d47f86c1cecc688f0e"
 "checksum syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "867cc5c2d7140ae7eaad2ae9e8bf39cb18a67ca651b7834f88d46ca98faadb9c"
 "checksum syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13ad4762fe52abc9f4008e85c4fb1b1fe3aa91ccb99ff4826a439c7c598e1047"
@@ -1370,11 +1370,11 @@ dependencies = [
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ name = "awesome"
 version = "0.8.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,6 +60,7 @@ dependencies = [
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -131,6 +133,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -817,6 +824,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rlua"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +971,19 @@ dependencies = [
  "phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1266,6 +1294,7 @@ dependencies = [
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum c_vec 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c32b15e95ce816aaf991a41420854e6ba772a2679a9296d906eab1114f1b4e9"
 "checksum cairo-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a110f269c2fd382df5fe8bd46dfa5f1b83608aa717fecb6e7a28c08c202f0e13"
 "checksum cairo-sys-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0395175ecba60accac076a02c31d143b9dcd9d5eb5316d7163a3273803b765c7"
@@ -1346,6 +1375,7 @@ dependencies = [
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rlua 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4d6a9d2d1da31dd5cb4878789b924e46a600bdca4895b30f2efd6370d0dfc80e"
 "checksum rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a654c5bda722c699be6b0fe4c0d90de218928da5b724c3e467fc48865c37263"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
@@ -1364,6 +1394,7 @@ dependencies = [
 "checksum syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13ad4762fe52abc9f4008e85c4fb1b1fe3aa91ccb99ff4826a439c7c598e1047"
 "checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
 "checksum target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
+"checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/awesome/Cargo.toml
+++ b/awesome/Cargo.toml
@@ -24,6 +24,8 @@ cairo-sys-rs = "0.6.0"
 gdk-pixbuf = "0.4.*"
 libc = "0.2.*"
 glib = "0.5.0"
+tempfile = "3.0.*"
+byteorder = "1.2.*"
 xcb = { version = "0.8.1", features = ["xkb"] }
 # Todo use the version with my patch
 wayland-client = "0.20.12"

--- a/awesome/Cargo.toml
+++ b/awesome/Cargo.toml
@@ -25,7 +25,6 @@ gdk-pixbuf = "0.4.*"
 libc = "0.2.*"
 glib = "0.5.0"
 tempfile = "3.0.*"
-byteorder = "1.2.*"
 xcb = { version = "0.8.1", features = ["xkb"] }
 # Todo use the version with my patch
 wayland-client = "0.20.12"

--- a/awesome/Cargo.toml
+++ b/awesome/Cargo.toml
@@ -16,20 +16,23 @@ log = "0.4"
 env_logger = "0.5"
 exec = "0.3"
 rlua = { version = "0.12.0", default-features = false }
-bitflags = "0.7"
+bitflags = "1.0"
 nix = "0.6"
 getopts = "0.2"
 cairo-rs = "0.4.1"
 cairo-sys-rs = "0.6.0"
 gdk-pixbuf = "0.4.*"
+libc = "0.2.*"
 glib = "0.5.0"
 xcb = { version = "0.8.1", features = ["xkb"] }
 # Todo use the version with my patch
-wayland-client = "0.20.11"
+wayland-client = "0.20.12"
+wayland-sys = "0.20.12"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 pkg-config = "0.3.*"
+wayland-scanner = "0.20.12"
 
 
 [features]

--- a/awesome/src/awesome.rs
+++ b/awesome/src/awesome.rs
@@ -293,7 +293,6 @@ fn set_preferred_icon_size(lua: &Lua, val: u32) -> rlua::Result<()> {
 }
 
 fn quit(_: &Lua, _: ()) -> rlua::Result<()> {
-    ::wlroots::terminate();
     ::lua::terminate();
     Ok(())
 }

--- a/awesome/src/awesome.rs
+++ b/awesome/src/awesome.rs
@@ -200,16 +200,16 @@ fn xkb_get_group_names<'lua>(lua: &'lua Lua, _: ()) -> rlua::Result<Value<'lua>>
         }
         let mut names_list: ffi::xkb::xcb_xkb_get_names_value_list_t = mem::uninitialized();
 
-        let _ = xcb_xkb_get_names_value_list_unpack(buffer,
-                                                    (*names_r_ptr).nTypes,
-                                                    (*names_r_ptr).indicators,
-                                                    (*names_r_ptr).virtualMods,
-                                                    (*names_r_ptr).groupNames,
-                                                    (*names_r_ptr).nKeys,
-                                                    (*names_r_ptr).nKeyAliases,
-                                                    (*names_r_ptr).nRadioGroups,
-                                                    (*names_r_ptr).which,
-                                                    &mut names_list);
+        xcb_xkb_get_names_value_list_unpack(buffer,
+                                            (*names_r_ptr).nTypes,
+                                            (*names_r_ptr).indicators,
+                                            (*names_r_ptr).virtualMods,
+                                            (*names_r_ptr).groupNames,
+                                            (*names_r_ptr).nKeys,
+                                            (*names_r_ptr).nKeyAliases,
+                                            (*names_r_ptr).nRadioGroups,
+                                            (*names_r_ptr).which,
+                                            &mut names_list);
         let atom_name_c = ffi::xproto::xcb_get_atom_name_unchecked(raw_con, names_list.symbolsName);
         let atom_name_r =
             ffi::xproto::xcb_get_atom_name_reply(raw_con, atom_name_c, ptr::null_mut());
@@ -267,14 +267,14 @@ fn pixbuf_to_surface<'lua>(lua: &'lua Lua, pixbuf: LightUserData) -> rlua::Resul
 
 fn exec(_: &Lua, command: String) -> rlua::Result<()> {
     trace!("exec: \"{}\"", command);
-    let _ = thread::Builder::new().name(command.clone())
-            .spawn(|| {
-                Command::new(command).stdout(Stdio::null())
-                    .spawn()
-                    .expect("Could not spawn command")
-                    .wait()
-            })
-            .expect("Unable to spawn thread");
+    thread::Builder::new().name(command.clone())
+        .spawn(|| {
+            Command::new(command).stdout(Stdio::null())
+                .spawn()
+                .expect("Could not spawn command")
+                .wait()
+        })
+        .expect("Unable to spawn thread");
     Ok(())
 }
 

--- a/awesome/src/common/class.rs
+++ b/awesome/src/common/class.rs
@@ -54,17 +54,13 @@ impl<'lua, S: ObjectStateType> ClassBuilder<'lua, S> {
         Ok(self)
     }
 
-    // TODO remove, do right
-    #[allow(dead_code)]
-    pub fn dummy_property(self, key: String, val: Value<'lua>) -> rlua::Result<Self> {
-        let table = self.class.class.get_user_value::<Table>()?;
-        let meta = table.get_metatable().expect("Class had no meta table!");
-        meta.set(key, val)?;
+    pub fn save_class(self, name: &str) -> rlua::Result<Self> {
+        self.lua.globals().set(name, self.class.class.clone())?;
         Ok(self)
     }
 
-    pub fn save_class(self, name: &str) -> rlua::Result<()> {
-        self.lua.globals().set(name, self.class.class.clone())
+    pub fn build(self) -> rlua::Result<Class<'lua, S>> {
+        Ok(self.class)
     }
 }
 

--- a/awesome/src/common/object.rs
+++ b/awesome/src/common/object.rs
@@ -196,7 +196,7 @@ impl<'lua, S: ObjectStateType> ToLua<'lua> for Object<'lua, S> {
 impl<'lua, S: ObjectStateType> FromLua<'lua> for Object<'lua, S> {
     fn from_lua(val: Value<'lua>, _lua: &'lua Lua) -> rlua::Result<Self> {
         if let Value::UserData(obj) = val {
-            Object::cast(obj)
+            Ok(obj.into())
         } else {
             Err(rlua::Error::RuntimeError("Invalid data supplied".into()))
         }

--- a/awesome/src/keygrabber.rs
+++ b/awesome/src/keygrabber.rs
@@ -2,7 +2,7 @@
 
 use rlua::{self, Function, Lua, Table, Value};
 use wlroots::{events::key_events::Key, wlr_key_state,
-              xkbcommon::xkb::keysym_get_name};
+              xkbcommon::xkb::keysym_get_name, WLR_KEY_PRESSED};
 
 use ::LUA;
 use common::signal;

--- a/awesome/src/keygrabber.rs
+++ b/awesome/src/keygrabber.rs
@@ -1,12 +1,11 @@
 //! AwesomeWM Keygrabber interface
 
 use rlua::{self, Function, Lua, Table, Value};
-use wlroots::{events::key_events::{Key, KeyEvent}, wlr_key_state,
-              xkbcommon::xkb::keysym_get_name, KeyboardModifier, WLR_KEY_PRESSED};
+use wlroots::{events::key_events::Key, wlr_key_state,
+              xkbcommon::xkb::keysym_get_name};
 
-use ::{LUA, lua, root::ROOT_KEYS_HANDLE};
+use ::LUA;
 use common::signal;
-use objects::key;
 
 pub const KEYGRABBER_TABLE: &str = "keygrabber";
 const KEYGRABBER_CALLBACK: &str = "__callback";
@@ -85,53 +84,4 @@ fn index(lua: &Lua, args: Value) -> rlua::Result<()> {
 
 fn new_index(lua: &Lua, args: Value) -> rlua::Result<()> {
     signal::global_emit_signal(lua, ("debug::newindex::miss".into(), args))
-}
-
-
-/// Emits the Awesome keybindinsg.
-#[allow(dead_code)]
-fn emit_awesome_keybindings(lua: &Lua,
-                            event: &KeyEvent,
-                            event_modifiers: KeyboardModifier)
-                            -> rlua::Result<()> {
-    let state_string = if event.key_state() == WLR_KEY_PRESSED {
-        "press"
-    } else {
-        "release"
-    };
-    // If keygrabber is set, grab key
-    // TODO check behavior when event.pressed_keys() isn't a singleton
-    if is_keygrabber_set(&*lua) {
-        for event_keysym in event.pressed_keys() {
-            let res = call_keygrabber(&*lua, (
-                    lua::mods_to_lua(&*lua, &lua::num_to_mods(event_modifiers))?,
-                    keysym_get_name(event_keysym),
-                    state_string.into()
-            ));
-            if let Err(err) = res {
-                warn!("Call to keygrabber failed for {}: {:?}", event_keysym, err);
-            }
-        }
-    } else {
-        // TODO Should also emit by current focused client so we can
-        // do client based rules.
-        let keybindings = lua.named_registry_value::<Vec<key::Key>>(ROOT_KEYS_HANDLE)?;
-        for event_keysym in event.pressed_keys() {
-            for key in &keybindings {
-                let keycode = key.keycode()?;
-                let keysym = key.keysym()?;
-                let modifiers = key.modifiers()?;
-                let binding_match = ((keysym != 0 && keysym == event_keysym)
-                                     || (keycode != 0 && keycode == event.keycode()))
-                                    && (modifiers == 0
-                                    || modifiers == event_modifiers.bits());
-                if binding_match {
-                    if let Err(err) = signal::emit_object_signal(&*lua, key.clone(), state_string.into(), ()) {
-                        warn!("Could not emit the signal for {}: {:?}", keysym, err);
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
 }

--- a/awesome/src/lua/config.rs
+++ b/awesome/src/lua/config.rs
@@ -18,8 +18,6 @@ pub const DEFAULT_CONFIG: &'static str = include_str!("../../../config/rc.lua");
 ///
 /// If a configuration file could not be found, the pre-compiled version is used.
 pub fn load_config(mut lua: &mut Lua) {
-    info!("Loading way-cooler libraries...");
-
     let maybe_init_file = get_config();
     match maybe_init_file {
         Some((init_dir, mut init_file)) => {

--- a/awesome/src/lua/config.rs
+++ b/awesome/src/lua/config.rs
@@ -36,7 +36,7 @@ pub fn load_config(mut lua: &mut Lua) {
                     .expect("Failed to set package.path");
             }
             let mut init_contents = String::new();
-            let _ = init_file.read_to_string(&mut init_contents)
+            init_file.read_to_string(&mut init_contents)
                              .expect("Could not read contents");
             lua.exec(init_contents.as_str(), Some("init.lua".into()))
                 .map(|_:()| info!("Read init.lua successfully"))

--- a/awesome/src/lua/mod.rs
+++ b/awesome/src/lua/mod.rs
@@ -29,7 +29,7 @@ thread_local! {
 }
 
 /// Sets up the Lua environment before running the compositor.
-pub fn setup_lua() {
+pub fn init_awesome() {
     LUA.with(|lua| {
         register_libraries(&*lua.borrow())
             .expect("Could not register lua libraries");

--- a/awesome/src/lua/utils.rs
+++ b/awesome/src/lua/utils.rs
@@ -44,6 +44,7 @@ pub fn mods_to_lua<'lua>(lua: &'lua Lua, mods: &[Key]) -> rlua::Result<Table<'lu
 }
 
 /// Convert a single number to a modifier list.
+#[allow(dead_code)]
 pub fn num_to_mods(modifiers: KeyboardModifier) -> Vec<Key> {
     let mut res = vec![];
     for (mod_km, mod_k) in MOD_TYPES.iter() {

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -153,6 +153,7 @@ fn main() {
         let _ = signal::sigaction(signal::SIGINT, &sig_action)
                         .expect("Could not set SIGINT catcher");
     }
+    lua::init_awesome();
     init_wayland();
 }
 
@@ -184,7 +185,6 @@ fn init_wayland() {
         wayland_glib_interface_init(display_ptr,
                                     &mut wayland_state as *mut _ as _);
     }
-    lua::setup_lua();
     lua::enter_glib_loop();
 }
 

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -47,6 +47,8 @@ extern crate log;
 extern crate nix;
 extern crate libc;
 extern crate rlua;
+extern crate tempfile;
+extern crate byteorder;
 extern crate xcb;
 #[macro_use]
 extern crate wayland_client;
@@ -75,7 +77,7 @@ use log::Level;
 use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet};
 use xcb::{xkb, Connection};
 use wayland_client::{Display, GlobalManager, EventQueue, GlobalError};
-use wayland_client::protocol::{wl_compositor, wl_output, wl_display::RequestsTrait};
+use wayland_client::protocol::{wl_compositor, wl_shm, wl_output, wl_display::RequestsTrait};
 use wayland_client::sys::client::wl_display;
 
 use self::lua::{LUA, NEXT_LUA};
@@ -179,6 +181,11 @@ fn init_wayland() {
                 wl_compositor::WlCompositor,
                 wayland_obj::WL_COMPOSITOR_VERSION,
                 wayland_obj::wl_compositor_init
+            ],
+            [
+                wl_shm::WlShm,
+                wayland_obj::WL_SHM_VERSION,
+                wayland_obj::wl_shm_init
             ]
         ),
     );

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -134,8 +134,9 @@ fn main() {
 fn init_wayland() {
     let (display, mut event_queue) = match Display::connect_to_env() {
         Ok(res) => res,
-        Err(_) => {
+        Err(err) => {
             error!("Could not connect to Wayland server. Is it running?");
+            error!("{:?}", err);
             exit(1);
         }
     };

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -75,14 +75,14 @@ use log::Level;
 use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet};
 use xcb::{xkb, Connection};
 use wayland_client::{Display, GlobalManager, EventQueue};
-use wayland_client::protocol::{wl_output, wl_display::RequestsTrait};
+use wayland_client::protocol::{wl_compositor, wl_output, wl_display::RequestsTrait};
 use wayland_client::sys::client::wl_display;
 
 use self::lua::{LUA, NEXT_LUA};
-
 use self::objects::key::Key;
 use self::common::{object::Object, signal::*};
 use self::root::ROOT_KEYS_HANDLE;
+use wayland_protocols::xdg_shell::xdg_wm_base;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const GIT_VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/git-version.txt"));
@@ -170,7 +170,9 @@ fn init_wayland() {
     let _globals = GlobalManager::new_with_cb(
         display.get_registry().unwrap(),
         global_filter!(
-            [wl_output::WlOutput, 2, wayland_obj::Output::new]
+            [wl_output::WlOutput, 2, wayland_obj::Output::new],
+            [wl_compositor::WlCompositor, 2, wayland_obj::wl_compositor_init],
+            [xdg_wm_base::XdgWmBase, 1, wayland_obj::xdg_shell_init]
         ),
     );
     event_queue.sync_roundtrip().unwrap();

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -170,8 +170,16 @@ fn init_wayland() {
     let globals = GlobalManager::new_with_cb(
         display.get_registry().unwrap(),
         global_filter!(
-            [wl_output::WlOutput, 2, wayland_obj::Output::new],
-            [wl_compositor::WlCompositor, 3, wayland_obj::wl_compositor_init]
+            [
+                wl_output::WlOutput,
+                wayland_obj::WL_OUTPUT_VERSION,
+                wayland_obj::Output::new
+            ],
+            [
+                wl_compositor::WlCompositor,
+                wayland_obj::WL_COMPOSITOR_VERSION,
+                wayland_obj::wl_compositor_init
+            ]
         ),
     );
     event_queue.sync_roundtrip().unwrap();

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -31,6 +31,8 @@
        unused_qualifications,
        unused_results))]
 
+#[macro_use]
+extern crate bitflags;
 extern crate cairo;
 extern crate cairo_sys;
 extern crate env_logger;
@@ -43,26 +45,27 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate nix;
+extern crate libc;
 extern crate rlua;
 extern crate xcb;
 #[macro_use]
 extern crate wayland_client;
+extern crate wayland_sys;
 
 // TODO remove
 extern crate wlroots;
 
 #[macro_use]
 mod macros;
-
 mod objects;
 mod common;
 mod wayland_obj;
-
 mod awesome;
 mod keygrabber;
 mod mousegrabber;
 mod root;
 mod lua;
+mod wayland_protocols;
 
 use std::{env, mem, path::PathBuf, process::exit, io::{self, Write}};
 

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -48,7 +48,6 @@ extern crate nix;
 extern crate libc;
 extern crate rlua;
 extern crate tempfile;
-extern crate byteorder;
 extern crate xcb;
 #[macro_use]
 extern crate wayland_client;

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -147,8 +147,8 @@ fn main() {
                                     SaFlags::empty(),
                                     SigSet::empty());
     unsafe {
-        let _ = signal::sigaction(signal::SIGINT, &sig_action)
-                        .expect("Could not set SIGINT catcher");
+        signal::sigaction(signal::SIGINT, &sig_action)
+            .expect("Could not set SIGINT catcher");
     }
     lua::init_awesome_libraries();
     init_wayland();
@@ -314,9 +314,9 @@ fn log_format(buf: &mut env_logger::fmt::Formatter, record: &log::Record) -> Res
 fn init_logs() {
     let env = env_logger::Env::default()
         .filter_or("WAY_COOLER_LOG", "trace");
-    let _ = env_logger::Builder::from_env(env)
-                .format(log_format)
-                .init();
+    env_logger::Builder::from_env(env)
+        .format(log_format)
+        .init();
     info!("Logger initialized");
 }
 

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -87,7 +87,7 @@ pub const XCB_CONNECTION_HANDLE: &'static str = "__xcb_connection";
 ///
 /// This restarts the Lua thread if there is a new one pending
 #[no_mangle]
-pub extern "C" fn refresh_awesome() {
+pub extern "C" fn awesome_refresh() {
     NEXT_LUA.with(|new_lua_check| {
         if new_lua_check.get() {
             new_lua_check.set(false);
@@ -129,8 +129,6 @@ fn main() {
                         .expect("Could not set SIGINT catcher");
     }
     init_wayland();
-    lua::setup_lua();
-    lua::enter_glib_loop();
 }
 
 fn init_wayland() {
@@ -155,7 +153,11 @@ fn init_wayland() {
         ),
     );
     // TODO Remove
-    let _ = event_queue.sync_roundtrip().unwrap();
+    event_queue.sync_roundtrip().unwrap();
+    event_queue.sync_roundtrip().unwrap();
+    event_queue.sync_roundtrip().unwrap();
+    lua::setup_lua();
+    lua::enter_glib_loop();
 }
 
 fn setup_awesome_path(lua: &Lua) -> rlua::Result<()> {

--- a/awesome/src/main.rs
+++ b/awesome/src/main.rs
@@ -28,8 +28,7 @@
        trivial_numeric_casts,
        unused_extern_crates,
        unused_import_braces,
-       unused_qualifications,
-       unused_results))]
+       unused_qualifications))]
 
 #[macro_use]
 extern crate bitflags;
@@ -80,9 +79,6 @@ use wayland_client::protocol::{wl_compositor, wl_shm, wl_output, wl_display::Req
 use wayland_client::sys::client::wl_display;
 
 use self::lua::{LUA, NEXT_LUA};
-use self::objects::key::Key;
-use self::common::{object::Object, signal::*};
-use self::root::ROOT_KEYS_HANDLE;
 use wayland_protocols::xdg_shell::xdg_wm_base;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -113,7 +109,7 @@ pub extern "C" fn awesome_refresh(wayland_state: *mut libc::c_void) {
     //
     // The only way it's unsafe is if we destructure `WaylandState`,
     // which we can't do because it's borrowed.
-    let wayland_state = unsafe { &mut *(wayland_state as *mut WaylandState) };
+    let _wayland_state = unsafe { &mut *(wayland_state as *mut WaylandState) };
     NEXT_LUA.with(|new_lua_check| {
         if new_lua_check.get() {
             new_lua_check.set(false);

--- a/awesome/src/objects/button.rs
+++ b/awesome/src/objects/button.rs
@@ -64,7 +64,7 @@ impl<'lua> Button<'lua> {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<ButtonState>> {
     Class::<ButtonState>::builder(lua, "button", None)?
         .method("__call".into(),
                 lua.create_function(|lua, args: Table|
@@ -77,7 +77,8 @@ pub fn init(lua: &Lua) -> rlua::Result<()> {
                                 Some(lua.create_function(set_modifiers)?),
                                 Some(lua.create_function(get_modifiers)?),
                                 Some(lua.create_function(set_modifiers)?)))?
-        .save_class("button")
+        .save_class("button")?
+        .build()
 }
 
 fn set_button<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/client.rs
+++ b/awesome/src/objects/client.rs
@@ -49,8 +49,10 @@ impl <'lua> Client<'lua> {
 
 impl UserData for ClientState {}
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
-    method_setup(lua, Class::builder(lua, "client", None)?)?.save_class("client")
+pub fn init(lua: &Lua) -> rlua::Result<Class<ClientState>> {
+    method_setup(lua, Class::builder(lua, "client", None)?)?
+        .save_class("client")?
+        .build()
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -101,14 +101,15 @@ impl UserData for DrawableState {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<DrawableState>> {
     Class::<DrawableState>::builder(lua, "drawable", None)?
         .method("geometry".into(), lua.create_function(geometry)?)?
         .property(Property::new("surface".into(),
                                 None,
                                 Some(lua.create_function(get_surface)?),
                                 None))?
-        .save_class("drawable")
+        .save_class("drawable")?
+        .build()
 }
 
 fn get_surface<'lua>(_: &'lua Lua, drawable: Drawable<'lua>) -> rlua::Result<Value<'lua>> {

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -11,9 +11,11 @@ use wlroots::{Area, Origin, Size};
 use common::{class::{self, Class},
              object::{self, Object},
              property::Property};
+use wayland_obj::{self, XdgToplevel};
 
 #[derive(Clone, Debug)]
 pub struct DrawableState {
+    wayland_shell: XdgToplevel,
     pub surface: Option<ImageSurface>,
     geo: Area,
     // TODO Use this to determine whether we draw this or not
@@ -24,7 +26,10 @@ pub type Drawable<'lua> = Object<'lua, DrawableState>;
 
 impl Default for DrawableState {
     fn default() -> Self {
-        DrawableState { surface: None,
+        let wayland_shell = wayland_obj::create_xdg_toplevel(None)
+            .expect("Could not construct an xdg toplevel for a drawable");
+        DrawableState { wayland_shell,
+                        surface: None,
                         geo: Area::default(),
                         refreshed: false }
     }

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -16,6 +16,7 @@ use common::{class::{self, Class},
              object::{self, Object},
              property::Property};
 use wayland_obj::{self, XdgToplevel};
+use common::signal::emit_object_signal;
 
 #[derive(Debug)]
 pub struct DrawableState {
@@ -81,8 +82,9 @@ impl<'lua> Drawable<'lua> {
     }
 
     /// Sets the geometry, and allocates a new surface.
-    pub fn set_geometry(&mut self, geometry: Area) -> rlua::Result<()> {
+    pub fn set_geometry(&mut self, lua: &Lua, geometry: Area) -> rlua::Result<()> {
         use rlua::Error::RuntimeError;
+        let obj_clone = self.clone();
         let mut drawable = self.state_mut()?;
         let size_changed = drawable.geo != geometry;
         drawable.geo = geometry;
@@ -104,7 +106,7 @@ impl<'lua> Drawable<'lua> {
                 drawable.wayland_shell.set_surface(&temp_file, size)
                     .map_err(|_| RuntimeError(format!("Could not set surface for drawable")))?;
                 drawable.temp_file = temp_file;
-                // TODO emity property::surface
+                emit_object_signal(lua, obj_clone.into(), "property::surface".into(), ())?;
             }
         }
         Ok(())

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -10,7 +10,6 @@ use rlua::{self, LightUserData, Lua, Table,
            UserData, UserDataMethods, Value};
 use wlroots::{Area, Origin, Size};
 use tempfile;
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use common::{class::{self, Class},
              object::{self, Object},

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -73,7 +73,7 @@ impl<'lua> Drawable<'lua> {
                 //
                 // If there's a bug, worst case scenario there's a memory leak.
                 unsafe {
-                    let _ = ::cairo_sys::cairo_surface_reference(ptr);
+                    ::cairo_sys::cairo_surface_reference(ptr);
                 }
                 Value::LightUserData(LightUserData(ptr as _))
             }

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -90,6 +90,10 @@ impl<'lua> Drawable<'lua> {
         if size_changed {
             drawable.refreshed = false;
             drawable.surface = None;
+            // TODO The first one we create is useless.
+            // How do we ensure we don't have that overhead? Option<>?
+            drawable.wayland_shell = wayland_obj::create_xdg_toplevel(None)
+                .expect("Could not construct an xdg toplevel for a drawable");
             let size: Size = geometry.size;
 
             if size.width > 0 && size.height > 0 {

--- a/awesome/src/objects/drawable.rs
+++ b/awesome/src/objects/drawable.rs
@@ -118,8 +118,6 @@ impl<'lua> Drawable<'lua> {
                     .map_err(|err| RuntimeError(format!("Could not allocate {:?}", err)))?);
                 drawable.wayland_shell.set_size(size);
                 drawable.wayland_shell.set_surface(raw_fd, size);
-                error!("COMMITING IN DRAWABLE");
-                //drawable.wayland_shell.commit();
                 // TODO emity property::surface
             }
         }

--- a/awesome/src/objects/drawin.rs
+++ b/awesome/src/objects/drawin.rs
@@ -134,11 +134,12 @@ impl<'lua> Drawin<'lua> {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<DrawinState>> {
     let drawins: Vec<Drawin> = Vec::new();
     lua.set_named_registry_value(DRAWINS_HANDLE, drawins.to_lua(lua)?)?;
     property_setup(lua, method_setup(lua, Class::builder(lua, "drawin", None)?)?)?
-        .save_class("drawin")
+        .save_class("drawin")?
+        .build()
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/drawin.rs
+++ b/awesome/src/objects/drawin.rs
@@ -7,7 +7,7 @@ use std::cell::RefMut;
 
 use cairo::ImageSurface;
 use rlua::prelude::LuaInteger;
-use rlua::{self, AnyUserData, Lua, Table, ToLua, UserData, UserDataMethods};
+use rlua::{self, Lua, Table, ToLua, UserData, UserDataMethods};
 use wlroots::{Area, Origin, Size, Texture};
 
 use common::{class::{self, Class, ClassBuilder},
@@ -264,7 +264,7 @@ fn set_width<'lua>(lua: &'lua Lua,
     Ok(())
 }
 
-fn get_height<'lua>(lua: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
+fn get_height<'lua>(_lua: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
     let Size { height, .. } = drawin.get_geometry()?.size;
     Ok(height as LuaInteger)
 }

--- a/awesome/src/objects/drawin.rs
+++ b/awesome/src/objects/drawin.rs
@@ -7,7 +7,7 @@ use std::cell::RefMut;
 
 use cairo::ImageSurface;
 use rlua::prelude::LuaInteger;
-use rlua::{self, Lua, Table, ToLua, UserData, UserDataMethods};
+use rlua::{self, AnyUserData, Lua, Table, ToLua, UserData, UserDataMethods};
 use wlroots::{Area, Origin, Size, Texture};
 
 use common::{class::{self, Class, ClassBuilder},
@@ -65,15 +65,14 @@ impl<'lua> Drawin<'lua> {
         Ok(RefMut::map(self.state_mut()?, |state| &mut state.texture))
     }
 
-    fn update_drawing(&mut self) -> rlua::Result<()> {
-        let mut drawable = self.get_associated_data::<Drawable>("drawable")?.clone();
+    fn update_drawing(&mut self, lua: &Lua) -> rlua::Result<()> {
+        let mut drawable: Drawable = self.get_associated_data("drawable")?;
         {
             let mut state = self.state_mut()?;
             if state.geometry_dirty {
-                drawable.set_geometry(state.geometry)?;
+                drawable.set_geometry(lua, state.geometry)?;
                 state.geometry_dirty = false;
             }
-            state.surface = drawable.state()?.surface.clone();
         }
         self.set_associated_data("drawable", drawable)?;
         Ok(())
@@ -84,21 +83,21 @@ impl<'lua> Drawin<'lua> {
         Ok(drawin.visible)
     }
 
-    fn set_visible(&mut self, val: bool) -> rlua::Result<()> {
+    fn set_visible(&mut self, lua: &Lua, val: bool) -> rlua::Result<()> {
         {
             let mut drawin = self.state_mut()?;
             drawin.visible = val;
         }
         if val {
-            self.map()
+            self.map(lua)
         } else {
             self.unmap()
         }
     }
 
-    fn map(&mut self) -> rlua::Result<()> {
+    fn map(&mut self, lua: &Lua) -> rlua::Result<()> {
         // TODO other things
-        self.update_drawing()?;
+        self.update_drawing(lua)?;
         Ok(())
     }
 
@@ -111,7 +110,7 @@ impl<'lua> Drawin<'lua> {
         Ok(self.state()?.geometry)
     }
 
-    fn resize(&mut self, geometry: Area) -> rlua::Result<()> {
+    fn resize(&mut self, lua: &Lua, geometry: Area) -> rlua::Result<()> {
         {
             let mut state = self.state_mut()?;
             let old_geometry = state.geometry;
@@ -130,7 +129,7 @@ impl<'lua> Drawin<'lua> {
             // TODO emit signals
             // TODO update screen workareas like in awesome? Might not be necessary
         }
-        self.update_drawing()
+        self.update_drawing(lua)
     }
 }
 
@@ -191,8 +190,8 @@ fn object_setup<'lua>(lua: &'lua Lua,
     builder.add_to_meta(table)
 }
 
-fn set_visible<'lua>(_: &'lua Lua, (mut drawin, visible): (Drawin<'lua>, bool)) -> rlua::Result<()> {
-    drawin.set_visible(visible)
+fn set_visible<'lua>(lua: &'lua Lua, (mut drawin, visible): (Drawin<'lua>, bool)) -> rlua::Result<()> {
+    drawin.set_visible(lua, visible)
     // TODO signal
 }
 
@@ -211,7 +210,7 @@ fn drawin_geometry<'lua>(lua: &'lua Lua,
         let y = geometry.get::<_, i32>("y")?;
         if width > 0 && height > 0 {
             let geo = Area::new(Origin { x, y }, Size { width, height });
-            drawin.resize(geo)?;
+            drawin.resize(lua, geo)?;
         }
     }
     let new_geo = drawin.get_geometry()?;
@@ -230,10 +229,10 @@ fn get_x<'lua>(_: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
     Ok(x as LuaInteger)
 }
 
-fn set_x<'lua>(_: &'lua Lua, (mut drawin, x): (Drawin<'lua>, LuaInteger)) -> rlua::Result<()> {
+fn set_x<'lua>(lua: &'lua Lua, (mut drawin, x): (Drawin<'lua>, LuaInteger)) -> rlua::Result<()> {
     let mut geo = drawin.get_geometry()?;
     geo.origin.x = x as i32;
-    drawin.resize(geo)?;
+    drawin.resize(lua, geo)?;
     Ok(())
 }
 
@@ -242,10 +241,10 @@ fn get_y<'lua>(_: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
     Ok(y as LuaInteger)
 }
 
-fn set_y<'lua>(_: &'lua Lua, (mut drawin, y): (Drawin<'lua>, LuaInteger)) -> rlua::Result<()> {
+fn set_y<'lua>(lua: &'lua Lua, (mut drawin, y): (Drawin<'lua>, LuaInteger)) -> rlua::Result<()> {
     let mut geo = drawin.get_geometry()?;
     geo.origin.y = y as i32;
-    drawin.resize(geo)?;
+    drawin.resize(lua, geo)?;
     Ok(())
 }
 
@@ -254,29 +253,29 @@ fn get_width<'lua>(_: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaIntege
     Ok(width as LuaInteger)
 }
 
-fn set_width<'lua>(_: &'lua Lua,
+fn set_width<'lua>(lua: &'lua Lua,
                    (mut drawin, width): (Drawin<'lua>, LuaInteger))
                    -> rlua::Result<()> {
     let mut geo = drawin.get_geometry()?;
     if width > 0 {
         geo.size.width = width as i32;
-        drawin.resize(geo)?;
+        drawin.resize(lua, geo)?;
     }
     Ok(())
 }
 
-fn get_height<'lua>(_: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
+fn get_height<'lua>(lua: &'lua Lua, drawin: Drawin<'lua>) -> rlua::Result<LuaInteger> {
     let Size { height, .. } = drawin.get_geometry()?.size;
     Ok(height as LuaInteger)
 }
 
-fn set_height<'lua>(_: &'lua Lua,
+fn set_height<'lua>(lua: &'lua Lua,
                     (mut drawin, height): (Drawin<'lua>, LuaInteger))
                     -> rlua::Result<()> {
     let mut geo = drawin.get_geometry()?;
     if height > 0 {
         geo.size.height = height as i32;
-        drawin.resize(geo)?;
+        drawin.resize(lua, geo)?;
     }
     Ok(())
 }

--- a/awesome/src/objects/key.rs
+++ b/awesome/src/objects/key.rs
@@ -68,9 +68,10 @@ impl UserData for KeyState {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<KeyState>> {
     property_setup(lua, method_setup(lua, Class::builder(lua, "key", None)?)?)?
-      .save_class("key")
+        .save_class("key")?
+        .build()
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/objects/mouse.rs
+++ b/awesome/src/objects/mouse.rs
@@ -5,11 +5,8 @@
 
 use std::default::Default;
 
-use rlua::{self, Lua, MetaMethod, Table, AnyUserData,
-           ToLua, UserData, UserDataMethods, Value};
-
-use objects::screen::{Screen, SCREENS_HANDLE};
-use wayland_obj::Output;
+use rlua::{self, AnyUserData, Lua, MetaMethod, Table,
+           UserData, UserDataMethods, Value};
 
 const INDEX_MISS_FUNCTION: &'static str = "__index_miss_function";
 const NEWINDEX_MISS_FUNCTION: &'static str = "__newindex_miss_function";
@@ -71,11 +68,7 @@ fn set_newindex_miss(lua: &Lua, func: rlua::Function) -> rlua::Result<()> {
     table.set(NEWINDEX_MISS_FUNCTION, func)
 }
 
-fn get_output() -> Option<Output> {
-    unimplemented!();
-}
-
-fn index<'lua>(lua: &'lua Lua,
+fn index<'lua>(_lua: &'lua Lua,
                (mouse, index): (AnyUserData<'lua>, Value<'lua>))
                -> rlua::Result<Value<'lua>> {
     let obj_table = mouse.get_user_value::<Table>()?;
@@ -83,9 +76,13 @@ fn index<'lua>(lua: &'lua Lua,
         if string.to_str()? == "screen" {
 
             // TODO Get output
-            let output = get_output();
+            let _output = unimplemented!();
 
-            let mut screens = lua.named_registry_value::<Vec<Screen>>(SCREENS_HANDLE)?;
+            /*let mut screens: Vec<Screen> = lua
+                .named_registry_value::<Vec<AnyUserData>>(SCREENS_HANDLE)?
+                .into_iter()
+                .map(|obj| Screen::cast(obj.into()).unwrap())
+                .collect();
 
             if let Some(output) = output {
                 for screen in &screens {
@@ -98,7 +95,7 @@ fn index<'lua>(lua: &'lua Lua,
                 return screens[0].clone().to_lua(lua)
             }
 
-            return Ok(Value::Nil)
+            return Ok(Value::Nil)*/
         }
     }
     return obj_table.get(index)

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -86,15 +86,15 @@ impl<'lua> Screen<'lua> {
     pub fn set_geometry(&mut self, lua: &Lua, geometry: Area)
                         -> rlua::Result<()> {
         let obj_clone = self.clone();
-        let mut state = self.state_mut()?;
-        if state.geometry != geometry {
+        if self.state()?.geometry != geometry {
+            let geometry = self.state()?.geometry;
             let old_area = lua.create_table()?;
-            old_area.set("x", state.geometry.origin.x)?;
-            old_area.set("y", state.geometry.origin.y)?;
-            old_area.set("width", state.geometry.size.width)?;
-            old_area.set("height", state.geometry.size.height)?;
-            state.geometry = geometry;
-            emit_object_signal(lua, obj_clone.into(), "property::geometry".into(), old_area)?;
+            old_area.set("x", geometry.origin.x)?;
+            old_area.set("y", geometry.origin.y)?;
+            old_area.set("width", geometry.size.width)?;
+            old_area.set("height", geometry.size.height)?;
+            self.state_mut()?.geometry = geometry;
+            emit_object_signal(lua, self.clone().into(), "property::geometry".into(), old_area)?;
         }
         Ok(())
     }
@@ -102,17 +102,16 @@ impl<'lua> Screen<'lua> {
     pub fn set_workarea(&mut self, lua: &Lua, geometry: Area)
                     -> rlua::Result<()> {
         let obj_clone = self.clone();
-        let mut state = self.state_mut()?;
-        if state.workarea != geometry {
+        if self.state()?.workarea != geometry {
+            let geometry = self.state()?.geometry;
             let old_area = lua.create_table()?;
-            old_area.set("x", state.geometry.origin.x)?;
-            old_area.set("y", state.geometry.origin.y)?;
-            old_area.set("width", state.geometry.size.width)?;
-            old_area.set("height", state.geometry.size.height)?;
-            state.geometry = geometry;
-            emit_object_signal(lua, obj_clone.into(), "property::workarea".into(), old_area)?;
+            old_area.set("x", geometry.origin.x)?;
+            old_area.set("y", geometry.origin.y)?;
+            old_area.set("width", geometry.size.width)?;
+            old_area.set("height", geometry.size.height)?;
+            self.state_mut()?.workarea = geometry;
+            emit_object_signal(lua, self.clone().into(), "property::workarea".into(), old_area)?;
         }
-        state.workarea = geometry;
         Ok(())
     }
 

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -85,7 +85,6 @@ impl<'lua> Screen<'lua> {
 
     pub fn set_geometry(&mut self, lua: &Lua, geometry: Area)
                         -> rlua::Result<()> {
-        let obj_clone = self.clone();
         if self.state()?.geometry != geometry {
             let geometry = self.state()?.geometry;
             let old_area = lua.create_table()?;
@@ -101,7 +100,6 @@ impl<'lua> Screen<'lua> {
 
     pub fn set_workarea(&mut self, lua: &Lua, geometry: Area)
                     -> rlua::Result<()> {
-        let obj_clone = self.clone();
         if self.state()?.workarea != geometry {
             let geometry = self.state()?.geometry;
             let old_area = lua.create_table()?;

--- a/awesome/src/objects/screen.rs
+++ b/awesome/src/objects/screen.rs
@@ -258,7 +258,7 @@ fn iterate_over_screens<'lua>(lua: &'lua Lua,
 }
 
 fn index<'lua>(lua: &'lua Lua,
-               (obj, index): (Screen<'lua>, Value<'lua>))
+               (obj, index): (AnyUserData<'lua>, Value<'lua>))
                -> rlua::Result<Value<'lua>> {
     let screens: Vec<Screen> = lua.named_registry_value(SCREENS_HANDLE)?;
     match index {
@@ -300,9 +300,10 @@ fn index<'lua>(lua: &'lua Lua,
         _ => {}
     }
     // TODO checkudata
-    let meta = obj.get_metatable()?.expect("screen had no metatable");
+    let table: Table = obj.get_user_value()?;
+    let meta = table.get_metatable().expect("screen had no metatable");
     match meta.get(index.clone()) {
-        Err(_) | Ok(Value::Nil) => object::default_index(lua, (obj, index)),
+        Err(_) | Ok(Value::Nil) => object::default_index(lua, (Screen::cast(obj)?, index)),
         Ok(value) => Ok(value)
     }
 }

--- a/awesome/src/objects/tag.rs
+++ b/awesome/src/objects/tag.rs
@@ -63,12 +63,14 @@ impl<'lua> Tag<'lua> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn client_index(&self, client: &Client) -> rlua::Result<Option<usize>> {
         // TODO: remove the chaining of collect and into_iter
         Ok(self.clients()?.iter()
                           .position(|c| *c == *client))
     }
 
+    #[allow(dead_code)]
     pub fn tag_client(&mut self, client: Client<'lua>) -> rlua::Result<()> {
         if let Some(_) = self.client_index(&client)? { // if it is already part of the clients
             return Ok(());
@@ -79,6 +81,7 @@ impl<'lua> Tag<'lua> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn untag_client(&mut self, client: Client<'lua>) -> rlua::Result<()> {
         let clients: Vec<_> = self.clients()?
                               .into_iter()
@@ -229,7 +232,7 @@ fn get_clients<'lua>(lua: &'lua Lua,  (mut tag, val): (Tag<'lua>, Value<'lua>)) 
 #[cfg(test)]
 mod test {
     use super::super::{tag::{self, Tag}, client::{self, Client}};
-    use rlua::Lua;
+    use rlua::{self, Lua};
 
     #[test]
     fn tag_name_empty() -> rlua::Result<()> {

--- a/awesome/src/objects/tag.rs
+++ b/awesome/src/objects/tag.rs
@@ -50,7 +50,7 @@ impl<'lua> Tag<'lua> {
                                    .collect::<HashSet<_>>();
             let new_clients = clients.iter().cloned()
                                      .collect::<HashSet<_>>();
-                
+
             for _client in new_clients.difference(&prev_clients) {
                 // emit signal
             };
@@ -95,9 +95,11 @@ impl UserData for TagState {
     }
 }
 
-pub fn init(lua: &Lua) -> rlua::Result<()> {
+pub fn init(lua: &Lua) -> rlua::Result<Class<TagState>> {
     lua.set_named_registry_value(TAG_LIST, lua.create_table()?)?;
-    method_setup(lua, Class::builder(lua, "tag", None)?)?.save_class("tag")
+    method_setup(lua, Class::builder(lua, "tag", None)?)?
+        .save_class("tag")?
+        .build()
 }
 
 fn method_setup<'lua>(lua: &'lua Lua,

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -3,4 +3,3 @@
 mod output;
 
 pub use self::output::Output;
-

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -4,6 +4,6 @@ mod output;
 mod xdg_shell;
 mod wl_compositor;
 
-pub use self::output::Output;
+pub use self::output::{WL_OUTPUT_VERSION, Output};
 pub use self::xdg_shell::{XDG_WM_BASE_VERSION, XdgToplevel, xdg_shell_init, create_xdg_toplevel};
-pub use self::wl_compositor::{wl_compositor_init, create_surface};
+pub use self::wl_compositor::{WL_COMPOSITOR_VERSION, wl_compositor_init, create_surface};

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -5,5 +5,5 @@ mod xdg_shell;
 mod wl_compositor;
 
 pub use self::output::Output;
-pub use self::xdg_shell::{XdgToplevel, xdg_shell_init, create_xdg_toplevel};
+pub use self::xdg_shell::{XDG_WM_BASE_VERSION, XdgToplevel, xdg_shell_init, create_xdg_toplevel};
 pub use self::wl_compositor::{wl_compositor_init, create_surface};

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -1,5 +1,9 @@
 //! Wrappers around Wayland objects
 
 mod output;
+mod xdg_shell;
+mod wl_compositor;
 
 pub use self::output::Output;
+pub use self::xdg_shell::xdg_shell_init;
+pub use self::wl_compositor::{wl_compositor_init, create_surface};

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -6,4 +6,4 @@ mod wl_compositor;
 
 pub use self::output::{WL_OUTPUT_VERSION, Output};
 pub use self::xdg_shell::{XDG_WM_BASE_VERSION, XdgToplevel, xdg_shell_init, create_xdg_toplevel};
-pub use self::wl_compositor::{WL_COMPOSITOR_VERSION, wl_compositor_init, create_surface};
+pub use self::wl_compositor::{WL_COMPOSITOR_VERSION, WL_SHM_VERSION, wl_compositor_init, wl_shm_init, create_surface, create_buffer};

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -3,7 +3,11 @@
 mod output;
 mod xdg_shell;
 mod wl_compositor;
+mod wl_shm;
 
 pub use self::output::{WL_OUTPUT_VERSION, Output};
-pub use self::xdg_shell::{XDG_WM_BASE_VERSION, XdgToplevel, xdg_shell_init, create_xdg_toplevel};
-pub use self::wl_compositor::{WL_COMPOSITOR_VERSION, WL_SHM_VERSION, wl_compositor_init, wl_shm_init, create_surface, create_buffer};
+pub use self::xdg_shell::{XDG_WM_BASE_VERSION, XdgToplevel,
+                          xdg_shell_init, create_xdg_toplevel};
+pub use self::wl_compositor::{WL_COMPOSITOR_VERSION, wl_compositor_init,
+                              create_surface};
+pub use self::wl_shm::{WL_SHM_VERSION, wl_shm_init, create_buffer};

--- a/awesome/src/wayland_obj/mod.rs
+++ b/awesome/src/wayland_obj/mod.rs
@@ -5,5 +5,5 @@ mod xdg_shell;
 mod wl_compositor;
 
 pub use self::output::Output;
-pub use self::xdg_shell::xdg_shell_init;
+pub use self::xdg_shell::{XdgToplevel, xdg_shell_init, create_xdg_toplevel};
 pub use self::wl_compositor::{wl_compositor_init, create_surface};

--- a/awesome/src/wayland_obj/output.rs
+++ b/awesome/src/wayland_obj/output.rs
@@ -22,13 +22,6 @@ struct OutputState {
     resolution: (i32, i32)
 }
 
-impl <'this> Into<&'this Proxy<WlOutput>> for &'this Output {
-    fn into(self) -> &'this Proxy<WlOutput> {
-        &self.proxy
-    }
-}
-
-
 impl Output {
     pub fn new(new_proxy: Result<NewProxy<WlOutput>, u32>, _: ()) {
         let new_proxy = new_proxy.expect("Could not create WlOutput");
@@ -98,6 +91,13 @@ impl fmt::Debug for Output {
         write!(f, "{:?}", self.proxy.c_ptr())
     }
 }
+
+impl <'this> Into<&'this Proxy<WlOutput>> for &'this Output {
+    fn into(self) -> &'this Proxy<WlOutput> {
+        &self.proxy
+    }
+}
+
 
 fn unwrap_state_mut<'this, I: Into<&'this mut Proxy<WlOutput>>>(proxy: I) -> &'this mut OutputState {
     unsafe {

--- a/awesome/src/wayland_obj/output.rs
+++ b/awesome/src/wayland_obj/output.rs
@@ -1,13 +1,13 @@
 //! Wrapper around a wl_output
 
-use std::cell::RefCell;
+use std::fmt;
 
+use wlroots::{Area, Size, Origin};
 use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::{Proxy, NewProxy};
 
-thread_local! {
-    pub static OUTPUTS: RefCell<Vec<Output>> = RefCell::new(Vec::new());
-}
+use lua::LUA;
+use objects::screen::{self, Screen};
 
 /// Wrapper around WlOutput.
 #[derive(Clone, Eq, PartialEq)]
@@ -33,22 +33,45 @@ impl Output {
     pub fn new(new_proxy: Result<NewProxy<WlOutput>, u32>, _: ()) {
         let new_proxy = new_proxy.expect("Could not create WlOutput");
         let state = Box::new(OutputState::default());
-        let proxy = new_proxy.implement(move |event, mut proxy| {
+        let proxy = new_proxy.implement(move |event, mut proxy: Proxy<WlOutput>| {
             use wayland_client::protocol::wl_output::Event;
+            let output = Output { proxy: proxy.clone() };
             let state = unwrap_state_mut(&mut proxy);
-            match event {
-                Event::Geometry { make, model, .. } => {
-                    state.name = format!("{} ({})", make, model);
-                },
-                Event::Mode { width, height, .. } => {
-                    state.resolution = (width, height);
+            LUA.with(|lua| {
+                let lua = lua.borrow();
+                let lua = &*lua;
+                let mut screen = screen::get_screen(lua, output)
+                    .expect("Got screen state for screen that doesn't exist");
+                match event {
+                    Event::Geometry { make, model,  .. } => {
+                        state.name = format!("{} ({})", make, model);
+                    },
+                    Event::Mode { width, height, .. } => {
+                        let geometry = Area { origin: Origin { x: 0, y: 0 },
+                                              size: Size { width, height }
+                        };
+                        screen.set_geometry(geometry)
+                            .expect("could not set geometry");
+                        screen.set_workarea(geometry)
+                            .expect("could not set workarea ");
+                        state.resolution = (width, height);
+                    }
+                    _ => {/* TODO */}
                 }
-                _ => {/* TODO */}
-            }
+            });
         });
         proxy.set_user_data(Box::into_raw(state) as _);
         let output = Output { proxy };
-        OUTPUTS.with(|outputs| outputs.borrow_mut().push(output));
+        LUA.with(|lua| {
+            let lua = lua.borrow();
+            let lua = &*lua;
+            let mut screen = Screen::new(lua)
+                .expect("Could not allocate new screen");
+            screen.init_screens(output.clone(), vec![output])
+                .expect("Could not initilize new output with a screen");
+            screen::add_screen(lua, screen)
+                .expect("Could not add screen to the list of screens");
+        });
     }
 
     pub fn resolution(&self) -> (i32, i32) {
@@ -57,6 +80,12 @@ impl Output {
 
     pub fn name(&self) -> &str {
         unwrap_state(self).name.as_str()
+    }
+}
+
+impl fmt::Debug for Output {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.proxy.c_ptr())
     }
 }
 

--- a/awesome/src/wayland_obj/output.rs
+++ b/awesome/src/wayland_obj/output.rs
@@ -9,6 +9,9 @@ use wayland_client::{Proxy, NewProxy};
 use lua::LUA;
 use objects::screen::{self, Screen};
 
+/// The minimum version of the wl_output global to bind to.
+pub const WL_OUTPUT_VERSION: u32 = 2;
+
 /// Wrapper around WlOutput.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Output {

--- a/awesome/src/wayland_obj/output.rs
+++ b/awesome/src/wayland_obj/output.rs
@@ -57,6 +57,8 @@ impl Output {
                         }
                     }
                     Event::Done => {
+                        // TODO We may not always want to add a new screen
+                        // see how awesome does it and fix this.
                         let mut screen = Screen::new(lua)
                             .expect("Could not allocate new screen");
                         screen.init_screens(output.clone(), vec![output])

--- a/awesome/src/wayland_obj/output.rs
+++ b/awesome/src/wayland_obj/output.rs
@@ -40,18 +40,18 @@ impl Output {
                     Event::Geometry { make, model,  .. } => {
                         state.name = format!("{} ({})", make, model);
                     },
-                    Event::Mode { width, height, .. } => {
+                    Event::Mode { width, height,  .. } => {
                         state.resolution = (width, height);
                         let geometry = Area { origin: Origin { x: 0, y: 0 },
                                               size: Size { width, height }
                         };
                         if let Ok(mut screen) = screen::get_screen(lua, output) {
-                            screen.set_geometry(geometry)
+                            screen.set_geometry(lua, geometry)
                                 .expect("could not set geometry");
-                            screen.set_workarea(geometry)
+                            screen.set_workarea(lua, geometry)
                                 .expect("could not set workarea ");
                         }
-                    }
+                    },
                     Event::Done => {
                         // TODO We may not always want to add a new screen
                         // see how awesome does it and fix this.
@@ -61,7 +61,7 @@ impl Output {
                             .expect("Could not initilize new output with a screen");
                         screen::add_screen(lua, screen)
                             .expect("Could not add screen to the list of screens");
-                    }
+                    },
                     _ => {/* TODO */}
                 }
             });

--- a/awesome/src/wayland_obj/wl_compositor.rs
+++ b/awesome/src/wayland_obj/wl_compositor.rs
@@ -1,0 +1,31 @@
+//! Wrapper around a wl_compositor.
+
+use std::cell::RefCell;
+
+use wayland_client::{Proxy, NewProxy};
+use wayland_client::protocol::wl_compositor::{WlCompositor,
+                                              RequestsTrait as WlCompositorTrait};
+use wayland_client::protocol::wl_surface::WlSurface;
+
+thread_local! {
+    static WL_COMPOSITOR: RefCell<Option<Proxy<WlCompositor>>> =
+        RefCell::new(None)
+}
+
+pub fn wl_compositor_init(new_proxy: Result<NewProxy<WlCompositor>, u32>, _: ()) {
+    let new_proxy = new_proxy.expect("Could not create wl_compositor");
+    let proxy = new_proxy.implement(|_event, _proxy| {});
+    WL_COMPOSITOR.with(|wl_compositor| {
+        *wl_compositor.borrow_mut() = Some(proxy);
+    })
+}
+
+pub fn create_surface() -> Result<Proxy<WlSurface>, ()> {
+    WL_COMPOSITOR.with(|wl_compositor| {
+        let wl_compositor = wl_compositor.borrow();
+        let wl_compositor = wl_compositor.as_ref()
+            .expect("WL_COMPOSITOR was not initilized");
+        wl_compositor.create_surface()
+            .map(|compositor| compositor.implement(|_event, _proxy| {}))
+    })
+}

--- a/awesome/src/wayland_obj/wl_compositor.rs
+++ b/awesome/src/wayland_obj/wl_compositor.rs
@@ -7,6 +7,9 @@ use wayland_client::protocol::wl_compositor::{WlCompositor,
                                               RequestsTrait as WlCompositorTrait};
 use wayland_client::protocol::wl_surface::WlSurface;
 
+/// The minimum version of the wl_compositor global to bind to.
+pub const WL_COMPOSITOR_VERSION: u32 = 3;
+
 thread_local! {
     static WL_COMPOSITOR: RefCell<Option<Proxy<WlCompositor>>> =
         RefCell::new(None)

--- a/awesome/src/wayland_obj/wl_compositor.rs
+++ b/awesome/src/wayland_obj/wl_compositor.rs
@@ -1,18 +1,31 @@
 //! Wrapper around a wl_compositor.
 
+use std::os::unix::io::RawFd;
 use std::cell::RefCell;
 
 use wayland_client::{Proxy, NewProxy};
 use wayland_client::protocol::wl_compositor::{WlCompositor,
                                               RequestsTrait as WlCompositorTrait};
 use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::protocol::wl_shm::{self,
+                                       WlShm,
+                                       RequestsTrait as WlShmTrait};
+use wayland_client::protocol::wl_shm_pool::{WlShmPool,
+                                            RequestsTrait as WlShmPoolTrait};
+use wayland_client::protocol::wl_buffer::WlBuffer;
+
+use wlroots::{Area, Size};
 
 /// The minimum version of the wl_compositor global to bind to.
 pub const WL_COMPOSITOR_VERSION: u32 = 3;
 
+/// The minimum version of the wl_shm global to bind to.
+pub const WL_SHM_VERSION: u32 = 1;
+
 thread_local! {
     static WL_COMPOSITOR: RefCell<Option<Proxy<WlCompositor>>> =
-        RefCell::new(None)
+        RefCell::new(None);
+    static WL_SHM: RefCell<Option<Proxy<WlShm>>> = RefCell::new(None);
 }
 
 pub fn wl_compositor_init(new_proxy: Result<NewProxy<WlCompositor>, u32>, _: ()) {
@@ -22,6 +35,13 @@ pub fn wl_compositor_init(new_proxy: Result<NewProxy<WlCompositor>, u32>, _: ())
         *wl_compositor.borrow_mut() = Some(proxy);
     })
 }
+pub fn wl_shm_init(new_proxy: Result<NewProxy<WlShm>, u32>, _: ()) {
+    let new_proxy = new_proxy.expect("Could not create wl_shm");
+    let proxy = new_proxy.implement(|_event, _proxy| {});
+    WL_SHM.with(|wl_shm| {
+        *wl_shm.borrow_mut() = Some(proxy);
+    });
+}
 
 pub fn create_surface() -> Result<Proxy<WlSurface>, ()> {
     WL_COMPOSITOR.with(|wl_compositor| {
@@ -30,5 +50,18 @@ pub fn create_surface() -> Result<Proxy<WlSurface>, ()> {
             .expect("WL_COMPOSITOR was not initilized");
         wl_compositor.create_surface()
             .map(|compositor| compositor.implement(|_event, _proxy| {}))
+    })
+}
+
+pub fn create_buffer(fd: RawFd, size: Size) -> Result<Proxy<WlBuffer>, ()> {
+    let Size { width, height } = size;
+    WL_SHM.with(|wl_shm| {
+        let wl_shm = wl_shm.borrow();
+        let wl_shm = wl_shm.as_ref()
+            .expect("WL_SHM was not initilized");
+        let pool = wl_shm.create_pool(fd, width * height * 4)?.implement(|_,_|{});
+        // TODO ARb32 instead
+        Ok(pool.create_buffer(0, width, height, (width * 4) as i32, wl_shm::Format::Argb8888)?
+            .implement(|_,_| {}))
     })
 }

--- a/awesome/src/wayland_obj/wl_compositor.rs
+++ b/awesome/src/wayland_obj/wl_compositor.rs
@@ -1,31 +1,18 @@
 //! Wrapper around a wl_compositor.
 
-use std::os::unix::io::RawFd;
 use std::cell::RefCell;
 
 use wayland_client::{Proxy, NewProxy};
 use wayland_client::protocol::wl_compositor::{WlCompositor,
                                               RequestsTrait as WlCompositorTrait};
 use wayland_client::protocol::wl_surface::WlSurface;
-use wayland_client::protocol::wl_shm::{self,
-                                       WlShm,
-                                       RequestsTrait as WlShmTrait};
-use wayland_client::protocol::wl_shm_pool::{WlShmPool,
-                                            RequestsTrait as WlShmPoolTrait};
-use wayland_client::protocol::wl_buffer::WlBuffer;
-
-use wlroots::{Area, Size};
 
 /// The minimum version of the wl_compositor global to bind to.
 pub const WL_COMPOSITOR_VERSION: u32 = 3;
 
-/// The minimum version of the wl_shm global to bind to.
-pub const WL_SHM_VERSION: u32 = 1;
-
 thread_local! {
     static WL_COMPOSITOR: RefCell<Option<Proxy<WlCompositor>>> =
         RefCell::new(None);
-    static WL_SHM: RefCell<Option<Proxy<WlShm>>> = RefCell::new(None);
 }
 
 pub fn wl_compositor_init(new_proxy: Result<NewProxy<WlCompositor>, u32>, _: ()) {
@@ -35,13 +22,6 @@ pub fn wl_compositor_init(new_proxy: Result<NewProxy<WlCompositor>, u32>, _: ())
         *wl_compositor.borrow_mut() = Some(proxy);
     })
 }
-pub fn wl_shm_init(new_proxy: Result<NewProxy<WlShm>, u32>, _: ()) {
-    let new_proxy = new_proxy.expect("Could not create wl_shm");
-    let proxy = new_proxy.implement(|_event, _proxy| {});
-    WL_SHM.with(|wl_shm| {
-        *wl_shm.borrow_mut() = Some(proxy);
-    });
-}
 
 pub fn create_surface() -> Result<Proxy<WlSurface>, ()> {
     WL_COMPOSITOR.with(|wl_compositor| {
@@ -50,18 +30,5 @@ pub fn create_surface() -> Result<Proxy<WlSurface>, ()> {
             .expect("WL_COMPOSITOR was not initilized");
         wl_compositor.create_surface()
             .map(|compositor| compositor.implement(|_event, _proxy| {}))
-    })
-}
-
-pub fn create_buffer(fd: RawFd, size: Size) -> Result<Proxy<WlBuffer>, ()> {
-    let Size { width, height } = size;
-    WL_SHM.with(|wl_shm| {
-        let wl_shm = wl_shm.borrow();
-        let wl_shm = wl_shm.as_ref()
-            .expect("WL_SHM was not initilized");
-        let pool = wl_shm.create_pool(fd, width * height * 4)?.implement(|_,_|{});
-        // TODO ARb32 instead
-        Ok(pool.create_buffer(0, width, height, (width * 4) as i32, wl_shm::Format::Argb8888)?
-            .implement(|_,_| {}))
     })
 }

--- a/awesome/src/wayland_obj/wl_shm.rs
+++ b/awesome/src/wayland_obj/wl_shm.rs
@@ -39,7 +39,7 @@ pub fn create_buffer(fd: RawFd, size: Size) -> Result<Proxy<WlBuffer>, ()> {
             .expect("WL_SHM was not initilized");
         let pool = wl_shm.create_pool(fd, width * height * 4)?.implement(|_,_|{});
         // TODO ARb32 instead
-        Ok(pool.create_buffer(0, width, height, (width * 4) as i32, wl_shm::Format::Argb8888)?
+        Ok(pool.create_buffer(0, width, height, width * 4, wl_shm::Format::Argb8888)?
            .implement(|_,_| {}))
     })
 }

--- a/awesome/src/wayland_obj/wl_shm.rs
+++ b/awesome/src/wayland_obj/wl_shm.rs
@@ -1,0 +1,46 @@
+//! Wrapper around a wl_shm.
+
+use std::os::unix::io::RawFd;
+use std::cell::RefCell;
+
+use wayland_client::{Proxy, NewProxy};
+use wayland_client::protocol::wl_shm::{self,
+                                       WlShm,
+                                       RequestsTrait as WlShmTrait};
+use wayland_client::protocol::wl_shm_pool::{WlShmPool,
+                                            RequestsTrait as WlShmPoolTrait};
+use wayland_client::protocol::wl_buffer::WlBuffer;
+
+use wlroots::Size;
+
+/// The minimum version of the wl_shm global to bind to.
+pub const WL_SHM_VERSION: u32 = 1;
+
+thread_local! {
+    static WL_SHM: RefCell<Option<Proxy<WlShm>>> = RefCell::new(None);
+}
+
+pub fn wl_shm_init(new_proxy: Result<NewProxy<WlShm>, u32>, _: ()) {
+    let new_proxy = new_proxy.expect("Could not create wl_shm");
+    let proxy = new_proxy.implement(|_event, _proxy| {});
+    WL_SHM.with(|wl_shm| {
+        *wl_shm.borrow_mut() = Some(proxy);
+    });
+}
+
+/// Create a buffer from the raw file descriptor in the given size.
+///
+/// This should be called from a shell and generally should not be used
+/// directly by the Awesome objects.
+pub fn create_buffer(fd: RawFd, size: Size) -> Result<Proxy<WlBuffer>, ()> {
+    let Size { width, height } = size;
+    WL_SHM.with(|wl_shm| {
+        let wl_shm = wl_shm.borrow();
+        let wl_shm = wl_shm.as_ref()
+            .expect("WL_SHM was not initilized");
+        let pool = wl_shm.create_pool(fd, width * height * 4)?.implement(|_,_|{});
+        // TODO ARb32 instead
+        Ok(pool.create_buffer(0, width, height, (width * 4) as i32, wl_shm::Format::Argb8888)?
+           .implement(|_,_| {}))
+    })
+}

--- a/awesome/src/wayland_obj/wl_shm.rs
+++ b/awesome/src/wayland_obj/wl_shm.rs
@@ -7,8 +7,7 @@ use wayland_client::{Proxy, NewProxy};
 use wayland_client::protocol::wl_shm::{self,
                                        WlShm,
                                        RequestsTrait as WlShmTrait};
-use wayland_client::protocol::wl_shm_pool::{WlShmPool,
-                                            RequestsTrait as WlShmPoolTrait};
+use wayland_client::protocol::wl_shm_pool::RequestsTrait as WlShmPoolTrait;
 use wayland_client::protocol::wl_buffer::WlBuffer;
 
 use wlroots::Size;

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -15,6 +15,9 @@ use wlroots::{Area, Origin, Size};
 
 use wayland_obj;
 
+/// The minimum version of the xdg_wm_base global to bind to.
+pub const XDG_WM_BASE_VERSION: u32 = 2;
+
 thread_local! {
     /// The XDG surface creator.
     ///

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -1,0 +1,64 @@
+//! Wrappers around a xdg_surface and xdg_shell setup code.
+
+use std::cell::RefCell;
+
+use wayland_client::{Proxy, NewProxy};
+use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_protocols::xdg_shell::{xdg_wm_base::{XdgWmBase,
+                                                 RequestsTrait as XdgwmBaseTrait},
+                                   xdg_toplevel::XdgToplevel,
+                                   xdg_surface::{self,
+                                                 XdgSurface,
+                                                 RequestsTrait as XdgSurfaceTrait}};
+use wlroots::{Area, Origin, Size};
+
+use wayland_obj;
+
+thread_local! {
+    /// The XDG surface creator.
+    ///
+    /// This should remain local to just this module.
+    static XDG_SHELL_CREATOR: RefCell<Option<Proxy<XdgWmBase>>> = RefCell::new(None);
+}
+
+pub fn xdg_shell_init(new_proxy: Result<NewProxy<XdgWmBase>, u32>, _: ()) {
+    let new_proxy = new_proxy.expect("Could not create Xdgsurface");
+    let proxy = new_proxy.implement(move |event, proxy: Proxy<XdgWmBase>| {
+        use xdg_wm_base::Event;
+        match event {
+            Event::Ping { serial } => proxy.pong(serial)
+        }
+    });
+    XDG_SHELL_CREATOR.with(|shell_creator| {
+        *shell_creator.borrow_mut() = Some(proxy);
+    });
+}
+
+pub fn create_xdg_toplevel<G>(geometry: G)
+                              -> Result<NewProxy<XdgToplevel>, ()>
+where G: Into<Option<Area>> {
+    let surface = wayland_obj::create_surface()?;
+    let xdg_surface = create_xdg_surface(&surface)?;
+    if let Some(geometry) = geometry.into() {
+        let Origin { x, y } = geometry.origin;
+        let Size { width, height } = geometry.size;
+        xdg_surface.set_window_geometry(x, y, width, height);
+    }
+    xdg_surface.get_toplevel()
+}
+
+fn create_xdg_surface(surface: &Proxy<WlSurface>)
+                      -> Result<Proxy<XdgSurface>, ()> {
+    XDG_SHELL_CREATOR.with(|shell_creator| {
+        let shell_creator = shell_creator.borrow();
+        let shell_creator = shell_creator.as_ref()
+            .expect("XDG Shell creator not initilized");
+        shell_creator.get_xdg_surface(surface)
+            .map(|new_proxy| new_proxy.implement(move |event, proxy: Proxy<XdgSurface>| {
+                use self::xdg_surface::Event;
+                match event {
+                    Event::Configure { serial } => proxy.ack_configure(serial)
+                }
+            }))
+    })
+}

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -101,6 +101,7 @@ impl XdgToplevel {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn commit(&self) {
         unwrap_state(&self.proxy).wl_surface.commit();
     }

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -63,7 +63,6 @@ impl XdgToplevel {
             match event {
                 Event::Configure { width, height, .. } => {
                     // TODO Fill in
-                    error!("Got request for geo : ({}, {})", width, height);
                     let state = unwrap_state(&proxy);
                     state.xdg_surface.set_window_geometry(0, 0, state.size.width, state.size.height);
                 },
@@ -72,7 +71,6 @@ impl XdgToplevel {
                 }
             }
         });
-        error!("COMMITING IN XDG SHELL");
         wl_surface.commit();
         let cached_state = Box::new(XdgToplevelState { wl_surface,
                                                        xdg_surface,
@@ -142,7 +140,6 @@ where G: Into<Option<Area>> {
 
 fn create_xdg_surface(surface: &Proxy<WlSurface>)
                       -> Result<Proxy<XdgSurface>, ()> {
-    error!("Creating an xdg surface");
     XDG_SHELL_CREATOR.with(|shell_creator| {
         let shell_creator = shell_creator.borrow();
         let shell_creator = shell_creator.as_ref()
@@ -153,7 +150,6 @@ fn create_xdg_surface(surface: &Proxy<WlSurface>)
                 use self::xdg_surface::Event;
                 match event {
                     Event::Configure { serial } => {
-                        error!("Get configure request");
                         proxy.ack_configure(serial);
                         surface_.commit();
                     }

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -108,6 +108,7 @@ impl XdgToplevel {
 
 impl Drop for XdgToplevel {
     fn drop(&mut self) {
+        self.proxy.destroy();
         unsafe {
             let user_data = self.proxy.get_user_data() as *mut XdgToplevelState;
             if !user_data.is_null() {

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -61,7 +61,7 @@ impl XdgToplevel {
         let proxy = xdg_proxy.implement(|event, proxy: Proxy<xdg_toplevel::XdgToplevel>| {
             use self::xdg_toplevel::Event;
             match event {
-                Event::Configure { width, height, .. } => {
+                Event::Configure { .. } => {
                     // TODO Fill in
                     let state = unwrap_state(&proxy);
                     state.xdg_surface.set_window_geometry(0, 0, state.size.width, state.size.height);

--- a/awesome/src/wayland_obj/xdg_shell.rs
+++ b/awesome/src/wayland_obj/xdg_shell.rs
@@ -86,7 +86,6 @@ impl XdgToplevel {
         unwrap_state(&self.proxy).xdg_surface.set_window_geometry(0, 0, width, height);
     }
 
-    // TODO Better interface than RawFd. T: AsRawFd?
     /// Set the backing storage of the xdg shell surface.
     ///
     /// The contents will not be sent until a wl_surface commit, due to

--- a/awesome/src/wayland_protocols/mod.rs
+++ b/awesome/src/wayland_protocols/mod.rs
@@ -1,0 +1,4 @@
+//! Module for all the Wayland objects generated from the Wayland extension
+//! protocols used by Awesome to talk to Way Cooler.
+
+pub mod xdg_shell;

--- a/awesome/src/wayland_protocols/xdg_shell.rs
+++ b/awesome/src/wayland_protocols/xdg_shell.rs
@@ -1,5 +1,5 @@
 /// Generated modules from the XML protocol spec.
-pub use self::generated::client;
+pub use self::generated::client::*;
 
 mod generated {
     // Generated code generally doesn't follow standards

--- a/awesome/src/wayland_protocols/xdg_shell.rs
+++ b/awesome/src/wayland_protocols/xdg_shell.rs
@@ -4,7 +4,7 @@ pub use self::generated::client::*;
 mod generated {
     // Generated code generally doesn't follow standards
     #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
-    #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
+    #![allow(non_upper_case_globals,non_snake_case,unused_imports, unused_qualifications)]
 
     pub mod c_interfaces {
         use wayland_client::sys::common::*;

--- a/awesome/src/wayland_protocols/xdg_shell.rs
+++ b/awesome/src/wayland_protocols/xdg_shell.rs
@@ -1,0 +1,26 @@
+/// Generated modules from the XML protocol spec.
+pub use self::generated::client;
+
+mod generated {
+    // Generated code generally doesn't follow standards
+    #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
+    #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
+
+    pub mod c_interfaces {
+        use wayland_client::sys::common::*;
+        use wayland_client::sys::protocol_interfaces::*;
+        #[doc(hidden)]
+        include!(concat!(env!("OUT_DIR"), "/xdg-shell_interface.rs"));
+    }
+
+    pub mod client {
+        #[doc(hidden)]
+        use wayland_client::*;
+        use wayland_client::commons::*;
+        #[doc(hidden)]
+        use wayland_client::protocol::*;
+        #[doc(hidden)]
+        use super::c_interfaces;
+        include!(concat!(env!("OUT_DIR"), "/xdg-shell_api.rs"));
+    }
+}

--- a/makefile
+++ b/makefile
@@ -4,9 +4,9 @@ build:
 	cargo build --all
 
 run: build
+	sleep .1 && WAYLAND_DISPLAY=wayland-1 ./target/debug/awesome &
 	trap 'kill %1' SIGINT
-	./target/debug/way-cooler &
-	./target/debug/awesome
+	./target/debug/way-cooler
 
 awesome:
 	./target/debug/awesome

--- a/makefile
+++ b/makefile
@@ -3,7 +3,10 @@ default: run
 build:
 	cargo build --all
 
-run: build way_cooler awesome
+run: build
+	trap 'kill %1' SIGINT
+	./target/debug/way-cooler &
+	./target/debug/awesome
 
 awesome:
 	./target/debug/awesome

--- a/protocols/xdg-shell.xml
+++ b/protocols/xdg-shell.xml
@@ -1,0 +1,1141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_shell">
+
+  <copyright>
+    Copyright © 2008-2013 Kristian Høgsberg
+    Copyright © 2013      Rafael Antognolli
+    Copyright © 2013      Jasper St. Pierre
+    Copyright © 2010-2013 Intel Corporation
+    Copyright © 2015-2017 Samsung Electronics Co., Ltd
+    Copyright © 2015-2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_wm_base" version="2">
+    <description summary="create desktop-style surfaces">
+      The xdg_wm_base interface is exposed as a global object enabling clients
+      to turn their wl_surfaces into windows in a desktop environment. It
+      defines the basic functionality needed for clients and the compositor to
+      create windows that can be dragged, resized, maximized, etc, as well as
+      creating transient windows such as popup menus.
+    </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+      <entry name="defunct_surfaces" value="1"
+	     summary="xdg_wm_base was destroyed before children"/>
+      <entry name="not_the_topmost_popup" value="2"
+	     summary="the client tried to map or destroy a non-topmost popup"/>
+      <entry name="invalid_popup_parent" value="3"
+	     summary="the client specified an invalid popup parent surface"/>
+      <entry name="invalid_surface_state" value="4"
+	     summary="the client provided an invalid surface state"/>
+      <entry name="invalid_positioner" value="5"
+	     summary="the client provided an invalid positioner"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy xdg_wm_base">
+	Destroy this xdg_wm_base object.
+
+	Destroying a bound xdg_wm_base object while there are surfaces
+	still alive created by this xdg_wm_base object instance is illegal
+	and will result in a protocol error.
+      </description>
+    </request>
+
+    <request name="create_positioner">
+      <description summary="create a positioner object">
+	Create a positioner object. A positioner object is used to position
+	surfaces relative to some parent surface. See the interface description
+	and xdg_surface.get_popup for details.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_positioner"/>
+    </request>
+
+    <request name="get_xdg_surface">
+      <description summary="create a shell surface from a surface">
+	This creates an xdg_surface for the given surface. While xdg_surface
+	itself is not a role, the corresponding surface may only be assigned
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup.
+
+	This creates an xdg_surface for the given surface. An xdg_surface is
+	used as basis to define a role to a given surface, such as xdg_toplevel
+	or xdg_popup. It also manages functionality shared between xdg_surface
+	based surface roles.
+
+	See the documentation of xdg_surface for more details about what an
+	xdg_surface is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_surface"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="pong">
+      <description summary="respond to a ping event">
+	A client must respond to a ping event with a pong request or
+	the client may be deemed unresponsive. See xdg_wm_base.ping.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the ping event"/>
+    </request>
+
+    <event name="ping">
+      <description summary="check if the client is alive">
+	The ping event asks the client if it's still alive. Pass the
+	serial specified in the event back to the compositor by sending
+	a "pong" request back with the specified serial. See xdg_wm_base.ping.
+
+	Compositors can use this to determine if the client is still
+	alive. It's unspecified what will happen if the client doesn't
+	respond to the ping request, or in what timeframe. Clients should
+	try to respond in a reasonable amount of time.
+
+	A compositor is free to ping in any way it wants, but a client must
+	always respond to any xdg_wm_base object it created.
+      </description>
+      <arg name="serial" type="uint" summary="pass this to the pong request"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_positioner" version="2">
+    <description summary="child surface positioner">
+      The xdg_positioner provides a collection of rules for the placement of a
+      child surface relative to a parent surface. Rules can be defined to ensure
+      the child surface remains within the visible area's borders, and to
+      specify how the child surface changes its position, such as sliding along
+      an axis, or flipping around a rectangle. These positioner-created rules are
+      constrained by the requirement that a child surface must intersect with or
+      be at least partially adjacent to its parent surface.
+
+      See the various requests for details about possible rules.
+
+      At the time of the request, the compositor makes a copy of the rules
+      specified by the xdg_positioner. Thus, after the request is complete the
+      xdg_positioner object can be destroyed or reused; further changes to the
+      object will have no effect on previous usages.
+
+      For an xdg_positioner object to be considered complete, it must have a
+      non-zero size set by set_size, and a non-zero anchor rectangle set by
+      set_anchor_rect. Passing an incomplete xdg_positioner object when
+      positioning a surface raises an error.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_input" value="0" summary="invalid input provided"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_positioner object">
+	Notify the compositor that the xdg_positioner will no longer be used.
+      </description>
+    </request>
+
+    <request name="set_size">
+      <description summary="set the size of the to-be positioned rectangle">
+	Set the size of the surface that is to be positioned with the positioner
+	object. The size is in surface-local coordinates and corresponds to the
+	window geometry. See xdg_surface.set_window_geometry.
+
+	If a zero or negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="width" type="int" summary="width of positioned rectangle"/>
+      <arg name="height" type="int" summary="height of positioned rectangle"/>
+    </request>
+
+    <request name="set_anchor_rect">
+      <description summary="set the anchor rectangle within the parent surface">
+	Specify the anchor rectangle within the parent surface that the child
+	surface will be placed relative to. The rectangle is relative to the
+	window geometry as defined by xdg_surface.set_window_geometry of the
+	parent surface.
+
+	When the xdg_positioner object is used to position a child surface, the
+	anchor rectangle may not extend outside the window geometry of the
+	positioned child's parent surface.
+
+	If a negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="x" type="int" summary="x position of anchor rectangle"/>
+      <arg name="y" type="int" summary="y position of anchor rectangle"/>
+      <arg name="width" type="int" summary="width of anchor rectangle"/>
+      <arg name="height" type="int" summary="height of anchor rectangle"/>
+    </request>
+
+    <enum name="anchor">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_anchor">
+      <description summary="set anchor rectangle anchor">
+	Defines the anchor point for the anchor rectangle. The specified anchor
+	is used derive an anchor point that the child surface will be
+	positioned relative to. If a corner anchor is set (e.g. 'top_left' or
+	'bottom_right'), the anchor point will be at the specified corner;
+	otherwise, the derived anchor point will be centered on the specified
+	edge, or in the center of the anchor rectangle if no edge is specified.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"
+	   summary="anchor"/>
+    </request>
+
+    <enum name="gravity">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_gravity">
+      <description summary="set child surface gravity">
+	Defines in what direction a surface should be positioned, relative to
+	the anchor point of the parent surface. If a corner gravity is
+	specified (e.g. 'bottom_right' or 'top_left'), then the child surface
+	will be placed towards the specified gravity; otherwise, the child
+	surface will be centered over the anchor point on any axis that had no
+	gravity specified.
+      </description>
+      <arg name="gravity" type="uint" enum="gravity"
+	   summary="gravity direction"/>
+    </request>
+
+    <enum name="constraint_adjustment" bitfield="true">
+      <description summary="constraint adjustments">
+	The constraint adjustment value define ways the compositor will adjust
+	the position of the surface, if the unadjusted position would result
+	in the surface being partly constrained.
+
+	Whether a surface is considered 'constrained' is left to the compositor
+	to determine. For example, the surface may be partly outside the
+	compositor's defined 'work area', thus necessitating the child surface's
+	position be adjusted until it is entirely inside the work area.
+
+	The adjustments can be combined, according to a defined precedence: 1)
+	Flip, 2) Slide, 3) Resize.
+      </description>
+      <entry name="none" value="0">
+	<description summary="don't move the child surface when constrained">
+	  Don't alter the surface position even if it is constrained on some
+	  axis, for example partially outside the edge of an output.
+	</description>
+      </entry>
+      <entry name="slide_x" value="1">
+	<description summary="move along the x axis until unconstrained">
+	  Slide the surface along the x axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the x axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  x axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="slide_y" value="2">
+	<description summary="move along the y axis until unconstrained">
+	  Slide the surface along the y axis until it is no longer constrained.
+
+	  First try to slide towards the direction of the gravity on the y axis
+	  until either the edge in the opposite direction of the gravity is
+	  unconstrained or the edge in the direction of the gravity is
+	  constrained.
+
+	  Then try to slide towards the opposite direction of the gravity on the
+	  y axis until either the edge in the direction of the gravity is
+	  unconstrained or the edge in the opposite direction of the gravity is
+	  constrained.
+	</description>
+      </entry>
+      <entry name="flip_x" value="4">
+	<description summary="invert the anchor and gravity on the x axis">
+	  Invert the anchor and gravity on the x axis if the surface is
+	  constrained on the x axis. For example, if the left edge of the
+	  surface is constrained, the gravity is 'left' and the anchor is
+	  'left', change the gravity to 'right' and the anchor to 'right'.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_x adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="flip_y" value="8">
+	<description summary="invert the anchor and gravity on the y axis">
+	  Invert the anchor and gravity on the y axis if the surface is
+	  constrained on the y axis. For example, if the bottom edge of the
+	  surface is constrained, the gravity is 'bottom' and the anchor is
+	  'bottom', change the gravity to 'top' and the anchor to 'top'.
+
+	  The adjusted position is calculated given the original anchor
+	  rectangle and offset, but with the new flipped anchor and gravity
+	  values.
+
+	  If the adjusted position also ends up being constrained, the resulting
+	  position of the flip_y adjustment will be the one before the
+	  adjustment.
+	</description>
+      </entry>
+      <entry name="resize_x" value="16">
+	<description summary="horizontally resize the surface">
+	  Resize the surface horizontally so that it is completely
+	  unconstrained.
+	</description>
+      </entry>
+      <entry name="resize_y" value="32">
+	<description summary="vertically resize the surface">
+	  Resize the surface vertically so that it is completely unconstrained.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_constraint_adjustment">
+      <description summary="set the adjustment to be done when constrained">
+	Specify how the window should be positioned if the originally intended
+	position caused the surface to be constrained, meaning at least
+	partially outside positioning boundaries set by the compositor. The
+	adjustment is set by constructing a bitmask describing the adjustment to
+	be made when the surface is constrained on that axis.
+
+	If no bit for one axis is set, the compositor will assume that the child
+	surface should not change its position on that axis when constrained.
+
+	If more than one bit for one axis is set, the order of how adjustments
+	are applied is specified in the corresponding adjustment descriptions.
+
+	The default adjustment is none.
+      </description>
+      <arg name="constraint_adjustment" type="uint"
+	   summary="bit mask of constraint adjustments"/>
+    </request>
+
+    <request name="set_offset">
+      <description summary="set surface position offset">
+	Specify the surface position offset relative to the position of the
+	anchor on the anchor rectangle and the anchor on the surface. For
+	example if the anchor of the anchor rectangle is at (x, y), the surface
+	has the gravity bottom|right, and the offset is (ox, oy), the calculated
+	surface position will be (x + ox, y + oy). The offset position of the
+	surface is the one used for constraint testing. See
+	set_constraint_adjustment.
+
+	An example use case is placing a popup menu on top of a user interface
+	element, while aligning the user interface element of the parent surface
+	with some user interface element placed somewhere in the popup surface.
+      </description>
+      <arg name="x" type="int" summary="surface position x offset"/>
+      <arg name="y" type="int" summary="surface position y offset"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_surface" version="2">
+    <description summary="desktop user interface surface base interface">
+      An interface that may be implemented by a wl_surface, for
+      implementations that provide a desktop-style user interface.
+
+      It provides a base set of functionality required to construct user
+      interface elements requiring management by the compositor, such as
+      toplevel windows, menus, etc. The types of functionality are split into
+      xdg_surface roles.
+
+      Creating an xdg_surface does not set the role for a wl_surface. In order
+      to map an xdg_surface, the client must create a role-specific object
+      using, e.g., get_toplevel, get_popup. The wl_surface for any given
+      xdg_surface can have at most one role, and may not be assigned any role
+      not based on xdg_surface.
+
+      A role must be assigned before any other requests are made to the
+      xdg_surface object.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_surface state to take effect.
+
+      Creating an xdg_surface from a wl_surface which has a buffer attached or
+      committed is a client error, and any attempts by a client to attach or
+      manipulate a buffer prior to the first xdg_surface.configure call must
+      also be treated as errors.
+
+      Mapping an xdg_surface-based role surface is defined as making it
+      possible for the surface to be shown by the compositor. Note that
+      a mapped surface is not guaranteed to be visible once it is mapped.
+
+      For an xdg_surface to be mapped by the compositor, the following
+      conditions must be met:
+      (1) the client has assigned an xdg_surface-based role to the surface
+      (2) the client has set and committed the xdg_surface state and the
+	  role-dependent state to the surface
+      (3) the client has committed a buffer to the surface
+
+      A newly-unmapped surface is considered to have met condition (1) out
+      of the 3 required conditions for mapping a surface if its role surface
+      has not been destroyed.
+    </description>
+
+    <enum name="error">
+      <entry name="not_constructed" value="1"/>
+      <entry name="already_constructed" value="2"/>
+      <entry name="unconfigured_buffer" value="3"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_surface">
+	Destroy the xdg_surface object. An xdg_surface must only be destroyed
+	after its role object has been destroyed.
+      </description>
+    </request>
+
+    <request name="get_toplevel">
+      <description summary="assign the xdg_toplevel surface role">
+	This creates an xdg_toplevel object for the given xdg_surface and gives
+	the associated wl_surface the xdg_toplevel role.
+
+	See the documentation of xdg_toplevel for more details about what an
+	xdg_toplevel is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_toplevel"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign the xdg_popup surface role">
+	This creates an xdg_popup object for the given xdg_surface and gives
+	the associated wl_surface the xdg_popup role.
+
+	If null is passed as a parent, a parent surface must be specified using
+	some other protocol, before committing the initial state.
+
+	See the documentation of xdg_popup for more details about what an
+	xdg_popup is and how it is used.
+      </description>
+      <arg name="id" type="new_id" interface="xdg_popup"/>
+      <arg name="parent" type="object" interface="xdg_surface" allow-null="true"/>
+      <arg name="positioner" type="object" interface="xdg_positioner"/>
+    </request>
+
+    <request name="set_window_geometry">
+      <description summary="set the new window geometry">
+	The window geometry of a surface is its "visible bounds" from the
+	user's perspective. Client-side decorations often have invisible
+	portions like drop-shadows which should be ignored for the
+	purposes of aligning, placing and constraining windows.
+
+	The window geometry is double buffered, and will be applied at the
+	time wl_surface.commit of the corresponding wl_surface is called.
+
+	When maintaining a position, the compositor should treat the (x, y)
+	coordinate of the window geometry as the top left corner of the window.
+	A client changing the (x, y) window geometry coordinate should in
+	general not alter the position of the window.
+
+	Once the window geometry of the surface is set, it is not possible to
+	unset it, and it will remain the same until set_window_geometry is
+	called again, even if a new subsurface or buffer is attached.
+
+	If never set, the value is the full bounds of the surface,
+	including any subsurfaces. This updates dynamically on every
+	commit. This unset is meant for extremely simple clients.
+
+	The arguments are given in the surface-local coordinate space of
+	the wl_surface associated with this xdg_surface.
+
+	The width and height must be greater than zero. Setting an invalid size
+	will raise an error. When applied, the effective window geometry will be
+	the set window geometry clamped to the bounding rectangle of the
+	combined geometry of the surface of the xdg_surface and the associated
+	subsurfaces.
+      </description>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+	When a configure event is received, if a client commits the
+	surface in response to the configure event, then the client
+	must make an ack_configure request sometime before the commit
+	request, passing along the serial of the configure event.
+
+	For instance, for toplevel surfaces the compositor might use this
+	information to move a surface to the top left only when the client has
+	drawn itself for the maximized or fullscreen state.
+
+	If the client receives multiple configure events before it
+	can respond to one, it only has to ack the last configure event.
+
+	A client is not required to commit immediately after sending
+	an ack_configure request - it may even ack_configure several times
+	before its next surface commit.
+
+	A client may send multiple ack_configure requests before committing, but
+	only the last request sent before a commit indicates which configure
+	event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	The configure event marks the end of a configure sequence. A configure
+	sequence is a set of one or more events configuring the state of the
+	xdg_surface, including the final xdg_surface.configure event.
+
+	Where applicable, xdg_surface surface roles will during a configure
+	sequence extend this event as a latched state sent as events before the
+	xdg_surface.configure event. Such events should be considered to make up
+	a set of atomically applied configuration states, where the
+	xdg_surface.configure commits the accumulated state.
+
+	Clients should arrange their surface for the new states, and then send
+	an ack_configure request with the serial sent in this configure event at
+	some point before committing the new surface.
+
+	If the client receives multiple configure events before it can respond
+	to one, it is free to discard all but the last event it received.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the configure event"/>
+    </event>
+  </interface>
+
+  <interface name="xdg_toplevel" version="2">
+    <description summary="toplevel surface">
+      This interface defines an xdg_surface role which allows a surface to,
+      among other things, set window-like properties such as maximize,
+      fullscreen, and minimize, set application-specific metadata like title and
+      id, and well as trigger user interactive operations such as interactive
+      resize and move.
+
+      Unmapping an xdg_toplevel means that the surface cannot be shown
+      by the compositor until it is explicitly mapped again.
+      All active operations (e.g., move, resize) are canceled and all
+      attributes (e.g. title, state, stacking, ...) are discarded for
+      an xdg_toplevel surface when it is unmapped.
+
+      Attaching a null buffer to a toplevel unmaps the surface.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel">
+	This request destroys the role surface and unmaps the surface;
+	see "Unmapping" behavior in interface section for details.
+      </description>
+    </request>
+
+    <request name="set_parent">
+      <description summary="set the parent of this surface">
+	Set the "parent" of this surface. This surface should be stacked
+	above the parent surface and all other ancestor surfaces.
+
+	Parent windows should be set on dialogs, toolboxes, or other
+	"auxiliary" surfaces, so that the parent is raised when the dialog
+	is raised.
+
+	Setting a null parent for a child window removes any parent-child
+	relationship for the child. Setting a null parent for a window which
+	currently has no parent is a no-op.
+
+	If the parent is unmapped then its children are managed as
+	though the parent of the now-unmapped parent has become the
+	parent of this surface. If no parent exists for the now-unmapped
+	parent then the children are managed as though they have no
+	parent surface.
+      </description>
+      <arg name="parent" type="object" interface="xdg_toplevel" allow-null="true"/>
+    </request>
+
+    <request name="set_title">
+      <description summary="set surface title">
+	Set a short title for the surface.
+
+	This string may be used to identify the surface in a task bar,
+	window list, or other user interface elements provided by the
+	compositor.
+
+	The string must be encoded in UTF-8.
+      </description>
+      <arg name="title" type="string"/>
+    </request>
+
+    <request name="set_app_id">
+      <description summary="set application ID">
+	Set an application identifier for the surface.
+
+	The app ID identifies the general class of applications to which
+	the surface belongs. The compositor can use this to group multiple
+	surfaces together, or to determine how to launch a new application.
+
+	For D-Bus activatable applications, the app ID is used as the D-Bus
+	service name.
+
+	The compositor shell will try to group application surfaces together
+	by their app ID. As a best practice, it is suggested to select app
+	ID's that match the basename of the application's .desktop file.
+	For example, "org.freedesktop.FooViewer" where the .desktop file is
+	"org.freedesktop.FooViewer.desktop".
+
+	See the desktop-entry specification [0] for more details on
+	application identifiers and how they relate to well-known D-Bus
+	names and .desktop files.
+
+	[0] http://standards.freedesktop.org/desktop-entry-spec/
+      </description>
+      <arg name="app_id" type="string"/>
+    </request>
+
+    <request name="show_window_menu">
+      <description summary="show the window menu">
+	Clients implementing client-side decorations might want to show
+	a context menu when right-clicking on the decorations, giving the
+	user a menu that they can use to maximize or minimize the window.
+
+	This request asks the compositor to pop up such a window menu at
+	the given position, relative to the local surface coordinates of
+	the parent surface. There are no guarantees as to what menu items
+	the window menu contains.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="x" type="int" summary="the x position to pop up the window menu at"/>
+      <arg name="y" type="int" summary="the y position to pop up the window menu at"/>
+    </request>
+
+    <request name="move">
+      <description summary="start an interactive move">
+	Start an interactive, user-driven move of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive move (touch,
+	pointer, etc).
+
+	The server may ignore move requests depending on the state of
+	the surface (e.g. fullscreen or maximized), or if the passed serial
+	is no longer valid.
+
+	If triggered, the surface will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the move. It is up to the
+	compositor to visually indicate that the move is taking place, such as
+	updating a pointer cursor, during the move. There is no guarantee
+	that the device focus will return when the move is completed.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <enum name="resize_edge">
+      <description summary="edge values for resizing">
+	These values are used to indicate which edge of a surface
+	is being dragged in a resize operation.
+      </description>
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="right" value="8"/>
+      <entry name="top_right" value="9"/>
+      <entry name="bottom_right" value="10"/>
+    </enum>
+
+    <request name="resize">
+      <description summary="start an interactive resize">
+	Start a user-driven, interactive resize of the surface.
+
+	This request must be used in response to some sort of user action
+	like a button press, key press, or touch down event. The passed
+	serial is used to determine the type of interactive resize (touch,
+	pointer, etc).
+
+	The server may ignore resize requests depending on the state of
+	the surface (e.g. fullscreen or maximized).
+
+	If triggered, the client will receive configure events with the
+	"resize" state enum value and the expected sizes. See the "resize"
+	enum value for more details about what is required. The client
+	must also acknowledge configure events using "ack_configure". After
+	the resize is completed, the client will receive another "configure"
+	event without the resize state.
+
+	If triggered, the surface also will lose the focus of the device
+	(wl_pointer, wl_touch, etc) used for the resize. It is up to the
+	compositor to visually indicate that the resize is taking place,
+	such as updating a pointer cursor, during the resize. There is no
+	guarantee that the device focus will return when the resize is
+	completed.
+
+	The edges parameter specifies how the surface should be resized,
+	and is one of the values of the resize_edge enum. The compositor
+	may use this information to update the surface position for
+	example when dragging the top left corner. The compositor may also
+	use this information to adapt its behavior, e.g. choose an
+	appropriate cursor image.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+      <arg name="edges" type="uint" summary="which edge or corner is being dragged"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of state on the surface">
+	The different state values used on the surface. This is designed for
+	state values like maximized, fullscreen. It is paired with the
+	configure event to ensure that both the client and the compositor
+	setting the state can be synchronized.
+
+	States set in this way are double-buffered. They will get applied on
+	the next commit.
+      </description>
+      <entry name="maximized" value="1" summary="the surface is maximized">
+	<description summary="the surface is maximized">
+	  The surface is maximized. The window geometry specified in the configure
+	  event must be obeyed by the client.
+	</description>
+      </entry>
+      <entry name="fullscreen" value="2" summary="the surface is fullscreen">
+	<description summary="the surface is fullscreen">
+	  The surface is fullscreen. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it. For
+	  a surface to cover the whole fullscreened area, the geometry
+	  dimensions must be obeyed by the client. For more details, see
+	  xdg_toplevel.set_fullscreen.
+	</description>
+      </entry>
+      <entry name="resizing" value="3" summary="the surface is being resized">
+	<description summary="the surface is being resized">
+	  The surface is being resized. The window geometry specified in the
+	  configure event is a maximum; the client cannot resize beyond it.
+	  Clients that have aspect ratio or cell sizing configuration can use
+	  a smaller size, however.
+	</description>
+      </entry>
+      <entry name="activated" value="4" summary="the surface is now activated">
+	<description summary="the surface is now activated">
+	  Client window decorations should be painted as if the window is
+	  active. Do not assume this means that the window actually has
+	  keyboard or pointer focus.
+	</description>
+      </entry>
+      <entry name="tiled_left" value="5" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the left edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_right" value="6" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the right edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_top" value="7" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the top edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+      <entry name="tiled_bottom" value="8" since="2">
+	<description summary="the surface is tiled">
+	  The window is currently in a tiled layout and the bottom edge is
+	  considered to be adjacent to another part of the tiling grid.
+	</description>
+      </entry>
+    </enum>
+
+    <request name="set_max_size">
+      <description summary="set the maximum size">
+	Set a maximum size for the window.
+
+	The client can specify a maximum size so that the compositor does
+	not try to configure the window beyond this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered. They will get applied
+	on the next commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the maximum
+	size. The compositor may decide to ignore the values set by the
+	client and request a larger size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected maximum size in the given dimension.
+	As a result, a client wishing to reset the maximum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a maximum size to be smaller than the minimum size of
+	a surface is illegal and will result in a protocol error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width and height will result in a
+	protocol error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_min_size">
+      <description summary="set the minimum size">
+	Set a minimum size for the window.
+
+	The client can specify a minimum size so that the compositor does
+	not try to configure the window below this size.
+
+	The width and height arguments are in window geometry coordinates.
+	See xdg_surface.set_window_geometry.
+
+	Values set in this way are double-buffered. They will get applied
+	on the next commit.
+
+	The compositor can use this information to allow or disallow
+	different states like maximize or fullscreen and draw accurate
+	animations.
+
+	Similarly, a tiling window manager may use this information to
+	place and resize client windows in a more effective way.
+
+	The client should not rely on the compositor to obey the minimum
+	size. The compositor may decide to ignore the values set by the
+	client and request a smaller size.
+
+	If never set, or a value of zero in the request, means that the
+	client has no expected minimum size in the given dimension.
+	As a result, a client wishing to reset the minimum size
+	to an unspecified state can use zero for width and height in the
+	request.
+
+	Requesting a minimum size to be larger than the maximum size of
+	a surface is illegal and will result in a protocol error.
+
+	The width and height must be greater than or equal to zero. Using
+	strictly negative values for width and height will result in a
+	protocol error.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="set_maximized">
+      <description summary="maximize the window">
+	Maximize the surface.
+
+	After requesting that the surface should be maximized, the compositor
+	will respond by emitting a configure event with the "maximized" state
+	and the required window geometry. The client should then update its
+	content, drawing it in a maximized state, i.e. without shadow or other
+	decoration outside of the window geometry. The client must also
+	acknowledge the configure when committing the new content (see
+	ack_configure).
+
+	It is up to the compositor to decide how and where to maximize the
+	surface, for example which output and what region of the screen should
+	be used.
+
+	If the surface was already maximized, the compositor will still emit
+	a configure event with the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It will alter the state the surface is returned to when
+	unmaximized if not overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="unmaximize the window">
+	Unmaximize the surface.
+
+	After requesting that the surface should be unmaximized, the compositor
+	will respond by emitting a configure event without the "maximized"
+	state. If available, the compositor will include the window geometry
+	dimensions the window had prior to being maximized in the configure
+	event. The client must then update its content, drawing it in a
+	regular state, i.e. potentially with shadow, etc. The client must also
+	acknowledge the configure when committing the new content (see
+	ack_configure).
+
+	It is up to the compositor to position the surface after it was
+	unmaximized; usually the position the surface had before maximizing, if
+	applicable.
+
+	If the surface was already not maximized, the compositor will still
+	emit a configure event without the "maximized" state.
+
+	If the surface is in a fullscreen state, this request has no direct
+	effect. It will alter the state the surface is returned to when
+	unmaximized if not overridden by the compositor.
+      </description>
+    </request>
+
+    <request name="set_fullscreen">
+      <description summary="set the window as fullscreen on an output">
+	Make the surface fullscreen.
+
+	After requesting that the surface should be fullscreened, the
+	compositor will respond by emitting a configure event with the
+	"fullscreen" state and the fullscreen window geometry. The client must
+	also acknowledge the configure when committing the new content (see
+	ack_configure).
+
+	The output passed by the request indicates the client's preference as
+	to which display it should be set fullscreen on. If this value is NULL,
+	it's up to the compositor to choose which display will be used to map
+	this surface.
+
+	If the surface doesn't cover the whole output, the compositor will
+	position the surface in the center of the output and compensate with
+	with border fill covering the rest of the output. The content of the
+	border fill is undefined, but should be assumed to be in some way that
+	attempts to blend into the surrounding area (e.g. solid black).
+
+	If the fullscreened surface is not opaque, the compositor must make
+	sure that other screen content not part of the same surface tree (made
+	up of subsurfaces, popups or similarly coupled surfaces) are not
+	visible below the fullscreened surface.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen">
+      <description summary="unset the window as fullscreen">
+	Make the surface no longer fullscreen.
+
+	After requesting that the surface should be unfullscreened, the
+	compositor will respond by emitting a configure event without the
+	"fullscreen" state.
+
+	Making a surface unfullscreen sets states for the surface based on the following:
+	* the state(s) it may have had before becoming fullscreen
+	* any state(s) decided by the compositor
+	* any state(s) requested by the client while the surface was fullscreen
+
+	The compositor may include the previous window geometry dimensions in
+	the configure event, if applicable.
+
+	The client must also acknowledge the configure when committing the new
+	content (see ack_configure).
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="set the window as minimized">
+	Request that the compositor minimize your surface. There is no
+	way to know if the surface is currently minimized, nor is there
+	any way to unset minimization on this surface.
+
+	If you are looking to throttle redrawing when minimized, please
+	instead use the wl_surface.frame event for this, as this will
+	also work with live previews on windows in Alt-Tab, Expose or
+	similar compositor features.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+	This configure event asks the client to resize its toplevel surface or
+	to change its state. The configured state should not be applied
+	immediately. See xdg_surface.configure for details.
+
+	The width and height arguments specify a hint to the window
+	about how its surface should be resized in window geometry
+	coordinates. See set_window_geometry.
+
+	If the width or height arguments are zero, it means the client
+	should decide its own window dimension. This may happen when the
+	compositor needs to configure the state of the surface but doesn't
+	have any information about any previous or expected dimension.
+
+	The states listed in the event specify how the width/height
+	arguments should be interpreted, and possibly how it should be
+	drawn.
+
+	Clients must send an ack_configure in response to this event. See
+	xdg_surface.configure and xdg_surface.ack_configure for details.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="states" type="array"/>
+    </event>
+
+    <event name="close">
+      <description summary="surface wants to be closed">
+	The close event is sent by the compositor when the user
+	wants the surface to be closed. This should be equivalent to
+	the user clicking the close button in client-side decorations,
+	if your application has any.
+
+	This is only a request that the user intends to close the
+	window. The client may choose to ignore this request, or show
+	a dialog to ask the user to save their data, etc.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="xdg_popup" version="2">
+    <description summary="short-lived, popup surfaces for menus">
+      A popup surface is a short-lived, temporary surface. It can be used to
+      implement for example menus, popovers, tooltips and other similar user
+      interface concepts.
+
+      A popup can be made to take an explicit grab. See xdg_popup.grab for
+      details.
+
+      When the popup is dismissed, a popup_done event will be sent out, and at
+      the same time the surface will be unmapped. See the xdg_popup.popup_done
+      event for details.
+
+      Explicitly destroying the xdg_popup object will also dismiss the popup and
+      unmap the surface. Clients that want to dismiss the popup when another
+      surface of their own is clicked should dismiss the popup using the destroy
+      request.
+
+      A newly created xdg_popup will be stacked on top of all previously created
+      xdg_popup surfaces associated with the same xdg_toplevel.
+
+      The parent of an xdg_popup must be mapped (see the xdg_surface
+      description) before the xdg_popup itself.
+
+      The x and y arguments passed when creating the popup object specify
+      where the top left of the popup should be placed, relative to the
+      local surface coordinates of the parent surface. See
+      xdg_surface.get_popup. An xdg_popup must intersect with or be at least
+      partially adjacent to its parent surface.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_popup state to take effect.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_grab" value="0"
+	     summary="tried to grab after being mapped"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove xdg_popup interface">
+	This destroys the popup. Explicitly destroying the xdg_popup
+	object will also dismiss the popup, and unmap the surface.
+
+	If this xdg_popup is not the "topmost" popup, a protocol error
+	will be sent.
+      </description>
+    </request>
+
+    <request name="grab">
+      <description summary="make the popup take an explicit grab">
+	This request makes the created popup take an explicit grab. An explicit
+	grab will be dismissed when the user dismisses the popup, or when the
+	client destroys the xdg_popup. This can be done by the user clicking
+	outside the surface, using the keyboard, or even locking the screen
+	through closing the lid or a timeout.
+
+	If the compositor denies the grab, the popup will be immediately
+	dismissed.
+
+	This request must be used in response to some sort of user action like a
+	button press, key press, or touch down event. The serial number of the
+	event should be passed as 'serial'.
+
+	The parent of a grabbing popup must either be an xdg_toplevel surface or
+	another xdg_popup with an explicit grab. If the parent is another
+	xdg_popup it means that the popups are nested, with this popup now being
+	the topmost popup.
+
+	Nested popups must be destroyed in the reverse order they were created
+	in, e.g. the only popup you are allowed to destroy at all times is the
+	topmost one.
+
+	When compositors choose to dismiss a popup, they may dismiss every
+	nested grabbing popup as well. When a compositor dismisses popups, it
+	will follow the same dismissing order as required from the client.
+
+	The parent of a grabbing popup must either be another xdg_popup with an
+	active explicit grab, or an xdg_popup or xdg_toplevel, if there are no
+	explicit grabs already taken.
+
+	If the topmost grabbing popup is destroyed, the grab will be returned to
+	the parent of the popup, if that parent previously had an explicit grab.
+
+	If the parent is a grabbing popup which has already been dismissed, this
+	popup will be immediately dismissed. If the parent is a popup that did
+	not take an explicit grab, an error will be raised.
+
+	During a popup grab, the client owning the grab will receive pointer
+	and touch events for all their surfaces as normal (similar to an
+	"owner-events" grab in X11 parlance), while the top most grabbing popup
+	will always have keyboard focus.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"
+	   summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="configure the popup surface">
+	This event asks the popup surface to configure itself given the
+	configuration. The configured state should not be applied immediately.
+	See xdg_surface.configure for details.
+
+	The x and y arguments represent the position the popup was placed at
+	given the xdg_positioner rule, relative to the upper left corner of the
+	window geometry of the parent surface.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position relative to parent surface window geometry"/>
+      <arg name="y" type="int"
+	   summary="y position relative to parent surface window geometry"/>
+      <arg name="width" type="int" summary="window geometry width"/>
+      <arg name="height" type="int" summary="window geometry height"/>
+    </event>
+
+    <event name="popup_done">
+      <description summary="popup interaction is done">
+	The popup_done event is sent out when a popup is dismissed by the
+	compositor. The client should destroy the xdg_popup object at this
+	point.
+      </description>
+    </event>
+
+  </interface>
+</protocol>

--- a/way-cooler/src/input/keyboard.rs
+++ b/way-cooler/src/input/keyboard.rs
@@ -10,7 +10,7 @@ fn key_is_meta(key: u32) -> bool {
 
 impl KeyboardHandler for Keyboard {
     fn on_key(&mut self, compositor: CompositorHandle, keyboard: KeyboardHandle, event: &KeyEvent) {
-        let _modifiers = dehandle!(
+        dehandle!(
             @compositor = {compositor};
             if event.key_state() == WLR_KEY_PRESSED {
                 for key in event.pressed_keys() {

--- a/way-cooler/src/main.rs
+++ b/way-cooler/src/main.rs
@@ -29,8 +29,7 @@
        trivial_numeric_casts,
        unused_extern_crates,
        unused_import_braces,
-       unused_qualifications,
-       unused_results))]
+       unused_qualifications))]
 
 extern crate env_logger;
 extern crate getopts;
@@ -90,7 +89,7 @@ impl Default for Server {
         if xcursor_manager.load(1.0) {
             warn!("Cursor did not load");
         }
-        
+
         Server { xcursor_manager,
                  layout: OutputLayoutHandle::default(),
                  seat: Seat::default(),

--- a/way-cooler/src/main.rs
+++ b/way-cooler/src/main.rs
@@ -170,6 +170,7 @@ pub fn setup_compositor() -> Compositor {
                                                  .input_manager(Box::new(InputManager::new()))
                                                  .xwayland(Box::new(XWaylandManager::new()))
                                                  .xdg_shell_v6_manager(Box::new(XdgV6ShellManager))
+                                                 .xdg_shell_manager(Box::new(XdgShellManager))
                                                  .build_auto(Server::new(layout, cursor));
     // NOTE We need to create this afterwards because it needs the compositor
     // running to announce the seat.

--- a/way-cooler/src/main.rs
+++ b/way-cooler/src/main.rs
@@ -146,8 +146,8 @@ fn main() {
                                     SaFlags::empty(),
                                     SigSet::empty());
     unsafe {
-        let _ = signal::sigaction(signal::SIGINT, &sig_action)
-                      .expect("Could not set SIGINT catcher");
+         signal::sigaction(signal::SIGINT, &sig_action)
+            .expect("Could not set SIGINT catcher");
     }
 
     init_logs();
@@ -304,9 +304,9 @@ pub fn init_logs() {
     wlroots::utils::init_logging(wlroots::utils::WLR_DEBUG, None);
     let env = env_logger::Env::default()
         .filter_or("WAY_COOLER_LOG", "trace");
-    let _ = env_logger::Builder::from_env(env)
-                .format(log_format)
-                .init();
+     env_logger::Builder::from_env(env)
+        .format(log_format)
+        .init();
     info!("Logger initialized");
 }
 

--- a/way-cooler/src/output/output.rs
+++ b/way-cooler/src/output/output.rs
@@ -14,14 +14,12 @@ impl OutputHandler for Output {
             @compositor = {compositor};
             @output = {output};
             let state: &mut Server = compositor.data.downcast_mut().unwrap();
-            let Server { ref mut layout,
-            ref mut views,
-            .. } = *state;
+            let Server { ref mut layout, ref mut views, .. } = *state;
             let renderer = compositor.renderer.as_mut().expect("gles2 disabled");
             let mut renderer = renderer.render(output, None);
             renderer.clear([0.25, 0.25, 0.25, 1.0]);
             render_views(&mut renderer, layout, views)
-            )
+        )
     }
 }
 

--- a/way-cooler/src/seat.rs
+++ b/way-cooler/src/seat.rs
@@ -104,7 +104,7 @@ impl Seat {
             }
             Some(start) => {
                 let pos = Origin::new(lx as i32 - start.x, ly as i32 - start.y);
-                let _ = view.origin.replace(pos);
+                view.origin.replace(pos);
             }
         };
     }
@@ -259,7 +259,7 @@ impl wlroots::DragIconHandler for DragIconHandler {
     fn destroyed(&mut self, compositor: CompositorHandle, drag_icon: DragIconHandle) {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut ::Server = compositor.into();
-            let _ = server.seat.drag_icons.remove(&DragIcon{ handle: drag_icon });
+            server.seat.drag_icons.remove(&DragIcon{ handle: drag_icon });
         }).unwrap();
     }
 }
@@ -291,7 +291,7 @@ impl SeatHandler for SeatManager {
         with_handles!([(compositor: {compositor})] => {
             let server: &mut ::Server = compositor.into();
             let ::Server { ref mut seat, .. } = *server;
-            let _ = seat.drag_icons.insert(DragIcon { handle: drag_icon });
+            seat.drag_icons.insert(DragIcon { handle: drag_icon });
         }).unwrap();
         (Some(Box::new(DragIconHandler)), None)
     }

--- a/way-cooler/src/seat.rs
+++ b/way-cooler/src/seat.rs
@@ -133,8 +133,21 @@ impl Seat {
                            cursor: &mut Cursor)
                            -> (Option<Rc<::View>>, Option<SurfaceHandle>, f64, f64) {
         for view in views {
-            match view.shell {
-                ::Shell::XdgV6(ref shell) => {
+            match view.shell.clone() {
+                ::Shell::XdgV6(mut shell) => {
+                    let (mut sx, mut sy) = (0.0, 0.0);
+                    let surface = dehandle!(
+                        @shell = {shell};
+                        let (lx, ly) = cursor.coords();
+                        let Origin {x: shell_x, y: shell_y} = view.origin.get();
+                        let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
+                        shell.surface_at(view_sx, view_sy, &mut sx, &mut sy)
+                    );
+                    if surface.is_some() {
+                        return (Some(view.clone()), surface, sx, sy)
+                    }
+                },
+                ::Shell::Xdg(mut shell) => {
                     let (mut sx, mut sy) = (0.0, 0.0);
                     let surface = dehandle!(
                         @shell = {shell};

--- a/way-cooler/src/shells/mod.rs
+++ b/way-cooler/src/shells/mod.rs
@@ -1,22 +1,29 @@
 mod xdg_v6;
+mod xdg;
 
 pub use self::xdg_v6::*;
+pub use self::xdg::*;
 
-use wlroots::{Area, HandleResult, SurfaceHandle, XdgV6ShellSurfaceHandle};
+use wlroots::{Area, HandleResult, SurfaceHandle, XdgV6ShellSurfaceHandle,
+              XdgShellSurfaceHandle};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Shell {
-    XdgV6(XdgV6ShellSurfaceHandle) /* TODO WlShell
-                                    * TODO Xdg */
+    XdgV6(XdgV6ShellSurfaceHandle),
+    Xdg(XdgShellSurfaceHandle)
 }
 
 impl Shell {
     /// Get a wlr surface from the shell.
-    pub fn surface(&mut self) -> SurfaceHandle {
-        match *self {
-            Shell::XdgV6(ref mut shell) => {
+    pub fn surface(&self) -> SurfaceHandle {
+        match self.clone() {
+            Shell::XdgV6(shell) => {
                 shell.run(|shell| shell.surface())
                      .expect("An xdg v6 client did not provide us a surface")
+            },
+            Shell::Xdg(mut shell) => {
+                shell.run(|shell| shell.surface())
+                    .expect("An xdg client did not provide us a surface")
             }
         }
     }
@@ -24,7 +31,8 @@ impl Shell {
     /// Get the geometry of a shell.
     pub fn geometry(&mut self) -> HandleResult<Area> {
         match *self {
-            Shell::XdgV6(ref mut shell) => shell.run(|shell| shell.geometry())
+            Shell::XdgV6(ref mut shell) => shell.run(|shell| shell.geometry()),
+            Shell::Xdg(ref mut shell) => shell.run(|shell| shell.geometry())
         }
     }
 }
@@ -32,5 +40,11 @@ impl Shell {
 impl Into<Shell> for XdgV6ShellSurfaceHandle {
     fn into(self) -> Shell {
         Shell::XdgV6(self)
+    }
+}
+
+impl Into<Shell> for XdgShellSurfaceHandle {
+    fn into(self) -> Shell {
+        Shell::Xdg(self)
     }
 }

--- a/way-cooler/src/shells/mod.rs
+++ b/way-cooler/src/shells/mod.rs
@@ -21,7 +21,7 @@ impl Shell {
                 shell.run(|shell| shell.surface())
                      .expect("An xdg v6 client did not provide us a surface")
             },
-            Shell::Xdg(mut shell) => {
+            Shell::Xdg(shell) => {
                 shell.run(|shell| shell.surface())
                     .expect("An xdg client did not provide us a surface")
             }

--- a/way-cooler/src/shells/xdg.rs
+++ b/way-cooler/src/shells/xdg.rs
@@ -127,17 +127,9 @@ impl XdgShellManagerHandler for XdgShellManager {
             @compositor = {compositor};
             let server: &mut ::Server = compositor.into();
             let ::Server { ref mut views, .. } = *server;
-            views.push(Rc::new(::View::new(::Shell::Xdg(xdg_surface.clone().into()))));
-            @xdg_surface = {xdg_surface};
-            match xdg_surface.state().unwrap() {
-                XdgShellState::TopLevel(toplevel) => {
-                    error!("CLIENT PENDING: {:#?}", toplevel.client_pending_state());
-                    warn!("SERVER PENDING: {:#?}", toplevel.server_pending_state());
-                },
-                _ => unimplemented!()
-            }
+            // TODO We should only push it once it's mapped.
+            views.push(Rc::new(::View::new(::Shell::Xdg(xdg_surface.clone().into()))))
         );
-        error!("Added this mother fucker");
         (Some(Box::new(::Xdg::new())), None)
     }
 }

--- a/way-cooler/src/shells/xdg.rs
+++ b/way-cooler/src/shells/xdg.rs
@@ -1,0 +1,112 @@
+use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler,
+              XdgShellSurfaceHandle, XdgShellHandler, XdgShellManagerHandler};
+
+use wlroots::xdg_shell_events::{MoveEvent, ResizeEvent};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Xdg {
+    shell_surface: XdgShellSurfaceHandle
+}
+
+impl Xdg {
+    pub fn new() -> Self {
+        Xdg { .. Xdg::default()}
+    }
+}
+
+impl XdgShellHandler for Xdg {
+    fn resize_request(&mut self,
+                      compositor: CompositorHandle,
+                      _: SurfaceHandle,
+                      shell_surface: XdgShellSurfaceHandle,
+                      event: &ResizeEvent) {
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut ::Server = compositor.into();
+            let ::Server { ref mut seat,
+                         ref mut views,
+                         ref mut cursor,
+                         .. } = *server;
+            let resizing_shell = shell_surface.into();
+
+            if let Some(view) = views.iter().find(|view| view.shell == resizing_shell).cloned() {
+                seat.begin_resize(cursor, view.clone(), views, event.edges())
+            }
+        }).unwrap();
+    }
+
+    fn move_request(&mut self,
+                    compositor: CompositorHandle,
+                    _: SurfaceHandle,
+                    shell_surface: XdgShellSurfaceHandle,
+                    _: &MoveEvent) {
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut ::Server = compositor.into();
+            let ref mut seat = server.seat;
+            let ref mut cursor = server.cursor;
+
+            if let Some(ref mut view) = seat.focused {
+                let shell: ::Shell = shell_surface.into();
+                let action = &mut seat.action;
+                if view.shell == shell {
+                    with_handles!([(cursor: {cursor})] => {
+                        let (lx, ly) = cursor.coords();
+                        let Origin { x: shell_x, y: shell_y } = view.origin.get();
+                        let (view_sx, view_sy) = (lx - shell_x as f64, ly - shell_y as f64);
+                        let start = Origin::new(view_sx as _, view_sy as _);
+                        *action = Some(::Action::Moving { start: start });
+                    }).unwrap();
+                }
+            }
+        }).unwrap();
+    }
+
+    fn on_commit(&mut self,
+                 compositor: CompositorHandle,
+                 _: SurfaceHandle,
+                 shell_surface: XdgShellSurfaceHandle) {
+        let configure_serial = {
+            with_handles!([(shell_surface: {shell_surface.clone()})] => {
+                shell_surface.configure_serial()
+            }).unwrap()
+        };
+
+        let surface = shell_surface.into();
+        with_handles!([(compositor: {compositor})] => {
+            let server: &mut ::Server = compositor.into();
+            let ::Server { ref mut views, .. } = *server;
+
+            if let Some(view) = views.iter().find(|view| view.shell == surface).cloned() {
+                if let Some(move_resize) = view.pending_move_resize.get() {
+                    if move_resize.serial >= configure_serial {
+                        let Origin {mut x, mut y} = view.origin.get();
+                        if move_resize.update_x {
+                            x  = move_resize.area.origin.x + move_resize.area.size.width -
+                                 view.get_size().width;
+                        }
+                        if move_resize.update_y {
+                            y  = move_resize.area.origin.y + move_resize.area.size.height -
+                                 view.get_size().height;
+                        }
+
+                        view.origin.set(Origin { x, y });
+
+                        if move_resize.serial == configure_serial {
+                            view.pending_move_resize.set(None);
+                        }
+                    }
+                }
+            }
+        }).unwrap();
+    }
+}
+
+pub struct XdgShellManager;
+
+impl XdgShellManagerHandler for XdgShellManager {
+    fn new_surface(&mut self,
+                   _: CompositorHandle,
+                   _: XdgShellSurfaceHandle)
+                   -> (Option<Box<XdgShellHandler>>, Option<Box<SurfaceHandler>>) {
+        (Some(Box::new(::Xdg::new())), None)
+    }
+}

--- a/way-cooler/src/shells/xdg.rs
+++ b/way-cooler/src/shells/xdg.rs
@@ -1,8 +1,7 @@
 use std::rc::Rc;
 
 use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler,
-              XdgShellSurfaceHandle, XdgShellHandler, XdgShellManagerHandler,
-              XdgShellState};
+              XdgShellSurfaceHandle, XdgShellHandler, XdgShellManagerHandler};
 use wlroots::xdg_shell_events::{MoveEvent, ResizeEvent};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/way-cooler/src/shells/xdg_v6.rs
+++ b/way-cooler/src/shells/xdg_v6.rs
@@ -137,10 +137,10 @@ impl XdgV6ShellHandler for XdgV6 {
             @compositor = {compositor};
             let server: &mut ::Server = compositor.into();
             let ::Server { ref mut seat,
-                         ref mut views,
-                         ref cursor,
-                         ref mut xcursor_manager,
-                         .. } = *server;
+                           ref mut views,
+                           ref cursor,
+                           ref mut xcursor_manager,
+                           .. } = *server;
             let destroyed_shell = shell_surface.into();
             views.retain(|view| view.shell != destroyed_shell);
 
@@ -152,6 +152,20 @@ impl XdgV6ShellHandler for XdgV6 {
             @cursor = {cursor};
             seat.update_cursor_position(cursor, xcursor_manager, views, None)
         );
+    }
+
+    fn destroyed(&mut self,
+                 compositor: CompositorHandle,
+                 shell_surface: XdgV6ShellSurfaceHandle) {
+        let surface = shell_surface.into();
+        dehandle!(
+            @compositor = {compositor};
+            let server: &mut ::Server = compositor.into();
+            let ::Server { ref mut views, .. } = *server;
+            if let Some(index) = views.iter().position(|view| view.shell == surface) {
+                views.remove(index);
+            }
+        )
     }
 }
 

--- a/way-cooler/src/shells/xdg_v6.rs
+++ b/way-cooler/src/shells/xdg_v6.rs
@@ -1,7 +1,8 @@
+use std::rc::Rc;
+
 use wlroots::{CompositorHandle, Origin, SurfaceHandle, SurfaceHandler, XdgV6ShellHandler,
               XdgV6ShellManagerHandler, XdgV6ShellState::*, XdgV6ShellSurfaceHandle};
 
-use std::rc::Rc;
 use wlroots::xdg_shell_v6_events::{MoveEvent, ResizeEvent};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This PR essentially gets Way Cooler back to the point it was at before we split up the compositor and awesome work into two processes.

This adds the xdg protocol to the awesome client side as that is the standard protocol we will use to render the top bar. It's possible we might want to switch to layer shell, however I haven't finished wrapping that in wlroots-rs so Way Cooler currently doesn't support it.

This isn't totally ready though because there is a type check I had to disable to get this to work...and I need to make sure it's something I can't work around before I merge this.

Also removed the unused result check on CI/Test, because that was a mistake.

# TODO
- [x] Fix that type check bug
- [x] Ensure that updating wlroots fixes the segfault when killing `awesome`.
  - It causes Way Cooler to segfault, but it happens in rootston as well (!) and the error reported makes it look like a bug in how they handle their `wl_list`s.
- [ ] ~Make `awesome` work when using `way-cooler` in DRM~ Lets do this in another patch
  - It's not working because we aren't setting up xwayland correctly and it's causing an early disconnect.