### PR TITLE
docs: contributing: IRC link should point to oftc

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -2,7 +2,7 @@
 
 To contribute code, all that is required is that you have an email address and you can send a pull request via Github.
 
-Regardless if you are planning for or looking for something to do, it's best if you reach out via the [IRC channel](https://webchat.freenode.net/?channels=awesome&uio=d4) first.
+Regardless if you are planning for or looking for something to do, it's best if you reach out via the [IRC channel](https://webchat.oftc.net/?channels=awesome&uio=d4) first.
 
 # Release Cycle
 For pre-1.0 there is no fixed release. Once 1.0 has been released a release cycle will be determined and will probably follow what Awesome does.


### PR DESCRIPTION
Just found another place in docs where freenode was referred to instead of oftc.