### PR TITLE
way-cooler seat: end keyboard grab before focus

### DIFF
--- a/way-cooler/src/seat.rs
+++ b/way-cooler/src/seat.rs
@@ -74,6 +74,7 @@ impl Seat {
             @seat = {&self.seat};
             if let Some(keyboard) = seat.get_keyboard() {
                 with_handles!([(keyboard: {keyboard}), (surface: {view.surface()})] => {
+                    seat.keyboard_end_grab();
                     seat.keyboard_notify_enter(surface,
                                                &mut keyboard.keycodes(),
                                                &mut keyboard.get_modifier_masks());


### PR DESCRIPTION
If a surface has the keyboard grab at the time we switch focus, it will
get the keyboard event instead of the intended surface. End the grab to
reset keyboard focus before sending enter notify.