### PR TITLE
Clean up listeners when resource destroyed

### DIFF
--- a/compositor/keyboard.c
+++ b/compositor/keyboard.c
@@ -66,6 +66,11 @@ static void wc_keyboard_removed(struct wl_listener* listener, void* data) {
 	struct wc_keyboard* keyboard = wl_container_of(listener, keyboard, destroy);
 	wlr_log(WLR_INFO, "Keyboard removed: %p", keyboard->device);
 	wl_list_remove(&keyboard->link);
+
+	wl_list_remove(&keyboard->key.link);
+	wl_list_remove(&keyboard->modifiers.link);
+	wl_list_remove(&keyboard->destroy.link);
+	free(keyboard);
 }
 
 void wc_new_keyboard(struct wc_server* server, struct wlr_input_device* device) {

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -41,6 +41,12 @@ static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
 static void wc_layer_shell_destroy(struct wl_listener* listener, void* data) {
 	struct wc_layer* layer = wl_container_of(listener, layer, destroy);
 	wl_list_remove(&layer->link);
+
+	wl_list_remove(&layer->commit.link);
+	wl_list_remove(&layer->map.link);
+	wl_list_remove(&layer->unmap.link);
+	wl_list_remove(&layer->destroy.link);
+
 	wlr_layer_surface_v1_close(layer->layer_surface);
 	free(layer);
 }

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -171,6 +171,10 @@ static void wc_output_destroy(struct wl_listener* listener, void* data) {
 	struct wc_output* output = wl_container_of(listener, output, destroy);
 	struct wc_server* server = output->server;
 	wl_list_remove(&output->link);
+
+	wl_list_remove(&output->frame.link);
+	wl_list_remove(&output->destroy.link);
+
 	if (server->active_output == output) {
 		server->active_output = NULL;
 		if (!wl_list_empty(&server->outputs)) {
@@ -178,6 +182,7 @@ static void wc_output_destroy(struct wl_listener* listener, void* data) {
 					server->outputs.prev, server->active_output, link);
 		}
 	}
+
 	free(output);
 }
 

--- a/compositor/pointer.c
+++ b/compositor/pointer.c
@@ -10,6 +10,10 @@
 static void wc_pointer_removed(struct wl_listener* listener, void* data) {
 	struct wc_pointer* pointer = wl_container_of(listener, pointer, destroy);
 	wl_list_remove(&pointer->link);
+
+	wl_list_remove(&pointer->destroy.link);
+
+	free(pointer);
 }
 
 void wc_new_pointer(struct wc_server* server, struct wlr_input_device* device) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -24,6 +24,13 @@ static void wc_xdg_surface_unmap(struct wl_listener* listener, void* data) {
 static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {
 	struct wc_view* view = wl_container_of(listener, view, destroy);
 	wl_list_remove(&view->link);
+
+	wl_list_remove(&view->map.link);
+	wl_list_remove(&view->unmap.link);
+	wl_list_remove(&view->request_move.link);
+	wl_list_remove(&view->request_resize.link);
+	wl_list_remove(&view->destroy.link);
+
 	free(view);
 }
 


### PR DESCRIPTION
This will help avoid supurious segfaults/aborts if the events arrive out
of order or e.g. several requests to destroy a resources are emitted.

Also fixes pointer and keyboard cleanup, which wasn't happening before.