### PR TITLE
Output damage

### DIFF
--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -18,33 +18,13 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 	struct wc_view* view = server->grabbed_view;
 	switch (server->cursor_mode) {
 	case WC_CURSOR_MOVE: {
-		struct wlr_output* outputs[4] = { 0 };
-		wc_view_get_outputs(view->server->output_layout, view, outputs);
+		wc_view_damage_whole(view);
 
-		for (int i = 0; i < 4; i++) {
-			struct wlr_output* output = outputs[i];
-			if (output) {
-				wc_output_damage_surface(
-						output->data, view->xdg_surface->surface,
-						view->x - output->lx, view->y - output->ly);
-			}
-		}
-
-		wc_view_get_outputs(view->server->output_layout, view, outputs);
 		view->x = wlr_cursor->x - server->grab_x;
 		view->y = wlr_cursor->y - server->grab_y;
 
-		for (int i = 0; i < 4; i++) {
-			struct wlr_output* output = outputs[i];
-			if (output) {
-				wc_output_damage_surface(
-						output->data, view->xdg_surface->surface,
-						view->x - output->lx, view->y - output->ly);
-			}
-		}
+		wc_view_damage_whole(view);
 		break;
-		// TODO Do we need to do a dameg calculation here?
-		// Relying on commit might leave artifacts from the previous position
 	}
 	case WC_CURSOR_RESIZE: {
 		double dx = wlr_cursor->x - server->grab_x;

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -31,10 +31,10 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 		double dy = wlr_cursor->y - cursor->grabbed.original_y;
 		double x = view->x;
 		double y = view->y;
-		int width = cursor->grabbed.original_width;
-		int height = cursor->grabbed.original_height;
+		int width = cursor->grabbed.original_view_width;
+		int height = cursor->grabbed.original_view_height;
 		if (cursor->grabbed.resize_edges & WLR_EDGE_TOP) {
-			y = cursor->grabbed.original_y + dy;
+			y = cursor->grabbed.original_view_y + dy;
 			height -= dy;
 			if (height < 1) {
 				y += height;
@@ -43,7 +43,7 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 			height += dy;
 		}
 		if (cursor->grabbed.resize_edges & WLR_EDGE_LEFT) {
-			x = cursor->grabbed.original_x + dx;
+			x = cursor->grabbed.original_view_x + dx;
 			width -= dx;
 			if (width < 1) {
 				x += width;

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -72,14 +72,14 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 			width += dx;
 		}
 
-		// TODO Check serial, if zero apply updates now.
-		wlr_xdg_toplevel_set_size(view->xdg_surface, width, height);
-
-		view->is_pending_geometry = true;
 		view->pending_geometry.x = x;
 		view->pending_geometry.y = y;
 		view->pending_geometry.width = width;
 		view->pending_geometry.height = height;
+
+		// TODO Handle it being zero, in which case resize immediately
+		view->pending_serial =
+			wlr_xdg_toplevel_set_size(view->xdg_surface, width, height);
 
 		break;
 	}

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -15,40 +15,40 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 	struct wc_seat* seat = server->seat;
 	struct wc_cursor* cursor = server->cursor;
 	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
-	struct wc_view* view = server->grabbed_view;
-	switch (server->cursor_mode) {
+	struct wc_view* view = cursor->grabbed.view;
+	switch (cursor->cursor_mode) {
 	case WC_CURSOR_MOVE: {
 		wc_view_damage_whole(view);
 
-		view->x = wlr_cursor->x - server->grab_x;
-		view->y = wlr_cursor->y - server->grab_y;
+		view->x = wlr_cursor->x - cursor->grabbed.original_x;
+		view->y = wlr_cursor->y - cursor->grabbed.original_y;
 
 		wc_view_damage_whole(view);
 		break;
 	}
 	case WC_CURSOR_RESIZE: {
-		double dx = wlr_cursor->x - server->grab_x;
-		double dy = wlr_cursor->y - server->grab_y;
+		double dx = wlr_cursor->x - cursor->grabbed.original_x;
+		double dy = wlr_cursor->y - cursor->grabbed.original_y;
 		double x = view->x;
 		double y = view->y;
-		int width = server->grab_width;
-		int height = server->grab_height;
-		if (server->resize_edges & WLR_EDGE_TOP) {
-			y = server->grab_y + dy;
+		int width = cursor->grabbed.original_width;
+		int height = cursor->grabbed.original_height;
+		if (cursor->grabbed.resize_edges & WLR_EDGE_TOP) {
+			y = cursor->grabbed.original_y + dy;
 			height -= dy;
 			if (height < 1) {
 				y += height;
 			}
-		} else if (server->resize_edges & WLR_EDGE_BOTTOM) {
+		} else if (cursor->grabbed.resize_edges & WLR_EDGE_BOTTOM) {
 			height += dy;
 		}
-		if (server->resize_edges & WLR_EDGE_LEFT) {
-			x = server->grab_x + dx;
+		if (cursor->grabbed.resize_edges & WLR_EDGE_LEFT) {
+			x = cursor->grabbed.original_x + dx;
 			width -= dx;
 			if (width < 1) {
 				x += width;
 			}
-		} else if (server->resize_edges & WLR_EDGE_RIGHT) {
+		} else if (cursor->grabbed.resize_edges & WLR_EDGE_RIGHT) {
 			width += dx;
 		}
 
@@ -120,7 +120,7 @@ static void wc_cursor_button(struct wl_listener* listener, void* data) {
 	struct wc_view* view = wc_view_at(server,
 			cursor->wlr_cursor->x, cursor->wlr_cursor->y, &sx, &sy, &surface);
 	if (event->state == WLR_BUTTON_RELEASED) {
-		server->cursor_mode = WC_CURSOR_PASSTHROUGH;
+		cursor->cursor_mode = WC_CURSOR_PASSTHROUGH;
 	} else if (view) {
 		wc_focus_view(view);
 	}

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -56,10 +56,10 @@ static void wc_process_motion(struct wc_server* server, uint32_t time) {
 
 		memcpy(&view->pending_geometry, &new_geo, sizeof(struct wlr_box));
 
-		// TODO Handle it being zero, in which case resize immediately
 		view->pending_serial =
 			wlr_xdg_toplevel_set_size(view->xdg_surface,
 					new_geo.width, new_geo.height);
+		view->is_pending_serial = true;
 
 		break;
 	}

--- a/compositor/cursor.h
+++ b/compositor/cursor.h
@@ -2,6 +2,7 @@
 #define WC_CURSOR_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_cursor.h>
 
 enum wc_cursor_mode {
@@ -26,9 +27,9 @@ struct wc_cursor {
 	 */
 	struct {
 		struct wc_view* view;
-		double original_x, original_y;
-		double original_view_x, original_view_y;
-		int original_view_width, original_view_height;
+		// Original coordinates of where the cursor was.
+		int original_x, original_y;
+		struct wlr_box original_view_geo;
 		uint32_t resize_edges;
 	} grabbed;
 

--- a/compositor/cursor.h
+++ b/compositor/cursor.h
@@ -27,7 +27,8 @@ struct wc_cursor {
 	struct {
 		struct wc_view* view;
 		double original_x, original_y;
-		int original_width, original_height;
+		double original_view_x, original_view_y;
+		int original_view_width, original_view_height;
 		uint32_t resize_edges;
 	} grabbed;
 

--- a/compositor/cursor.h
+++ b/compositor/cursor.h
@@ -4,11 +4,32 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_cursor.h>
 
+enum wc_cursor_mode {
+	WC_CURSOR_PASSTHROUGH = 0,
+	WC_CURSOR_MOVE,
+	WC_CURSOR_RESIZE,
+};
+
 struct wc_cursor {
 	struct wc_server* server;
 	struct wlr_cursor* wlr_cursor;
 
 	char* image;
+
+	enum wc_cursor_mode cursor_mode;
+	/*
+	 * Original location data of a view when it is grabbed. This is
+	 * used in calculations when resizing and moving it from
+	 * the original location.
+	 *
+	 * depending on mode, these may or may not be valid
+	 */
+	struct {
+		struct wc_view* view;
+		double original_x, original_y;
+		int original_width, original_height;
+		uint32_t resize_edges;
+	} grabbed;
 
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -30,10 +30,10 @@ static void wc_layer_shell_commit(struct wl_listener* listener, void* data) {
 	wc_layer_shell_arrange_layers(wlr_output->data);
 
 	if (memcmp(&old_geo, &layer->geo, sizeof(struct wlr_box)) != 0) {
-		output_damage_surface(wlr_output->data, layer_surface->surface,
+		wc_output_damage_surface(wlr_output->data, layer_surface->surface,
 				old_geo.x, old_geo.y);
 	}
-	output_damage_surface(wlr_output->data, layer_surface->surface,
+	wc_output_damage_surface(wlr_output->data, layer_surface->surface,
 			layer->geo.x, layer->geo.y);
 }
 
@@ -41,7 +41,7 @@ static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
 	struct wc_layer* layer = wl_container_of(listener, layer, map);
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = true;
-	output_damage_surface(layer_surface->output->data, layer_surface->surface,
+	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
 			layer->geo.x, layer->geo.y);
 }
 
@@ -49,7 +49,7 @@ static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
 	struct wc_layer* layer = wl_container_of(listener, layer, unmap);
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = false;
-	output_damage_surface(layer_surface->output->data, layer_surface->surface,
+	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
 			layer->geo.x, layer->geo.y);
 }
 

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -31,10 +31,10 @@ static void wc_layer_shell_commit(struct wl_listener* listener, void* data) {
 
 	if (memcmp(&old_geo, &layer->geo, sizeof(struct wlr_box)) != 0) {
 		wc_output_damage_surface(wlr_output->data, layer_surface->surface,
-				old_geo.x, old_geo.y);
+				old_geo.x, old_geo.y, old_geo.width, old_geo.height);
 	}
 	wc_output_damage_surface(wlr_output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y);
+			layer->geo.x, layer->geo.y, old_geo.width, old_geo.height);
 }
 
 static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
@@ -42,7 +42,7 @@ static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = true;
 	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y);
+			layer->geo.x, layer->geo.y, layer->geo.width, layer->geo.height);
 }
 
 static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
@@ -50,7 +50,7 @@ static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = false;
 	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y);
+			layer->geo.x, layer->geo.y, layer->geo.width, layer->geo.height);
 }
 
 static void wc_layer_shell_destroy(struct wl_listener* listener, void* data) {

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -28,13 +28,14 @@ static void wc_layer_shell_commit(struct wl_listener* listener, void* data) {
 	}
 	struct wlr_box old_geo = layer->geo;
 	wc_layer_shell_arrange_layers(wlr_output->data);
+	// TODO Only update what layer shell says is damaged
 
 	if (memcmp(&old_geo, &layer->geo, sizeof(struct wlr_box)) != 0) {
 		wc_output_damage_surface(wlr_output->data, layer_surface->surface,
-				old_geo.x, old_geo.y, old_geo.width, old_geo.height);
+				NULL, old_geo);
 	}
 	wc_output_damage_surface(wlr_output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y, old_geo.width, old_geo.height);
+			NULL, layer->geo);
 }
 
 static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
@@ -42,7 +43,7 @@ static void wc_layer_shell_map(struct wl_listener* listener, void* data) {
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = true;
 	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y, layer->geo.width, layer->geo.height);
+			NULL, layer->geo);
 }
 
 static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
@@ -50,7 +51,7 @@ static void wc_layer_shell_unmap(struct wl_listener* listener, void* data) {
 	struct wlr_layer_surface_v1* layer_surface = layer->layer_surface;
 	layer->mapped = false;
 	wc_output_damage_surface(layer_surface->output->data, layer_surface->surface,
-			layer->geo.x, layer->geo.y, layer->geo.width, layer->geo.height);
+			NULL, layer->geo);
 }
 
 static void wc_layer_shell_destroy(struct wl_listener* listener, void* data) {

--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -29,16 +29,14 @@ static void wc_layer_shell_commit(struct wl_listener* listener, void* data) {
 	struct wlr_box old_geo = layer->geo;
 	wc_layer_shell_arrange_layers(wlr_output->data);
 
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	wlr_surface_get_effective_damage(layer_surface->surface, &damage);
-	pixman_region32_translate(&damage, old_geo.x, old_geo.y);
-
 	if (memcmp(&old_geo, &layer->geo, sizeof(struct wlr_box)) != 0) {
 		wc_output_damage_surface(wlr_output->data, layer_surface->surface,
-				&damage, old_geo);
+				NULL, old_geo);
 	}
 
+
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
 	wlr_surface_get_effective_damage(layer_surface->surface, &damage);
 	pixman_region32_translate(&damage, layer->geo.x, layer->geo.y);
 	wc_output_damage_surface(wlr_output->data, layer_surface->surface,

--- a/compositor/main.c
+++ b/compositor/main.c
@@ -17,13 +17,14 @@ const char* WC_HELP_MESSAGE =
 	"\n"
 	"  -c <command>           Execute the command after startup.\n"
 	"  -h                     Show help message and quit.\n"
+	"  -d                     Turn on debugging"
 	"\n";
 
 const char* WC_GETOPT_OPTIONS =
 #ifdef __GNUC__
 "+"
 #endif
-"hc:";
+"hc:d";
 
 const char* WC_BINARY_PATH = NULL;
 
@@ -40,6 +41,9 @@ int main(int argc, char* argv[]) {
 	int c;
 	while ((c = getopt(argc, argv, WC_GETOPT_OPTIONS)) != -1) {
 		switch (c) {
+		case 'd':
+			WC_DEBUG = 1;
+			break;
 		case 'c':
 			startup_cmd = strdup(optarg);
 			break;

--- a/compositor/main.c
+++ b/compositor/main.c
@@ -7,6 +7,7 @@
 #include <wordexp.h>
 #include <unistd.h>
 
+#include <wlr/types/wlr_data_device.h>
 #include <wlr/backend.h>
 #include <wlr/util/log.h>
 
@@ -78,6 +79,8 @@ int main(int argc, char* argv[]) {
 			execl("/bin/sh", "/bin/sh", "-c", startup_cmd, (void*)NULL);
 		}
 	}
+
+	wlr_data_device_manager_create(server.wl_display);
 
 	wl_display_run(server.wl_display);
 	fini_server(&server);

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -7,6 +7,7 @@ wayland_egl    = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')
 xcb            = dependency('xcb')
+pixman         = dependency('pixman-1')
 
 # Try first to find wlroots as a subproject, then as a system dependency
 wlroots_version = '>=0.5.0'
@@ -34,6 +35,7 @@ way_cooler_deps = [
 	wlroots,
 	xkbcommon,
 	server_protos,
+	pixman,
 ]
 
 way_cooler_sources = files(

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -50,10 +50,10 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 	struct wc_output* output = data->output;
 	double width = data->width;
 	double height = data->height;
-	if (width == 0) {
+	if (surface->current.width > width) {
 		width = surface->current.width;
 	}
-	if (height == 0) {
+	if (surface->current.height > height) {
 		height = surface->current.height;
 	}
 	struct wlr_box surface_area = {

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -40,8 +40,8 @@ struct wc_layer_render_data {
 /* Used when calculating the damage of a surface */
 struct wc_surface_damage_data {
 	struct wc_output* output;
-	double ox, oy;
-	double width, height;
+	int ox, oy;
+	int width, height;
 };
 
 static void damage_surface_iterator(struct wlr_surface* surface,
@@ -50,12 +50,6 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 	struct wc_output* output = data->output;
 	double width = data->width;
 	double height = data->height;
-	if (surface->current.width > width) {
-		width = surface->current.width;
-	}
-	if (surface->current.height > height) {
-		height = surface->current.height;
-	}
 	struct wlr_box surface_area = {
 		.x = data->ox + sx,
 		.y = data->oy + sy,
@@ -71,8 +65,8 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 }
 
 void wc_output_damage_surface(struct wc_output* output,
-		struct wlr_surface* surface, double ox, double oy,
-		double width, double height) {
+		struct wlr_surface* surface, int ox, int oy,
+		int width, int height) {
 	struct wc_surface_damage_data damage_data = {
 		.output = output,
 		.ox = ox,
@@ -109,7 +103,7 @@ static void scissor_output(struct wlr_output* wlr_output,
 static void wc_render_surface(struct wlr_surface* surface,
 		pixman_region32_t* damage, struct wlr_output* output,
 		struct wlr_renderer* renderer, struct timespec* when,
-		int sx, int sy, double ox, double oy) {
+		int sx, int sy, int ox, int oy) {
 	struct wlr_texture* texture = wlr_surface_get_texture(surface);
 	if (texture == NULL) {
 		return;

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -61,8 +61,8 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 	}
 }
 
-void output_damage_surface(struct wc_output* output, struct wlr_surface* surface,
-		double ox, double oy) {
+void wc_output_damage_surface(struct wc_output* output,
+		struct wlr_surface* surface, double ox, double oy) {
 	struct wc_surface_damage_data damage_data = {
 		.output = output,
 		.ox = ox,
@@ -146,7 +146,7 @@ static void wc_render_view(struct wlr_surface* surface,
 	ox += view->x + sx, oy += view->y + sy;
 
 	wc_render_surface(surface, damage, output, rdata->renderer,
-			rdata->when, sx, sy, view->x, view->y);
+			rdata->when, sx, sy, ox, oy);
 }
 
 static void wc_render_layer(struct wlr_surface* surface,

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -124,7 +124,8 @@ static void wc_render_view(struct wlr_surface* surface,
 	double ox = 0, oy = 0;
 	wlr_output_layout_output_coords(
 			view->server->output_layout, output, &ox, &oy);
-	ox += view->x + sx, oy += view->y + sy;
+	ox += view->geo.x + sx;
+	oy += view->geo.y + sy;
 
 	wc_render_surface(surface, damage, output, rdata->renderer,
 			rdata->when, sx, sy, ox, oy);

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -59,6 +59,7 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 		wlr_log(WLR_DEBUG, "New damage whole => x: %d, y: %d, width: %d, height: %d",
 				surface_area.x, surface_area.y, surface_area.width, surface_area.height);
 	}
+	wlr_output_schedule_frame(output->output);
 }
 
 void wc_output_damage_surface(struct wc_output* output,

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -41,18 +41,26 @@ struct wc_layer_render_data {
 struct wc_surface_damage_data {
 	struct wc_output* output;
 	double ox, oy;
-
+	double width, height;
 };
 
 static void damage_surface_iterator(struct wlr_surface* surface,
 		int sx, int sy, void* data_) {
 	struct wc_surface_damage_data* data = data_;
 	struct wc_output* output = data->output;
+	double width = data->width;
+	double height = data->height;
+	if (width == 0) {
+		width = surface->current.width;
+	}
+	if (height == 0) {
+		height = surface->current.height;
+	}
 	struct wlr_box surface_area = {
 		.x = data->ox + sx,
 		.y = data->oy + sy,
-		.width = surface->current.width,
-		.height = surface->current.height
+		.width = width,
+		.height = height
 	};
 	wlr_output_damage_add_box(output->damage, &surface_area);
 	if (WC_DEBUG) {
@@ -63,11 +71,14 @@ static void damage_surface_iterator(struct wlr_surface* surface,
 }
 
 void wc_output_damage_surface(struct wc_output* output,
-		struct wlr_surface* surface, double ox, double oy) {
+		struct wlr_surface* surface, double ox, double oy,
+		double width, double height) {
 	struct wc_surface_damage_data damage_data = {
 		.output = output,
 		.ox = ox,
-		.oy = oy
+		.oy = oy,
+		.width = width,
+		.height = height
 	};
 	wlr_surface_for_each_surface(surface, damage_surface_iterator, &damage_data);
 }

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -31,7 +31,7 @@ void wc_init_output(struct wc_server* server);
 struct wc_output* wc_get_active_output(struct wc_server* server);
 
 /// Damages the entire surface which is at the given output coordinates.
-void output_damage_surface(struct wc_output* output, struct wlr_surface* surface,
-		double ox, double oy);
+void wc_output_damage_surface(struct wc_output* output,
+		struct wlr_surface* surface, double ox, double oy);
 
 #endif // WC_OUTPUT_H

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -3,6 +3,8 @@
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_output_damage.h>
 
 #include "server.h"
 
@@ -11,6 +13,7 @@ struct wc_output {
 	struct wc_server* server;
 
 	struct wlr_output* output;
+	struct wlr_output_damage* damage;
 
 	struct wlr_box usable_area;
 	struct wl_list layers[4];
@@ -26,5 +29,9 @@ void wc_init_output(struct wc_server* server);
 // If there are no outputs, NULL is returned. If there has been no activity,
 // the first output in the list is returned.
 struct wc_output* wc_get_active_output(struct wc_server* server);
+
+/// Damages the entire surface which is at the given output coordinates.
+void output_damage_surface(struct wc_output* output, struct wlr_surface* surface,
+		double ox, double oy);
 
 #endif // WC_OUTPUT_H

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -32,7 +32,7 @@ struct wc_output* wc_get_active_output(struct wc_server* server);
 
 /// Damages the entire surface which is at the given output coordinates.
 void wc_output_damage_surface(struct wc_output* output,
-		struct wlr_surface* surface, double ox, double oy,
-		double width, double height);
+		struct wlr_surface* surface, int ox, int oy,
+		int width, int height);
 
 #endif // WC_OUTPUT_H

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -30,9 +30,12 @@ void wc_init_output(struct wc_server* server);
 // the first output in the list is returned.
 struct wc_output* wc_get_active_output(struct wc_server* server);
 
-/// Damages the entire surface which is at the given output coordinates.
+/// Damages the surface which is at the given output coordinates.
+///
+/// If surface_damage is NULL the entire surface is damaged using the
+/// geometry provided in surface_output_geo.
 void wc_output_damage_surface(struct wc_output* output,
-		struct wlr_surface* surface, int ox, int oy,
-		int width, int height);
+		struct wlr_surface* surface, pixman_region32_t* surface_damage,
+		struct wlr_box surface_output_geo);
 
 #endif // WC_OUTPUT_H

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -32,6 +32,7 @@ struct wc_output* wc_get_active_output(struct wc_server* server);
 
 /// Damages the entire surface which is at the given output coordinates.
 void wc_output_damage_surface(struct wc_output* output,
-		struct wlr_surface* surface, double ox, double oy);
+		struct wlr_surface* surface, double ox, double oy,
+		double width, double height);
 
 #endif // WC_OUTPUT_H

--- a/compositor/server.c
+++ b/compositor/server.c
@@ -39,8 +39,6 @@ bool init_server(struct wc_server* server) {
 
 	server->screencopy_manager = wlr_screencopy_manager_v1_create(server->wl_display);
 
-	server->cursor_mode = WC_CURSOR_PASSTHROUGH;
-
 	wc_init_seat(server);
 	wc_init_output(server);
 	wc_init_inputs(server);

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -13,6 +13,8 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
+int WC_DEBUG;
+
 enum wc_cursor_mode {
 	WC_CURSOR_PASSTHROUGH,
 	WC_CURSOR_MOVE,

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -15,12 +15,6 @@
 
 int WC_DEBUG;
 
-enum wc_cursor_mode {
-	WC_CURSOR_PASSTHROUGH,
-	WC_CURSOR_MOVE,
-	WC_CURSOR_RESIZE,
-};
-
 struct wc_server {
 	const char* wayland_socket;
 	struct wl_display* wl_display;
@@ -29,11 +23,6 @@ struct wc_server {
 
 	struct wlr_xcursor_manager* xcursor_mgr;
 	struct wc_cursor *cursor;
-	enum wc_cursor_mode cursor_mode;
-	struct wc_view* grabbed_view;
-	double grab_x, grab_y;
-    int grab_width, grab_height;
-	uint32_t resize_edges;
 
 	struct wc_seat* seat;
 

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -12,6 +12,40 @@
 #include "server.h"
 #include "xdg.h"
 
+
+struct wc_output* wc_view_get_output(struct wlr_output_layout* layout,
+		struct wc_view* view) {
+	int width, height, x, y;
+	struct wlr_output* output = NULL;
+	switch (view->surface_type) {
+	case WC_XDG:
+		x = view->xdg_surface->geometry.x;
+		y = view->xdg_surface->geometry.y;
+		height = view->xdg_surface->geometry.height;
+		width = view->xdg_surface->geometry.width;
+	}
+	// top left
+	output = wlr_output_layout_output_at(layout, x, y);
+	if (output == NULL) {
+		// bottom right
+		output = wlr_output_layout_output_at(layout, x + width, y);
+	}
+	if (output == NULL) {
+		// top right
+		output = wlr_output_layout_output_at(layout, x + width, y + height);
+	}
+	if (output == NULL) {
+		// bottom left
+		output = wlr_output_layout_output_at(layout, x, y + height);
+	}
+	if (output == NULL) {
+		// center
+		output = wlr_output_layout_output_at(layout,
+				x + (width / 2), y + (height / 2));
+	}
+	return output ? output->data : NULL;
+}
+
 struct wlr_surface* wc_view_surface(struct wc_view* view) {
 	switch (view->surface_type) {
 	case WC_XDG:

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -5,7 +5,9 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/util/log.h>
+#include <wlr/types/wlr_output_damage.h>
 
+#include "output.h"
 #include "cursor.h"
 #include "layer_shell.h"
 #include "seat.h"
@@ -59,6 +61,19 @@ static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
 		break;
 	}
 	return *out_surface != NULL;
+}
+
+void wc_view_damage_whole(struct wc_view* view) {
+	struct wlr_output* outputs[4] = { 0 };
+	wc_view_get_outputs(view->server->output_layout, view, outputs);
+
+	for (int i = 0; i < 4; i++) {
+		struct wlr_output* output = outputs[i];
+		if (output) {
+			wc_output_damage_surface(output->data, view->xdg_surface->surface,
+					view->x - output->lx, view->y - output->ly);
+		}
+	}
 }
 
 struct wc_view* wc_view_at(struct wc_server* server, double lx, double ly,

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -71,7 +71,8 @@ void wc_view_damage_whole(struct wc_view* view) {
 		struct wlr_output* output = outputs[i];
 		if (output) {
 			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly, view->width, view->height);
+					view->x - output->lx, view->y - output->ly,
+					view->width + 100, view->height);
 		}
 	}
 }

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -15,6 +15,20 @@
 #include "xdg.h"
 
 
+static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
+		double* out_sx, double* out_sy, struct wlr_surface** out_surface) {
+	double view_sx = lx - view->x;
+	double view_sy = ly - view->y;
+
+	switch (view->surface_type) {
+	case WC_XDG:
+		*out_surface = wlr_xdg_surface_surface_at(
+				view->xdg_surface, view_sx, view_sy, out_sx, out_sy);
+		break;
+	}
+	return *out_surface != NULL;
+}
+
 void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 		struct wlr_output** out_outputs) {
 	int width, height, x, y;
@@ -31,13 +45,13 @@ void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 		wlr_output_layout_output_at(layout, x, y);
 	// top right
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x + width, y + height);
+		wlr_output_layout_output_at(layout, x + width, y);
 	// bottom left
 	out_outputs[next_index++] =
 		wlr_output_layout_output_at(layout, x, y + height);
 	// bottom right
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x + width, y);
+		wlr_output_layout_output_at(layout, x + width, y + height);
 }
 
 struct wlr_surface* wc_view_surface(struct wc_view* view) {
@@ -49,19 +63,6 @@ struct wlr_surface* wc_view_surface(struct wc_view* view) {
 	}
 }
 
-static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
-		double* out_sx, double* out_sy, struct wlr_surface** out_surface) {
-	double view_sx = lx - view->x;
-	double view_sy = ly - view->y;
-
-	switch (view->surface_type) {
-	case WC_XDG:
-		*out_surface = wlr_xdg_surface_surface_at(
-				view->xdg_surface, view_sx, view_sy, out_sx, out_sy);
-		break;
-	}
-	return *out_surface != NULL;
-}
 
 void wc_view_damage_whole(struct wc_view* view) {
 	struct wlr_output* outputs[4] = { 0 };

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -22,8 +22,8 @@ void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 	case WC_XDG:
 		x = view->x;
 		y = view->y;
-		height = view->xdg_surface->geometry.height;
-		width = view->xdg_surface->geometry.width;
+		height = view->height;
+		width = view->width;
 	}
 	int next_index = 0;
 	// top left

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -69,19 +69,43 @@ struct wlr_surface* wc_view_surface(struct wc_view* view) {
 	}
 }
 
-
-void wc_view_damage_whole(struct wc_view* view) {
-	struct wlr_output* outputs[4] = { 0 };
+void wc_view_damage(struct wc_view* view, pixman_region32_t* damage) {
+	struct wlr_output* outputs[4] = {0};
 	wc_view_get_outputs(view->server->output_layout, view, outputs);
 
-	for (int i = 0; i < 4; i++) {
+	// Keep a copy of the damage because otherwise it gets screwed up
+	// in the presence of multiple outputs.
+	pixman_region32_t damage_copy;
+	pixman_region32_init(&damage_copy);
+	if (damage != NULL) {
+		pixman_region32_copy(&damage_copy, damage);
+	}
+
+	for (size_t i = 0; i < 4; i++) {
 		struct wlr_output* output = outputs[i];
 		if (output) {
-			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->geo.x - output->lx, view->geo.y - output->ly,
-					view->geo.width, view->geo.height);
+			struct wlr_box view_output_geo = {
+				.x = view->geo.x - output->lx,
+				.y = view->geo.y - output->ly,
+				.width = view->geo.width,
+				.height = view->geo.height
+			};
+			if (damage != NULL) {
+				pixman_region32_translate(damage, view_output_geo.x, view_output_geo.y);
+				wc_output_damage_surface(output->data, view->xdg_surface->surface,
+						damage, view_output_geo);
+				pixman_region32_copy(damage, &damage_copy);
+			} else {
+				wc_output_damage_surface(output->data, view->xdg_surface->surface,
+						damage, view_output_geo);
+			}
 		}
 	}
+	pixman_region32_fini(&damage_copy);
+}
+
+void wc_view_damage_whole(struct wc_view* view) {
+	wc_view_damage(view, NULL);
 }
 
 struct wc_view* wc_view_at(struct wc_server* server, double lx, double ly,

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -17,8 +17,8 @@
 
 static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
 		double* out_sx, double* out_sy, struct wlr_surface** out_surface) {
-	double view_sx = lx - view->x;
-	double view_sy = ly - view->y;
+	int view_sx = lx - view->geo.x;
+	int view_sy = ly - view->geo.y;
 
 	switch (view->surface_type) {
 	case WC_XDG:
@@ -31,27 +31,24 @@ static bool wc_is_view_at(struct wc_view* view, double lx, double ly,
 
 void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 		struct wlr_output** out_outputs) {
-	int width, height, x, y;
+	struct wlr_box geo = {0};
 	switch (view->surface_type) {
 	case WC_XDG:
-		x = view->x;
-		y = view->y;
-		height = view->height;
-		width = view->width;
+		memcpy(&geo, &view->geo, sizeof(struct wlr_box));
 	}
 	int next_index = 0;
 	// top left
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x, y);
+		wlr_output_layout_output_at(layout, geo.x, geo.y);
 	// top right
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x + width, y);
+		wlr_output_layout_output_at(layout, geo.x + geo.width, geo.y);
 	// bottom left
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x, y + height);
+		wlr_output_layout_output_at(layout, geo.x, geo.y + geo.height);
 	// bottom right
 	out_outputs[next_index++] =
-		wlr_output_layout_output_at(layout, x + width, y + height);
+		wlr_output_layout_output_at(layout, geo.x + geo.width, geo.y + geo.height);
 }
 
 struct wlr_surface* wc_view_surface(struct wc_view* view) {
@@ -72,8 +69,8 @@ void wc_view_damage_whole(struct wc_view* view) {
 		struct wlr_output* output = outputs[i];
 		if (output) {
 			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly,
-					view->width, view->height);
+					view->geo.x - output->lx, view->geo.y - output->ly,
+					view->geo.width, view->geo.height);
 		}
 	}
 }

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -71,7 +71,7 @@ void wc_view_damage_whole(struct wc_view* view) {
 		struct wlr_output* output = outputs[i];
 		if (output) {
 			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly);
+					view->x - output->lx, view->y - output->ly, view->width, view->height);
 		}
 	}
 }

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -36,7 +36,8 @@ void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 	case WC_XDG:
 		memcpy(&geo, &view->geo, sizeof(struct wlr_box));
 	}
-	int next_index = 0;
+
+	size_t next_index = 0;
 	// top left
 	out_outputs[next_index++] =
 		wlr_output_layout_output_at(layout, geo.x, geo.y);
@@ -49,6 +50,14 @@ void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 	// bottom right
 	out_outputs[next_index++] =
 		wlr_output_layout_output_at(layout, geo.x + geo.width, geo.y + geo.height);
+
+	for (size_t i = 1; i < 4; i++) {
+		for (size_t j = 0; j < i; j++) {
+			if (out_outputs[i] == out_outputs[j]) {
+				out_outputs[i] = NULL;
+			}
+		}
+	}
 }
 
 struct wlr_surface* wc_view_surface(struct wc_view* view) {

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -13,37 +13,29 @@
 #include "xdg.h"
 
 
-struct wc_output* wc_view_get_output(struct wlr_output_layout* layout,
-		struct wc_view* view) {
+void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
+		struct wlr_output** out_outputs) {
 	int width, height, x, y;
-	struct wlr_output* output = NULL;
 	switch (view->surface_type) {
 	case WC_XDG:
-		x = view->xdg_surface->geometry.x;
-		y = view->xdg_surface->geometry.y;
+		x = view->x;
+		y = view->y;
 		height = view->xdg_surface->geometry.height;
 		width = view->xdg_surface->geometry.width;
 	}
+	int next_index = 0;
 	// top left
-	output = wlr_output_layout_output_at(layout, x, y);
-	if (output == NULL) {
-		// bottom right
-		output = wlr_output_layout_output_at(layout, x + width, y);
-	}
-	if (output == NULL) {
-		// top right
-		output = wlr_output_layout_output_at(layout, x + width, y + height);
-	}
-	if (output == NULL) {
-		// bottom left
-		output = wlr_output_layout_output_at(layout, x, y + height);
-	}
-	if (output == NULL) {
-		// center
-		output = wlr_output_layout_output_at(layout,
-				x + (width / 2), y + (height / 2));
-	}
-	return output ? output->data : NULL;
+	out_outputs[next_index++] =
+		wlr_output_layout_output_at(layout, x, y);
+	// top right
+	out_outputs[next_index++] =
+		wlr_output_layout_output_at(layout, x + width, y + height);
+	// bottom left
+	out_outputs[next_index++] =
+		wlr_output_layout_output_at(layout, x, y + height);
+	// bottom right
+	out_outputs[next_index++] =
+		wlr_output_layout_output_at(layout, x + width, y);
 }
 
 struct wlr_surface* wc_view_surface(struct wc_view* view) {

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -72,7 +72,7 @@ void wc_view_damage_whole(struct wc_view* view) {
 		if (output) {
 			wc_output_damage_surface(output->data, view->xdg_surface->surface,
 					view->x - output->lx, view->y - output->ly,
-					view->width + 100, view->height);
+					view->width, view->height);
 		}
 	}
 }

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -29,6 +29,7 @@ struct wc_view {
 
 	struct wl_listener map;
 	struct wl_listener unmap;
+	struct wl_listener commit;
 	struct wl_listener destroy;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
@@ -51,5 +52,11 @@ struct wc_view* wc_view_at(struct wc_server* server, double lx, double ly,
 
 // Focuses on a view. Automatically un-focuses the previous view.
 void wc_focus_view(struct wc_view* view);
+
+// Get the output that the view is on.
+//
+// NULL could be returned if none of the corners or center is on an output.
+struct wc_output* wc_view_get_output(struct wlr_output_layout* layout,
+		struct wc_view* view);
 
 #endif//WC_VIEW_H

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -46,6 +46,9 @@ struct wc_view {
 
 void wc_init_views(struct wc_server* server);
 
+/// Damage the whole view, based on its current geometry.
+void wc_view_damage_whole(struct wc_view* view);
+
 // Get the main surface associated with the view.
 struct wlr_surface* wc_view_surface(struct wc_view* view);
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -24,17 +24,22 @@ struct wc_view {
 	};
 
 	bool mapped;
+
+	// Current coordinates of the view.
 	int x, y;
+	// NOTE These may not reflect what the client currently thinks, but
+	// this is only temporary - when you change these you _must_ notify the
+	// client of its new size.
 	int width, height;
 
+	// Serial for a pending move / resize.
 	uint32_t pending_serial;
 	struct {
 		int x, y;
+		// NOTE Do not use the width and height for damage calculation,
+		// use the surface's wlr_surface.current field.
 		int width, height;
 	} pending_geometry;
-
-	// These variables are layer surface specific
-	struct wlr_box wc_layer_geo;
 
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -52,6 +52,9 @@ struct wc_view {
 
 void wc_init_views(struct wc_server* server);
 
+/// Add the calculated damage to all the surfaces that make up this view.
+void wc_view_damage(struct wc_view* view, pixman_region32_t* damage);
+
 /// Damage the whole view, based on its current geometry.
 void wc_view_damage_whole(struct wc_view* view);
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -23,6 +23,13 @@ struct wc_view {
 
 	bool mapped;
 	int x, y;
+	int width, height;
+
+	bool is_pending_geometry;
+	struct {
+		double x, y;
+		int width, height;
+	} pending_geometry;
 
 	// These variables are layer surface specific
 	struct wlr_box wc_layer_geo;
@@ -53,10 +60,13 @@ struct wc_view* wc_view_at(struct wc_server* server, double lx, double ly,
 // Focuses on a view. Automatically un-focuses the previous view.
 void wc_focus_view(struct wc_view* view);
 
-// Get the output that the view is on.
+// Get the outputs that the view is on.
 //
-// NULL could be returned if none of the corners or center is on an output.
-struct wc_output* wc_view_get_output(struct wlr_output_layout* layout,
-		struct wc_view* view);
+// There can be up to four (one for each corner), so the out_outputs should be
+// an array of at least 4 (it will zero out the first four).
+//
+// The order is as follows (with holes being null): top left, top right, bottom left, bottom right
+void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
+		struct wlr_output* out_outputs[4]);
 
 #endif//WC_VIEW_H

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -76,6 +76,8 @@ void wc_focus_view(struct wc_view* view);
 // an array of at least 4 (it will zero out the first four).
 //
 // The order is as follows (with holes being null): top left, top right, bottom left, bottom right
+//
+// Each output is guaranteed to be unique in the array.
 void wc_view_get_outputs(struct wlr_output_layout* layout, struct wc_view* view,
 		struct wlr_output* out_outputs[4]);
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -29,7 +29,7 @@ struct wc_view {
 
 	uint32_t pending_serial;
 	struct {
-		double x, y;
+		int x, y;
 		int width, height;
 	} pending_geometry;
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -25,21 +25,21 @@ struct wc_view {
 
 	bool mapped;
 
-	// Current coordinates of the view.
-	int x, y;
-	// NOTE These may not reflect what the client currently thinks, but
-	// this is only temporary - when you change these you _must_ notify the
-	// client of its new size.
-	int width, height;
+	/* Current coordinates of the view.
+	 *
+	 * NOTE The width and height may not reflect what the client currently
+	 * thinks, but
+	 * this is only temporary - when you change these you _must_ notify the
+	 * client of its new size.
+	 */
+	struct wlr_box geo;
 
 	// Serial for a pending move / resize.
 	uint32_t pending_serial;
-	struct {
-		int x, y;
-		// NOTE Do not use the width and height for damage calculation,
-		// use the surface's wlr_surface.current field.
-		int width, height;
-	} pending_geometry;
+	/* NOTE Do not use the width and height for damage calculation,
+	 * use the surface's wlr_surface.current field.
+	 */
+	struct wlr_box pending_geometry;
 
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -1,6 +1,8 @@
 #ifndef WC_VIEW_H
 #define WC_VIEW_H
 
+#include <stdint.h>
+
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
@@ -25,7 +27,7 @@ struct wc_view {
 	int x, y;
 	int width, height;
 
-	bool is_pending_geometry;
+	uint32_t pending_serial;
 	struct {
 		double x, y;
 		int width, height;

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -36,6 +36,7 @@ struct wc_view {
 
 	// Serial for a pending move / resize.
 	uint32_t pending_serial;
+	bool is_pending_serial;
 	/* NOTE Do not use the width and height for damage calculation,
 	 * use the surface's wlr_surface.current field.
 	 */

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -50,16 +50,14 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 	struct wlr_box size = {0};
 	wlr_xdg_surface_get_geometry(surface, &size);
 
+	view->width = size.width;
+	view->height = size.height;
+
+	wc_view_damage_whole(view);
+
 	uint32_t pending_serial =
 		view->pending_serial;
-	if (pending_serial != 0 && pending_serial >= surface->configure_serial) {
-		if (view->pending_geometry.width != view->width) {
-			view->width = view->pending_geometry.width;
-		}
-		if (view->pending_geometry.height != view->height) {
-			view->height = view->pending_geometry.height;
-		}
-		wc_view_damage_whole(view);
+	if (pending_serial > 0 && pending_serial >= surface->configure_serial) {
 		if (view->pending_geometry.x != view->x) {
 			view->x = view->pending_geometry.x +
 				view->pending_geometry.width - size.width;
@@ -68,11 +66,12 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 			view->y = view->pending_geometry.y +
 				view->pending_geometry.height - size.height;
 		}
+
+		wc_view_damage_whole(view);
+
 		if (pending_serial == surface->configure_serial) {
 			view->pending_serial = 0;
 		}
-
-		wc_view_damage_whole(view);
 	}
 }
 

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -83,43 +83,50 @@ static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {
 static void wc_xdg_toplevel_request_move(struct wl_listener* listener, void* data) {
 	struct wc_view* view = wl_container_of(listener, view, request_move);
 	struct wc_server* server = view->server;
-	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
+	struct wc_cursor* cursor = server->cursor;
+	struct wlr_cursor* wlr_cursor = cursor->wlr_cursor;
 	struct wlr_surface* focused_surface =
 		server->seat->seat->pointer_state.focused_surface;
 	struct wlr_surface* surface = wc_view_surface(view);
+
 	if (surface != focused_surface) {
 		return;
 	}
-	server->grabbed_view = view;
-	server->cursor_mode = WC_CURSOR_MOVE;
 	struct wlr_box geo_box;
 	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
-	server->grab_x = wlr_cursor->x - view->x;
-	server->grab_y = wlr_cursor->y - view->y;
-	server->grab_width = geo_box.width;
-	server->grab_height = geo_box.height;
+
+	cursor->cursor_mode = WC_CURSOR_MOVE;
+	cursor->grabbed.view = view;
+	cursor->grabbed.original_x = wlr_cursor->x - view->x;
+	cursor->grabbed.original_y = wlr_cursor->y - view->y;
+	cursor->grabbed.original_width = geo_box.width;
+	cursor->grabbed.original_height = geo_box.height;
 }
 
 static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* data) {
 	struct wc_view* view = wl_container_of(listener, view, request_resize);
 	struct wlr_xdg_toplevel_resize_event *event = data;
 	struct wc_server* server = view->server;
-	struct wlr_cursor* wlr_cursor = server->cursor->wlr_cursor;
+	struct wc_cursor* cursor = server->cursor;
+	struct wlr_cursor* wlr_cursor = cursor->wlr_cursor;
 	struct wlr_surface* focused_surface =
 		server->seat->seat->pointer_state.focused_surface;
 	struct wlr_surface* surface = wc_view_surface(view);
+
 	if (surface != focused_surface) {
 		return;
 	}
-	server->grabbed_view = view;
-	server->cursor_mode = WC_CURSOR_RESIZE;
+
 	struct wlr_box geo_box;
 	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
-	server->grab_x = wlr_cursor->x + geo_box.x;
-	server->grab_y = wlr_cursor->y + geo_box.y;
-	server->grab_width = geo_box.width;
-	server->grab_height = geo_box.height;
-	server->resize_edges = event->edges;
+
+	cursor->cursor_mode = WC_CURSOR_RESIZE;
+	cursor->grabbed.view = view;
+	cursor->grabbed.original_x = wlr_cursor->x;
+	cursor->grabbed.original_y = wlr_cursor->y;
+	cursor->grabbed.original_width = geo_box.width;
+	cursor->grabbed.original_height = geo_box.height;
+	cursor->grabbed.resize_edges = event->edges;
 }
 
 static void wc_xdg_new_surface(struct wl_listener* listener, void* data) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -60,7 +60,9 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 			view->y = view->pending_geometry.y +
 				view->pending_geometry.height - size.height;
 		}
-		view->pending_serial = 0;
+		if (pending_serial == surface->configure_serial) {
+			view->pending_serial = 0;
+		}
 	}
 
 	wc_view_damage_whole(view);

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -63,9 +63,9 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 		if (pending_serial == surface->configure_serial) {
 			view->pending_serial = 0;
 		}
-	}
 
-	wc_view_damage_whole(view);
+		wc_view_damage_whole(view);
+	}
 }
 
 static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -50,8 +50,8 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 	struct wlr_box size = {0};
 	wlr_xdg_surface_get_geometry(surface, &size);
 
-	view->width = size.width;
-	view->height = size.height;
+	view->width = surface->surface->current.width;
+	view->height = surface->surface->current.height;
 
 	wc_view_damage_whole(view);
 

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -1,6 +1,7 @@
 #include "xdg.h"
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_xdg_shell.h>
@@ -70,8 +71,10 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 		}
 	}
 
-	if (view->is_pending_geometry) {
-		view->is_pending_geometry = false;
+	struct wlr_xdg_surface* surface = view->xdg_surface;
+	uint32_t pending_serial =
+		view->pending_serial;
+	if (pending_serial != 0 && pending_serial >+ surface->configure_serial) {
 		if (view->pending_geometry.x != view->x) {
 			view->x = view->pending_geometry.x;
 		}
@@ -84,6 +87,7 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 		if (view->pending_geometry.height != view->height) {
 			view->height = view->pending_geometry.height;
 		}
+		view->pending_serial = 0;
 	}
 
 	wc_view_get_outputs(view->server->output_layout, view, outputs);

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -52,54 +52,36 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 		return;
 	}
 
-	struct wlr_output* outputs[4] = { 0 };
-	wc_view_get_outputs(view->server->output_layout, view, outputs);
-
-	for (int i = 0; i < 4; i++) {
-		struct wlr_output* output = outputs[i];
-		if (output) {
-			struct wlr_box surface_area = {
-				.x = view->x - output->lx,
-				.y = view->y - output->ly,
-				.width = view->width,
-				.height = view->height
-			};
-			wlr_log(WLR_DEBUG, "DAMAGING (%d, %d : %d, %d)",
-					surface_area.x, surface_area.y, surface_area.width, surface_area.height);
-			struct wc_output* wc_output = output->data;
-			wlr_output_damage_add_box(wc_output->damage, &surface_area);
-		}
-	}
+	// TODO Only damage what's changed from the surface,
+	// then move this down into the pending if block below
+	wc_view_damage_whole(view);
 
 	struct wlr_xdg_surface* surface = view->xdg_surface;
+	struct wlr_box size = {0};
+	wlr_xdg_surface_get_geometry(surface, &size);
+
 	uint32_t pending_serial =
 		view->pending_serial;
-	if (pending_serial != 0 && pending_serial >+ surface->configure_serial) {
-		if (view->pending_geometry.x != view->x) {
-			view->x = view->pending_geometry.x;
-		}
-		if (view->pending_geometry.y != view->y) {
-			view->y = view->pending_geometry.y;
-		}
+	if (pending_serial != 0 && pending_serial >= surface->configure_serial) {
 		if (view->pending_geometry.width != view->width) {
 			view->width = view->pending_geometry.width;
 		}
 		if (view->pending_geometry.height != view->height) {
 			view->height = view->pending_geometry.height;
 		}
+		wc_view_damage_whole(view);
+		if (view->pending_geometry.x != view->x) {
+			view->x = view->pending_geometry.x +
+				view->pending_geometry.width - size.width;
+		}
+		if (view->pending_geometry.y != view->y) {
+			view->y = view->pending_geometry.y +
+				view->pending_geometry.height - size.height;
+		}
 		view->pending_serial = 0;
 	}
 
-	wc_view_get_outputs(view->server->output_layout, view, outputs);
-	// TODO Damage only what has changed
-	for (int i = 0; i < 4; i++) {
-		struct wlr_output* output = outputs[i];
-		if (output) {
-			wc_output_damage_surface(
-					output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly);
-		}
-	}
+	wc_view_damage_whole(view);
 }
 
 static void wc_xdg_surface_destroy(struct wl_listener* listener, void* data) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -18,32 +18,14 @@ static void wc_xdg_surface_map(struct wl_listener* listener, void* data) {
 	view->mapped = true;
 	wc_focus_view(view);
 
-	struct wlr_output* outputs[4] = { 0 };
-	wc_view_get_outputs(view->server->output_layout, view, outputs);
-
-	for (int i = 0; i < 4; i++) {
-		struct wlr_output* output = outputs[i];
-		if (output) {
-			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly);
-		}
-	}
+	wc_view_damage_whole(view);
 }
 
 static void wc_xdg_surface_unmap(struct wl_listener* listener, void* data) {
 	struct wc_view* view = wl_container_of(listener, view, unmap);
 	view->mapped = false;
 
-	struct wlr_output* outputs[4] = { 0 };
-	wc_view_get_outputs(view->server->output_layout, view, outputs);
-
-	for (int i = 0; i < 4; i++) {
-		struct wlr_output* output = outputs[i];
-		if (output) {
-			wc_output_damage_surface(output->data, view->xdg_surface->surface,
-					view->x - output->lx, view->y - output->ly);
-		}
-	}
+	wc_view_damage_whole(view);
 }
 
 static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -99,8 +99,10 @@ static void wc_xdg_toplevel_request_move(struct wl_listener* listener, void* dat
 	cursor->grabbed.view = view;
 	cursor->grabbed.original_x = wlr_cursor->x - view->x;
 	cursor->grabbed.original_y = wlr_cursor->y - view->y;
-	cursor->grabbed.original_width = geo_box.width;
-	cursor->grabbed.original_height = geo_box.height;
+	cursor->grabbed.original_view_x = view->x;
+	cursor->grabbed.original_view_y = view->y;
+	cursor->grabbed.original_view_width = geo_box.width;
+	cursor->grabbed.original_view_height = geo_box.height;
 }
 
 static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* data) {
@@ -124,8 +126,10 @@ static void wc_xdg_toplevel_request_resize(struct wl_listener* listener, void* d
 	cursor->grabbed.view = view;
 	cursor->grabbed.original_x = wlr_cursor->x;
 	cursor->grabbed.original_y = wlr_cursor->y;
-	cursor->grabbed.original_width = geo_box.width;
-	cursor->grabbed.original_height = geo_box.height;
+	cursor->grabbed.original_view_x = view->x;
+	cursor->grabbed.original_view_y = view->y;
+	cursor->grabbed.original_view_width = geo_box.width;
+	cursor->grabbed.original_view_height = geo_box.height;
 	cursor->grabbed.resize_edges = event->edges;
 }
 

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -18,6 +18,14 @@ static void wc_xdg_surface_map(struct wl_listener* listener, void* data) {
 	view->mapped = true;
 	wc_focus_view(view);
 
+	struct wlr_xdg_surface* surface = view->xdg_surface;
+	struct wlr_box box = {0};
+	wlr_xdg_surface_get_geometry(surface, &box);
+	view->x = box.x;
+	view->y = box.y;
+	view->width = box.width;
+	view->height = box.height;
+
 	wc_view_damage_whole(view);
 }
 

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -68,6 +68,7 @@ static void wc_xdg_surface_commit(struct wl_listener* listener, void* data) {
 
 		if (pending_serial == surface->configure_serial) {
 			view->pending_serial = 0;
+			view->is_pending_serial = false;
 		}
 	}
 }


### PR DESCRIPTION
Adds damage tracking for layer shell and xdg shell. This means that when a client changes only that part of the screen will update - not the entire screen.

# TODO
- [x] Ensure there is still no xdg shell artifacts from basic testing - resizing, moving around, resizing across outputs, resizing within a nested x11/wayland instance.
- [x] Ensure there is still no layer shell artifacts from resizing clients.
- [x] Do not damage the entire surface on each commit only damage what the client has changed.
- [x] Cleanup git history