### PR TITLE
Implement layer shell in compositor

### DIFF
--- a/compositor/input.c
+++ b/compositor/input.c
@@ -8,6 +8,7 @@
 
 #include "keyboard.h"
 #include "pointer.h"
+#include "seat.h"
 #include "server.h"
 
 static void wc_new_input(struct wl_listener* listener, void* data) {
@@ -28,7 +29,7 @@ static void wc_new_input(struct wl_listener* listener, void* data) {
 	if (!wl_list_empty(&server->keyboards)) {
 		caps |= WL_SEAT_CAPABILITY_KEYBOARD;
 	}
-	wlr_seat_set_capabilities(server->seat, caps);
+	wlr_seat_set_capabilities(server->seat->seat, caps);
 }
 
 void wc_init_inputs(struct wc_server* server) {

--- a/compositor/keyboard.c
+++ b/compositor/keyboard.c
@@ -6,15 +6,17 @@
 #include <wayland-server.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend/multi.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
-#include "wlr/types/wlr_input_device.h"
+#include "seat.h"
+
 
 static void wc_keyboard_on_key(struct wl_listener* listener, void* data) {
 	struct wc_keyboard* keyboard = wl_container_of(listener, keyboard, key);
 	struct wc_server* server = keyboard->server;
-	struct wlr_seat* seat = server->seat;
+	struct wlr_seat* seat = server->seat->seat;
 	struct wlr_event_keyboard_key* event = data;
 
 	uint32_t keycode = event->keycode + 8;
@@ -55,8 +57,8 @@ static void wc_keyboard_on_key(struct wl_listener* listener, void* data) {
 static void wc_keyboard_on_modifiers(struct wl_listener* listener, void* data) {
 	struct wc_keyboard* keyboard = wl_container_of(listener, keyboard,
 			modifiers);
-	wlr_seat_set_keyboard(keyboard->server->seat, keyboard->device);
-	wlr_seat_keyboard_notify_modifiers(keyboard->server->seat,
+	wlr_seat_set_keyboard(keyboard->server->seat->seat, keyboard->device);
+	wlr_seat_keyboard_notify_modifiers(keyboard->server->seat->seat,
 			&keyboard->device->keyboard->modifiers);
 }
 
@@ -69,7 +71,7 @@ static void wc_keyboard_removed(struct wl_listener* listener, void* data) {
 void wc_new_keyboard(struct wc_server* server, struct wlr_input_device* device) {
 	wlr_log(WLR_INFO, "New keyboard detected: %p", device);
 
-	wlr_seat_set_keyboard(server->seat, device);
+	wlr_seat_set_keyboard(server->seat->seat, device);
 
 	struct wc_keyboard* keyboard = calloc(1, sizeof(struct wc_keyboard));
 	keyboard->server = server;

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -1,0 +1,237 @@
+#include "layer_shell.h"
+
+#include <stdlib.h>
+
+#include <wayland-server.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_box.h>
+#include <wlr/util/log.h>
+
+#include "output.h"
+#include "seat.h"
+#include "server.h"
+#include "view.h"
+
+static const uint32_t LAYER_BOTH_HORIZ = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT
+	| ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+static const uint32_t LAYER_BOTH_VERT = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP
+	| ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+
+static void wc_layer_shell_commit(struct wl_listener* listener, void* data) {
+	struct wc_layer* layer = wl_container_of(listener, layer, commit);
+	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
+	struct wlr_output* wlr_output = layer_surface->output;
+	if (wlr_output == NULL) {
+		return;
+	}
+	wc_layer_shell_arrange_layers(wlr_output->data);
+}
+
+static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
+	struct wc_layer* layer = wl_container_of(listener, layer, map);
+	layer->mapped = true;
+}
+
+static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
+	struct wc_layer* layer = wl_container_of(listener, layer, unmap);
+	layer->mapped = false;
+}
+
+static void wc_layer_shell_destroy(struct wl_listener* listener, void* data) {
+	struct wc_layer* layer = wl_container_of(listener, layer, destroy);
+	wl_list_remove(&layer->link);
+	wlr_layer_surface_v1_close(layer->layer_surface);
+	free(layer);
+}
+
+static void wc_arrange_layer(struct wc_output* output,
+		struct wc_seat* seat, struct wl_list* layers,
+		struct wlr_box* usable_area, bool exclusive) {
+	struct wlr_box full_area = { 0 };
+	wlr_output_effective_resolution(output->output,
+			&full_area.width, &full_area.height);
+	struct wc_layer* wc_layer;
+	wl_list_for_each_reverse(wc_layer, layers, link) {
+		struct wlr_layer_surface_v1* layer = wc_layer->layer_surface;
+		struct wlr_layer_surface_v1_state* state = &layer->current;
+		if (exclusive != (state->exclusive_zone > 0)) {
+			continue;
+		}
+		struct wlr_box bounds = *usable_area;
+		if (state->exclusive_zone == -1) {
+			bounds = full_area;
+		}
+		struct wlr_box arranged_area = {
+			.width = state->desired_width,
+			.height = state->desired_height
+		};
+
+		// horizontal axis
+		if ((state->anchor & LAYER_BOTH_HORIZ) && arranged_area.width == 0) {
+			arranged_area.x = bounds.x;
+			arranged_area.width = bounds.width;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT) {
+			arranged_area.x = bounds.x;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
+			arranged_area.x = bounds.x + (bounds.width - arranged_area.width);
+		} else {
+			arranged_area.x =
+				bounds.x + ((bounds.width / 2) - (arranged_area.width / 2));
+		}
+
+		// vertical axis
+		if ((state->anchor & LAYER_BOTH_VERT) && arranged_area.height == 0) {
+			arranged_area.y = bounds.y;
+			arranged_area.height = bounds.height;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) {
+			arranged_area.y = bounds.y;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM) {
+			arranged_area.y = bounds.y + (bounds.height - arranged_area.height);
+		} else {
+			arranged_area.y =
+				bounds.y + ((bounds.height / 2) - (arranged_area.height / 2));
+		}
+
+		// left and right margin
+		if ((state->anchor & LAYER_BOTH_HORIZ) == LAYER_BOTH_HORIZ) {
+			arranged_area.x += state->margin.left;
+			arranged_area.width -= state->margin.left + state->margin.right;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT) {
+			arranged_area.x += state->margin.left;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
+			arranged_area.x -= state->margin.right;
+		}
+
+		// top and bottom margin
+		if ((state->anchor & LAYER_BOTH_VERT) == LAYER_BOTH_VERT) {
+			arranged_area.y += state->margin.top;
+			arranged_area.height -= state->margin.top + state->margin.bottom;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) {
+			arranged_area.y += state->margin.top;
+		} else if (state->anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM) {
+			arranged_area.y -= state->margin.bottom;
+		}
+
+		if (arranged_area.width < 0 || arranged_area.width < 0) {
+			wlr_layer_surface_v1_close(layer);
+			continue;
+		}
+
+		wc_layer->geo = arranged_area;
+		// TODO Apply exclusive zones
+		wlr_layer_surface_v1_configure(layer,
+				arranged_area.width, arranged_area.height);
+
+		// TODO send cursor enter events if it's now hovering
+	}
+}
+
+void wc_layer_shell_arrange_layers(struct wc_output* output) {
+	struct wlr_box usable_area = { 0 };
+	struct wc_server* server = output->server;
+	struct wc_seat* seat = server->seat;
+	wlr_output_effective_resolution(output->output,
+			&usable_area.width, &usable_area.height);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+			&usable_area, true);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
+			&usable_area, true);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
+			&usable_area, true);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
+			&usable_area, true);
+
+	memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
+	// TODO Arrange maximized views once we have those
+
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+			&usable_area, false);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
+			&usable_area, false);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
+			&usable_area, false);
+	wc_arrange_layer(output, seat,
+			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
+			&usable_area, false);
+
+	uint32_t layers_above_shell[] = {
+		ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
+		ZWLR_LAYER_SHELL_V1_LAYER_TOP,
+	};
+	size_t nlayers = sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
+	struct wc_layer* layer = NULL;
+	struct wc_layer* topmost = NULL;
+	for (size_t i = 0; i < nlayers; i++) {
+		wl_list_for_each_reverse(layer,
+				&output->layers[layers_above_shell[i]], link) {
+			if (layer->layer_surface->current.keyboard_interactive) {
+				topmost = layer;
+				break;
+			}
+		}
+		if (topmost != NULL) {
+			break;
+		}
+	}
+
+	wc_seat_set_focus_layer(seat, topmost ? topmost->layer_surface : NULL);
+}
+
+static void wc_layer_shell_new_surface(
+		struct wl_listener* listener, void* data) {
+	struct wc_server* server = wl_container_of(listener, server, new_layer_surface);
+	struct wlr_layer_surface_v1* layer_surface = data;
+	struct wc_output* active_output = wc_get_active_output(server);
+	if (active_output == NULL) {
+		wlr_layer_surface_v1_close(layer_surface);
+		return;
+	}
+
+	if (!layer_surface->output) {
+		// If client did not request an output, give them the focused one.
+		layer_surface->output = active_output->output;
+	}
+	struct wc_output* output = layer_surface->output->data;
+
+	struct wc_layer* layer = calloc(1, sizeof(struct wc_layer));
+	layer->server = server;
+	layer->layer_surface = layer_surface;
+
+	layer->commit.notify = wc_layer_shell_commit;
+	wl_signal_add(&layer_surface->surface->events.commit, &layer->commit);
+	layer->map.notify = wc_layer_shell_map;
+	wl_signal_add(&layer_surface->events.map, &layer->map);
+	layer->unmap.notify = wc_layer_shell_unmap;
+	wl_signal_add(&layer_surface->events.unmap, &layer->unmap);
+	layer->destroy.notify = wc_layer_shell_destroy;
+	wl_signal_add(&layer_surface->events.destroy, &layer->destroy);
+
+	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
+	if (layer_surface->layer >= len) {
+		wlr_log(WLR_ERROR, "Bad surface layer %d", layer_surface->layer);
+		wlr_layer_surface_v1_close(layer_surface);
+		return;
+	}
+	wl_list_insert(&output->layers[layer_surface->layer], &layer->link);
+
+	struct wlr_layer_surface_v1_state old_state = layer_surface->current;
+	layer_surface->current = layer_surface->client_pending;
+	wc_layer_shell_arrange_layers(output);
+	layer_surface->current = old_state;
+}
+
+void wc_init_layers(struct wc_server* server) {
+	server->layer_shell = wlr_layer_shell_v1_create(server->wl_display);
+
+	server->new_layer_surface.notify = wc_layer_shell_new_surface;
+	wl_signal_add(&server->layer_shell->events.new_surface,
+			&server->new_layer_surface);
+}

