### PR TITLE
README: fix link to irc channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ If you find bugs or have questions about the code, please [submit an issue][] or
 [AwesomeWM]: https://awesomewm.org/
 [submit an issue]: https://github.com/Immington-Industries/way-cooler/issues/new
 [wlroots]: https://github.com/swaywm/wlroots
-[IRC]: https://webchat.freenode.net/?channels=awesome&uio=d4
+[IRC]: https://webchat.oftc.net/?channels=awesome&uio=d4
 [i3]: https://i3wm.org


### PR DESCRIPTION
I don't think this ever meant to point to freenode since the channel
there is almost empty, don't seem to be related to Way-Cooler or
Awesome, and doesn't have Timidger :)