### PR TITLE
Restore way-cooler.desktop

### DIFF
--- a/way-cooler/way-cooler.desktop
+++ b/way-cooler/way-cooler.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Way Cooler
+Comment=Customizable Wayland compositor
+TryExec=way-cooler
+Exec=dbus-launch --exit-with-session way-cooler
+Type=Application


### PR DESCRIPTION
It looks like this went lost in 207d2e74 or is there any reason behind its removal?