--- a/compositor/layer_shell.h
+++ b/compositor/layer_shell.h
@@ -1,0 +1,27 @@
+#ifndef LAYER_SHELL_H
+#define LAYER_SHELL_H
+
+#include <wayland-server.h>
+
+#include "server.h"
+
+struct wc_layer {
+	struct wl_list link;
+	struct wc_server* server;
+
+	struct wlr_layer_surface_v1* layer_surface;
+	struct wlr_box geo;
+	bool mapped;
+
+	struct wl_listener commit;
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+};
+
+void wc_init_layers(struct wc_server* server);
+
+// Arrange the layer shells on this output.
+void wc_layer_shell_arrange_layers(struct wc_output* output);
+
+#endif//LAYER_SHELL_H

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -46,6 +46,7 @@ way_cooler_sources = files(
 	'seat.c',
 	'server.c',
 	'view.c',
+	'xdg.c',
 )
 
 executable(

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -40,6 +40,7 @@ way_cooler_sources = files(
 	'cursor.c',
 	'input.c',
 	'keyboard.c',
+	'layer_shell.c',
 	'main.c',
 	'output.c',
 	'pointer.c',

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -12,34 +12,33 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/render/wlr_renderer.h>
 
+#include "layer_shell.h"
 #include "view.h"
 #include "server.h"
 
 /* Used to move all of the data necessary to render a surface from the top-level
  * frame handler to the per-surface render function. */
-struct wc_render_data {
-	struct wlr_output *output;
-	struct wlr_renderer *renderer;
-	struct wc_view *view;
-	struct timespec *when;
+struct wc_view_render_data {
+	struct wlr_output* output;
+	struct wlr_renderer* renderer;
+	struct wc_view* view;
+	struct timespec* when;
+};
+
+/* Used to move all of the data necessary to render a surface from the layers */
+struct wc_layer_render_data {
+	struct wlr_renderer* renderer;
+	struct wc_layer* layer;
+	struct timespec* when;
 };
 
 static void wc_render_surface(struct wlr_surface* surface,
-		int sx, int sy, void *data) {
-	struct wc_render_data* rdata = data;
-	struct wc_view* view = rdata->view;
-	struct wlr_output* output = rdata->output;
-
+		struct wlr_output* output, struct wlr_renderer* renderer,
+		struct timespec* when, int sx, int sy, double ox, double oy) {
 	struct wlr_texture* texture = wlr_surface_get_texture(surface);
 	if (texture == NULL) {
 		return;
 	}
-
-	double ox = 0, oy = 0;
-	wlr_output_layout_output_coords(
-			view->server->output_layout, output, &ox, &oy);
-	ox += view->x + sx, oy += view->y + sy;
-
 	struct wlr_box box = {
 		.x = ox * output->scale,
 		.y = oy * output->scale,
@@ -52,13 +51,64 @@ static void wc_render_surface(struct wlr_surface* surface,
 	wlr_matrix_project_box(matrix, &box, transform, 0,
 			output->transform_matrix);
 
-	wlr_render_texture_with_matrix(rdata->renderer, texture, matrix, 1);
+	wlr_render_texture_with_matrix(renderer, texture, matrix, 1);
 
-	wlr_surface_send_frame_done(surface, rdata->when);
+	wlr_surface_send_frame_done(surface, when);
+}
+
+static void wc_render_view(struct wlr_surface* surface,
+		int sx, int sy, void* data) {
+	struct wc_view_render_data* rdata = data;
+	struct wc_view* view = rdata->view;
+	struct wlr_output* output = rdata->output;
+
+	double ox = 0, oy = 0;
+	wlr_output_layout_output_coords(
+			view->server->output_layout, output, &ox, &oy);
+	ox += view->x + sx, oy += view->y + sy;
+
+	wc_render_surface(surface, output, rdata->renderer,
+			rdata->when, sx, sy, ox, oy);
+}
+
+static void wc_render_layer(struct wlr_surface* surface,
+		int sx, int sy, void* data) {
+	struct wc_layer_render_data* rdata = data;
+	struct wc_layer* layer = rdata->layer;
+	struct wc_server* server = layer->server;
+	struct wlr_output* output = layer->layer_surface->output;
+
+	double ox = 0, oy = 0;
+	wlr_output_layout_output_coords(
+			server->output_layout, output, &ox, &oy);
+	ox += layer->geo.x + sx, oy += layer->geo.y + sy;
+
+	wc_render_surface(surface, output, rdata->renderer,
+			rdata->when, sx, sy, ox, oy);
+}
+
+static void wc_render_layers(struct timespec* now,
+		struct wlr_renderer* renderer, struct wc_output* output,
+		struct wl_list* layers) {
+	struct wc_layer* layer;
+	wl_list_for_each_reverse(layer, layers, link) {
+		if (!layer->mapped) {
+			continue;
+		}
+		struct wc_layer_render_data rdata = {
+			.layer = layer,
+			.renderer = renderer,
+			.when = now
+		};
+
+		wlr_layer_surface_v1_for_each_surface(layer->layer_surface,
+				wc_render_layer, &rdata);
+	}
 }
 
 static void wc_output_frame(struct wl_listener* listener, void* data) {
 	struct wc_output* output = wl_container_of(listener, output, frame);
+	struct wc_server* server = output->server;
 	struct wlr_output* wlr_output = output->output;
 	struct wlr_renderer* renderer = wlr_backend_get_renderer(wlr_output->backend);
 	assert(renderer);
@@ -74,15 +124,29 @@ static void wc_output_frame(struct wl_listener* listener, void* data) {
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 	wlr_renderer_begin(renderer, width, height);
 
+	// TODO Remove this once a background renders
 	float color[4] = { 0.25f, 0.25f, 0.25f, 1 };
 	wlr_renderer_clear(renderer, color);
 
+	struct wl_list* backgrounds =
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND];
+	struct wl_list* bottom =
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM];
+	struct wl_list* top =
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP];
+	struct wl_list* overlay =
+		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY];
+
+	wc_render_layers(&now, renderer, output, backgrounds);
+	wc_render_layers(&now, renderer, output, bottom);
+
+	// Render traditional shell surfaces between bottom and top layers.
 	struct wc_view* view;
-	wl_list_for_each_reverse(view, &output->server->views, link) {
+	wl_list_for_each_reverse(view, &server->views, link) {
 		if (!view->mapped) {
 			continue;
 		}
-		struct wc_render_data rdata = {
+		struct wc_view_render_data rdata = {
 			.output = output->output,
 			.view = view,
 			.renderer = renderer,
@@ -90,8 +154,11 @@ static void wc_output_frame(struct wl_listener* listener, void* data) {
 		};
 
 		wlr_xdg_surface_for_each_surface(view->xdg_surface,
-				wc_render_surface, &rdata);
+				wc_render_view, &rdata);
 	}
+
+	wc_render_layers(&now, renderer, output, top);
+	wc_render_layers(&now, renderer, output, overlay);
 
 	wlr_output_render_software_cursors(wlr_output, NULL);
 
@@ -127,6 +194,12 @@ static void wc_new_output(struct wl_listener* listener, void* data) {
 	struct wc_output* wc_output = calloc(1, sizeof(struct wc_output));
 	wc_output->output = output;
 	wc_output->server = server;
+	output->data = wc_output;
+
+	size_t len = sizeof(wc_output->layers) / sizeof(wc_output->layers[0]);
+	for (size_t i = 0; i < len; i++) {
+		wl_list_init(&wc_output->layers[i]);
+	}
 
 	wc_output->frame.notify = wc_output_frame;
 	wl_signal_add(&output->events.frame, &wc_output->frame);
@@ -141,6 +214,8 @@ static void wc_new_output(struct wl_listener* listener, void* data) {
 
 	wlr_output_layout_add_auto(server->output_layout, output);
 	wlr_output_create_global(output);
+
+	wc_layer_shell_arrange_layers(wc_output);
 }
 
 

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -2,6 +2,7 @@
 #define WC_OUTPUT_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_box.h>
 
 #include "server.h"
 
@@ -10,6 +11,9 @@ struct wc_output {
 	struct wc_server* server;
 
 	struct wlr_output* output;
+
+	struct wlr_box usable_area;
+	struct wl_list layers[4];
 
 	struct wl_listener destroy;
 	struct wl_listener frame;

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -11,10 +11,16 @@ struct wc_output {
 
 	struct wlr_output* output;
 
+	struct wl_listener destroy;
 	struct wl_listener frame;
 };
 
-void wc_output_frame(struct wl_listener* listener, void* data);
 void wc_init_output(struct wc_server* server);
+
+// Gets the output that was last active (e.g. last had user activity).
+//
+// If there are no outputs, NULL is returned. If there has been no activity,
+// the first output in the list is returned.
+struct wc_output* wc_get_active_output(struct wc_server* server);
 
 #endif // WC_OUTPUT_H

--- a/compositor/seat.c
+++ b/compositor/seat.c
@@ -37,6 +37,11 @@ void wc_seat_update_surface_focus(struct wc_seat* seat,
 	}
 }
 
+void wc_seat_set_focus_layer(struct wc_seat* seat,
+		struct wlr_layer_surface_v1* layer) {
+	// TODO
+}
+
 void wc_init_seat(struct wc_server* server) {
 	struct wc_seat* seat = calloc(1, sizeof(struct wc_seat));
 	seat->server = server;

--- a/compositor/seat.c
+++ b/compositor/seat.c
@@ -1,17 +1,21 @@
 #include "seat.h"
 
+#include <stdlib.h>
+
 #include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_surface.h>
 
 #include "cursor.h"
 #include "server.h"
 
 static void wc_seat_request_cursor(struct wl_listener* listener, void* data) {
-	struct wc_server* server = wl_container_of(listener, server,
+	struct wc_seat* seat = wl_container_of(listener, seat,
 			request_set_cursor);
+	struct wc_server* server = seat->server;
 	struct wc_cursor* cursor = server->cursor;
 	struct wlr_seat_pointer_request_set_cursor_event* event = data;
 	struct wlr_seat_client *focused_client =
-		server->seat->pointer_state.focused_client;
+		server->seat->seat->pointer_state.focused_client;
 	if (focused_client == event->seat_client) {
 		cursor->image = NULL;
 		wlr_cursor_set_surface(cursor->wlr_cursor,
@@ -19,9 +23,28 @@ static void wc_seat_request_cursor(struct wl_listener* listener, void* data) {
 	}
 }
 
+void wc_seat_update_surface_focus(struct wc_seat* seat,
+		struct wlr_surface* surface, double sx, double sy, uint32_t time) {
+	struct wlr_seat* wlr_seat = seat->seat;
+	if (surface == NULL) {
+		wlr_seat_pointer_clear_focus(wlr_seat);
+		return;
+	}
+	bool focused_changed = wlr_seat->pointer_state.focused_surface != surface;
+	wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
+	if (!focused_changed) {
+		wlr_seat_pointer_notify_motion(wlr_seat, time, sx, sy);
+	}
+}
+
 void wc_init_seat(struct wc_server* server) {
-	server->seat = wlr_seat_create(server->wl_display, "seat0");
-	server->request_set_cursor.notify = wc_seat_request_cursor;
-	wl_signal_add(&server->seat->events.request_set_cursor,
-			&server->request_set_cursor);
+	struct wc_seat* seat = calloc(1, sizeof(struct wc_seat));
+	seat->server = server;
+	seat->seat = wlr_seat_create(server->wl_display, "seat0");
+
+	seat->request_set_cursor.notify = wc_seat_request_cursor;
+	wl_signal_add(&seat->seat->events.request_set_cursor,
+			&seat->request_set_cursor);
+
+	server->seat = seat;
 }

--- a/compositor/seat.h
+++ b/compositor/seat.h
@@ -2,14 +2,22 @@
 #define WC_SEAT_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_surface.h>
 
 #include "server.h"
 
 struct wc_seat {
-	struct wl_list link;
 	struct wc_server* server;
+	struct wlr_seat* seat;
+
+	struct wl_listener request_set_cursor;
 };
 
 void wc_init_seat(struct wc_server* server);
+
+// Updates the seat's focus based on the surface. If surface is NULL the focus
+// is cleared.
+void wc_seat_update_surface_focus(struct wc_seat* seat,
+		struct wlr_surface* surface, double sx, double sy, uint32_t time);
 
 #endif//WC_SEAT_H

--- a/compositor/seat.h
+++ b/compositor/seat.h
@@ -3,6 +3,7 @@
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
 
 #include "server.h"
 
@@ -19,5 +20,8 @@ void wc_init_seat(struct wc_server* server);
 // is cleared.
 void wc_seat_update_surface_focus(struct wc_seat* seat,
 		struct wlr_surface* surface, double sx, double sy, uint32_t time);
+
+void wc_seat_set_focus_layer(struct wc_seat* seat,
+		struct wlr_layer_surface_v1* layer);
 
 #endif//WC_SEAT_H

--- a/compositor/server.c
+++ b/compositor/server.c
@@ -15,6 +15,7 @@
 
 #include "cursor.h"
 #include "input.h"
+#include "layer_shell.h"
 #include "output.h"
 #include "seat.h"
 #include "view.h"
@@ -41,6 +42,7 @@ bool init_server(struct wc_server* server) {
 	wc_init_output(server);
 	wc_init_inputs(server);
 	wc_init_views(server);
+	wc_init_layers(server);
 	wc_init_cursor(server);
 
 	return true;

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -39,6 +39,7 @@ struct wc_server {
 	struct wl_listener new_input;
 
 	struct wlr_output_layout* output_layout;
+	struct wc_output* active_output;
 	struct wl_list outputs;
 	struct wl_listener new_output;
 

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -6,6 +6,7 @@
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -42,9 +43,12 @@ struct wc_server {
 	struct wl_list outputs;
 	struct wl_listener new_output;
 
+	struct wl_list views;
 	struct wlr_xdg_shell* xdg_shell;
 	struct wl_listener new_xdg_surface;
-	struct wl_list views;
+
+	struct wlr_layer_shell_v1* layer_shell;
+	struct wl_listener new_layer_surface;
 };
 
 bool init_server(struct wc_server* server);

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -31,8 +31,7 @@ struct wc_server {
     int grab_width, grab_height;
 	uint32_t resize_edges;
 
-	struct wlr_seat* seat;
-	struct wl_listener request_set_cursor;
+	struct wc_seat* seat;
 
 	struct wl_list keyboards;
 	struct wl_list pointers;

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -4,10 +4,11 @@
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
-#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/util/log.h>
 
 #include "cursor.h"
 #include "server.h"
+#include "xdg.h"
 
 static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
 		double* out_sx, double* out_sy, struct wlr_surface** out_surface) {
@@ -56,94 +57,7 @@ void wc_focus_view(struct wc_view* view) {
 			keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
 }
 
-static void wc_xdg_surface_map(struct wl_listener* listener, void* data) {
-	struct wc_view* view = wl_container_of(listener, view, map);
-	view->mapped = true;
-	wc_focus_view(view);
-}
-
-static void wc_xdg_surface_unmap(struct wl_listener* listener, void* data) {
-	struct wc_view* view = wl_container_of(listener, view, unmap);
-	view->mapped = false;
-}
-
-static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {
-	struct wc_view* view = wl_container_of(listener, view, destroy);
-	wl_list_remove(&view->link);
-	free(view);
-}
-
-static void wc_xdg_toplevel_request_move(struct wl_listener* listener, void* data) {
-	struct wc_view* view = wl_container_of(listener, view, request_move);
-	struct wc_server* server = view->server;
-	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
-	struct wlr_surface* focused_surface =
-		server->seat->pointer_state.focused_surface;
-	if (view->xdg_surface->surface != focused_surface) {
-		return;
-	}
-	server->grabbed_view = view;
-	server->cursor_mode = WC_CURSOR_MOVE;
-	struct wlr_box geo_box;
-	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
-	server->grab_x = wlr_cursor->x - view->x;
-	server->grab_y = wlr_cursor->y - view->y;
-	server->grab_width = geo_box.width;
-	server->grab_height = geo_box.height;
-}
-
-static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* data) {
-	struct wc_view* view = wl_container_of(listener, view, request_resize);
-	struct wlr_xdg_toplevel_resize_event *event = data;
-	struct wc_server* server = view->server;
-	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
-	struct wlr_surface* focused_surface =
-		server->seat->pointer_state.focused_surface;
-	if (view->xdg_surface->surface != focused_surface) {
-		return;
-	}
-	server->grabbed_view = view;
-	server->cursor_mode = WC_CURSOR_RESIZE;
-	struct wlr_box geo_box;
-	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
-	server->grab_x = wlr_cursor->x + geo_box.x;
-	server->grab_y = wlr_cursor->y + geo_box.y;
-	server->grab_width = geo_box.width;
-	server->grab_height = geo_box.height;
-	server->resize_edges = event->edges;
-}
-
-static void wc_new_xdg_surface(struct wl_listener* listener, void* data) {
-	struct wc_server* server = wl_container_of(listener, server, new_xdg_surface);
-	struct wlr_xdg_surface* xdg_surface = data;
-	if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
-		return;
-	}
-
-	struct wc_view* view = calloc(1, sizeof(struct wc_view));
-	view->server = server;
-	view->xdg_surface = xdg_surface;
-
-	view->map.notify = wc_xdg_surface_map;
-	wl_signal_add(&xdg_surface->events.map, &view->map);
-	view->unmap.notify = wc_xdg_surface_unmap;
-	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
-	view->destroy.notify = wc_xdg_surface_destroy;
-	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
-
-	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
-	view->request_move.notify = wc_xdg_toplevel_request_move;
-	wl_signal_add(&toplevel->events.request_move, &view->request_move);
-	view->request_resize.notify = wc_xdg_toplevel_request_resize;
-	wl_signal_add(&toplevel->events.request_resize, &view->request_resize);
-
-	wl_list_insert(&server->views, &view->link);
-}
-
 void wc_init_views(struct wc_server* server) {
 	wl_list_init(&server->views);
-	server->xdg_shell = wlr_xdg_shell_create(server->wl_display);
-	server->new_xdg_surface.notify = wc_new_xdg_surface;
-	wl_signal_add(&server->xdg_shell->events.new_surface,
-				  &server->new_xdg_surface);
+	wc_init_xdg(server);
 }

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -7,6 +7,7 @@
 #include <wlr/util/log.h>
 
 #include "cursor.h"
+#include "seat.h"
 #include "server.h"
 #include "xdg.h"
 
@@ -36,9 +37,10 @@ void wc_focus_view(struct wc_view* view) {
 		return;
 	}
 	struct wc_server* server = view->server;
-	struct wlr_surface* surface = view->xdg_surface->surface;
-	struct wlr_seat* seat = server->seat;
-	struct wlr_surface* prev_surface = server->seat->keyboard_state.focused_surface;
+	struct wlr_surface* surface = wc_view_surface(view);
+	struct wlr_seat* seat = server->seat->seat;
+	struct wlr_surface* prev_surface =
+		server->seat->seat->keyboard_state.focused_surface;
 	if (prev_surface == surface) {
 		return;
 	}

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -25,6 +25,9 @@ struct wc_view {
 
 void wc_init_views(struct wc_server* server);
 
+// Get the main surface associated with the view.
+struct wlr_surface* wc_view_surface(struct wc_view* view);
+
 // Finds the topmost (assuming server->views is top-to-bottom) view at the
 // specified output layout coordinates. If one cannot be found NULL is returned.
 //

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -3,18 +3,29 @@
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 
 #include "server.h"
 
+enum wc_surface_type {
+	WC_XDG,
+};
+
 struct wc_view {
 	struct wl_list link;
-	struct wc_server *server;
+	struct wc_server* server;
 
-	// TODO This should be abstract over surfaces of all kinds (xwayland, layer shell)
-	struct wlr_xdg_surface *xdg_surface;
+	enum wc_surface_type surface_type;
+	union {
+		struct wlr_xdg_surface* xdg_surface;
+	};
+
 	bool mapped;
 	int x, y;
+
+	// These variables are layer surface specific
+	struct wlr_box wc_layer_geo;
 
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -1,0 +1,104 @@
+#include "xdg.h"
+
+#include <stdlib.h>
+
+#include <wayland-server.h>
+#include <wlr/types/wlr_xdg_shell.h>
+
+#include "cursor.h"
+#include "server.h"
+#include "view.h"
+
+static void wc_xdg_surface_map(struct wl_listener* listener, void* data) {
+	struct wc_view* view = wl_container_of(listener, view, map);
+	view->mapped = true;
+	wc_focus_view(view);
+}
+
+static void wc_xdg_surface_unmap(struct wl_listener* listener, void* data) {
+	struct wc_view* view = wl_container_of(listener, view, unmap);
+	view->mapped = false;
+}
+
+static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {
+	struct wc_view* view = wl_container_of(listener, view, destroy);
+	wl_list_remove(&view->link);
+	free(view);
+}
+
+static void wc_xdg_toplevel_request_move(struct wl_listener* listener, void* data) {
+	struct wc_view* view = wl_container_of(listener, view, request_move);
+	struct wc_server* server = view->server;
+	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
+	struct wlr_surface* focused_surface =
+		server->seat->pointer_state.focused_surface;
+	struct wlr_surface* surface = wc_view_surface(view);
+	if (surface != focused_surface) {
+		return;
+	}
+	server->grabbed_view = view;
+	server->cursor_mode = WC_CURSOR_MOVE;
+	struct wlr_box geo_box;
+	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
+	server->grab_x = wlr_cursor->x - view->x;
+	server->grab_y = wlr_cursor->y - view->y;
+	server->grab_width = geo_box.width;
+	server->grab_height = geo_box.height;
+}
+
+static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* data) {
+	struct wc_view* view = wl_container_of(listener, view, request_resize);
+	struct wlr_xdg_toplevel_resize_event *event = data;
+	struct wc_server* server = view->server;
+	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
+	struct wlr_surface* focused_surface =
+		server->seat->pointer_state.focused_surface;
+	struct wlr_surface* surface = wc_view_surface(view);
+	if (surface != focused_surface) {
+		return;
+	}
+	server->grabbed_view = view;
+	server->cursor_mode = WC_CURSOR_RESIZE;
+	struct wlr_box geo_box;
+	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
+	server->grab_x = wlr_cursor->x + geo_box.x;
+	server->grab_y = wlr_cursor->y + geo_box.y;
+	server->grab_width = geo_box.width;
+	server->grab_height = geo_box.height;
+	server->resize_edges = event->edges;
+}
+
+static void wc_xdg_new_surface(struct wl_listener* listener, void* data) {
+	struct wc_server* server = wl_container_of(listener, server, new_xdg_surface);
+	struct wlr_xdg_surface* xdg_surface = data;
+	if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
+		return;
+	}
+
+	struct wc_view* view = calloc(1, sizeof(struct wc_view));
+	view->server = server;
+	view->xdg_surface = xdg_surface;
+	view->surface_type = WC_XDG;
+
+	view->map.notify = wc_xdg_surface_map;
+	wl_signal_add(&xdg_surface->events.map, &view->map);
+	view->unmap.notify = wc_xdg_surface_unmap;
+	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
+	view->destroy.notify = wc_xdg_surface_destroy;
+	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
+
+	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
+	view->request_move.notify = wc_xdg_toplevel_request_move;
+	wl_signal_add(&toplevel->events.request_move, &view->request_move);
+	view->request_resize.notify = wc_xdg_toplevel_request_resize;
+	wl_signal_add(&toplevel->events.request_resize, &view->request_resize);
+
+	wl_list_insert(&server->views, &view->link);
+}
+
+void wc_init_xdg(struct wc_server* server) {
+	server->xdg_shell = wlr_xdg_shell_create(server->wl_display);
+	server->new_xdg_surface.notify = wc_xdg_new_surface;
+	wl_signal_add(&server->xdg_shell->events.new_surface,
+			&server->new_xdg_surface);
+}

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 
 #include "cursor.h"
+#include "seat.h"
 #include "server.h"
 #include "view.h"
 
@@ -31,7 +32,7 @@ static void wc_xdg_toplevel_request_move(struct wl_listener* listener, void* dat
 	struct wc_server* server = view->server;
 	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
 	struct wlr_surface* focused_surface =
-		server->seat->pointer_state.focused_surface;
+		server->seat->seat->pointer_state.focused_surface;
 	struct wlr_surface* surface = wc_view_surface(view);
 	if (surface != focused_surface) {
 		return;
@@ -52,7 +53,7 @@ static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* d
 	struct wc_server* server = view->server;
 	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
 	struct wlr_surface* focused_surface =
-		server->seat->pointer_state.focused_surface;
+		server->seat->seat->pointer_state.focused_surface;
 	struct wlr_surface* surface = wc_view_surface(view);
 	if (surface != focused_surface) {
 		return;

--- a/compositor/xdg.h
+++ b/compositor/xdg.h
@@ -1,0 +1,8 @@
+#ifndef XDG_H
+#define XDG_H
+
+#include "server.h"
+
+void wc_init_xdg(struct wc_server* server);
+
+#endif//XDG_H

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -26,6 +26,7 @@ wayland_scanner_server = generator(
 
 server_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+	['wlr-layer-shell-unstable-v1.xml'],
 ]
 
 server_protos_src = []

--- a/protocols/wlr-layer-shell-unstable-v1.xml
+++ b/protocols/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_v1_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="1">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="1">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
+      is double-buffered, and will be applied at the time wl_surface.commit of
+      the corresponding wl_surface is called.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthoginal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area of the surface
+        with other surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to an
+        edge, rather than a corner. The zone is the number of surface-local
+        coordinates from the edge that are considered exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive excluzive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accomodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set to 1 to request that the seat send keyboard events to this layer
+        surface. For layers below the shell surface layer, the seat will use
+        normal focus semantics. For layers above the shell surface layers, the
+        seat will always give exclusive keyboard focus to the top-most layer
+        which has keyboard interactivity set to true.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Events is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+  </interface>
+</protocol>


### PR DESCRIPTION
* Adds the unstable layer shell protocol
  * The plan is that the client can use this protocol to render wiboxes. This will come in a later PR.
* xdg-shell specific code is now in its own file (and infrastructure for later view types was added)
* The "active" output is kept track of