### PR TITLE
Xwayland support

### DIFF
--- a/compositor/layer_shell.c
+++ b/compositor/layer_shell.c
@@ -99,7 +99,9 @@ static void wc_arrange_layer(struct wc_output *output, struct wc_seat *seat,
 			bounds = full_area;
 		}
 		struct wlr_box arranged_area = {
-				.width = state->desired_width, .height = state->desired_height};
+				.width = state->desired_width,
+				.height = state->desired_height,
+		};
 
 		// horizontal axis
 		if ((state->anchor & LAYER_BOTH_HORIZ) && arranged_area.width == 0) {

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -50,6 +50,7 @@ way_cooler_sources = files(
 	'server.c',
 	'view.c',
 	'xdg.c',
+	'xwayland.c',
 )
 
 executable(

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -357,9 +357,11 @@ struct wc_output *wc_get_active_output(struct wc_server *server) {
 void wc_output_damage_surface(struct wc_output *output,
 		struct wlr_surface *surface, pixman_region32_t *surface_damage,
 		struct wlr_box surface_output_geo) {
-	struct wc_surface_damage_data damage_data = {.output = output,
+	struct wc_surface_damage_data damage_data = {
+			.output = output,
 			.surface_output_geo = surface_output_geo,
-			.surface_damage = surface_damage};
+			.surface_damage = surface_damage,
+	};
 	wlr_surface_for_each_surface(
 			surface, damage_surface_iterator, &damage_data);
 }

--- a/compositor/seat.c
+++ b/compositor/seat.c
@@ -4,6 +4,7 @@
 
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/xwayland.h>
 
 #include "cursor.h"
 #include "server.h"
@@ -53,6 +54,8 @@ void wc_seat_init(struct wc_server *server) {
 	wl_signal_add(
 			&seat->seat->events.request_set_cursor, &seat->request_set_cursor);
 
+	wlr_xwayland_set_seat(server->xwayland, seat->seat);
+
 	server->seat = seat;
 }
 
@@ -62,6 +65,8 @@ void wc_seat_fini(struct wc_server *server) {
 	wlr_seat_destroy(seat->seat);
 
 	wl_list_remove(&seat->request_set_cursor.link);
+
+	wlr_xwayland_set_seat(server->xwayland, NULL);
 
 	free(seat);
 	server->seat = NULL;

--- a/compositor/server.c
+++ b/compositor/server.c
@@ -21,11 +21,13 @@
 #include "output.h"
 #include "seat.h"
 #include "view.h"
+#include "xwayland.h"
 
 bool init_server(struct wc_server *server) {
 	if (server == NULL) {
 		return false;
 	}
+
 	server->wl_display = wl_display_create();
 	server->wayland_socket = wl_display_add_socket_auto(server->wl_display);
 	if (!server->wayland_socket) {
@@ -47,6 +49,7 @@ bool init_server(struct wc_server *server) {
 	server->data_device_manager =
 			wlr_data_device_manager_create(server->wl_display);
 
+	wc_xwayland_init(server);
 	wc_seat_init(server);
 	wc_output_init(server);
 	wc_inputs_init(server);
@@ -64,6 +67,7 @@ void fini_server(struct wc_server *server) {
 	wc_views_fini(server);
 	wc_layers_fini(server);
 	wc_cursor_fini(server);
+	wc_xwayland_fini(server);
 
 	wlr_screencopy_manager_v1_destroy(server->screencopy_manager);
 	wlr_data_device_manager_destroy(server->data_device_manager);

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -12,6 +12,7 @@
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/xwayland.h>
 
 int WC_DEBUG;
 
@@ -37,6 +38,10 @@ struct wc_server {
 	struct wl_listener new_output;
 
 	struct wl_list views;
+
+	struct wlr_xwayland *xwayland;
+	struct wl_listener new_xwayland_surface;
+
 	struct wlr_xdg_shell *xdg_shell;
 	struct wl_listener new_xdg_surface;
 

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -332,8 +332,7 @@ void wc_view_for_each_surface(struct wc_view *view,
 		break;
 	case WC_XWAYLAND: {
 		struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
-		iterator(xwayland_surface->surface, xwayland_surface->x,
-				xwayland_surface->y, data);
+		iterator(xwayland_surface->surface, 0, 0, data);
 		break;
 	}
 	}

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -235,6 +235,8 @@ void wc_view_commit(struct wc_view *view, struct wlr_box geo) {
 	case WC_XDG:
 		if (pending_serial > 0 &&
 				pending_serial >= view->xdg_surface->configure_serial) {
+			wc_view_damage_whole(view);
+
 			if (view->pending_geometry.x != view->geo.x) {
 				view->geo.x = view->pending_geometry.x +
 						view->pending_geometry.width - geo.width;
@@ -254,6 +256,8 @@ void wc_view_commit(struct wc_view *view, struct wlr_box geo) {
 		break;
 	case WC_XWAYLAND:
 		if (pending_serial > 0) {
+			wc_view_damage_whole(view);
+
 			if (view->pending_geometry.x != view->geo.x) {
 				view->geo.x = view->pending_geometry.x +
 						view->pending_geometry.width - geo.width;

--- a/compositor/view.c
+++ b/compositor/view.c
@@ -76,6 +76,55 @@ struct wlr_surface *wc_view_surface(struct wc_view *view) {
 	return NULL;
 }
 
+void wc_view_move(struct wc_view *view, struct wlr_box geo) {
+	struct wc_server *server = view->server;
+	struct wlr_surface *focused_surface =
+			server->seat->seat->pointer_state.focused_surface;
+	struct wlr_surface *surface = wc_view_surface(view);
+
+	if (surface != focused_surface) {
+		return;
+	}
+
+	struct wc_cursor *cursor = server->cursor;
+	struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
+
+	cursor->cursor_mode = WC_CURSOR_MOVE;
+	cursor->grabbed.view = view;
+	cursor->grabbed.original_x = wlr_cursor->x - view->geo.x;
+	cursor->grabbed.original_y = wlr_cursor->y - view->geo.y;
+
+	cursor->grabbed.original_view_geo.x = view->geo.x;
+	cursor->grabbed.original_view_geo.y = view->geo.y;
+	cursor->grabbed.original_view_geo.width = geo.width;
+	cursor->grabbed.original_view_geo.height = geo.height;
+}
+
+void wc_view_resize(struct wc_view *view, struct wlr_box geo, uint32_t edges) {
+	struct wc_server *server = view->server;
+	struct wc_cursor *cursor = server->cursor;
+	struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
+	struct wlr_surface *focused_surface =
+			server->seat->seat->pointer_state.focused_surface;
+	struct wlr_surface *surface = wc_view_surface(view);
+
+	if (surface != focused_surface) {
+		return;
+	}
+
+	cursor->cursor_mode = WC_CURSOR_RESIZE;
+	cursor->grabbed.view = view;
+	cursor->grabbed.original_x = wlr_cursor->x;
+	cursor->grabbed.original_y = wlr_cursor->y;
+
+	cursor->grabbed.original_view_geo.x = view->geo.x;
+	cursor->grabbed.original_view_geo.y = view->geo.y;
+	cursor->grabbed.original_view_geo.width = geo.width;
+	cursor->grabbed.original_view_geo.height = geo.height;
+
+	cursor->grabbed.resize_edges = edges;
+}
+
 void wc_view_update_geometry(struct wc_view *view, struct wlr_box new_geo) {
 	switch (view->surface_type) {
 	case WC_XDG:

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -66,6 +66,12 @@ void wc_view_damage(struct wc_view *view, pixman_region32_t *damage);
 // Damage the whole view, based on its current geometry.
 void wc_view_damage_whole(struct wc_view *view);
 
+/* Commits damage from the client.
+ *
+ * If the size has changed the entire view is automatically damaged.
+ */
+void wc_view_commit(struct wc_view *view, struct wlr_box geo);
+
 // Get the main surface associated with the view.
 struct wlr_surface *wc_view_surface(struct wc_view *view);
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -75,6 +75,19 @@ void wc_view_commit(struct wc_view *view, struct wlr_box geo);
 // Get the main surface associated with the view.
 struct wlr_surface *wc_view_surface(struct wc_view *view);
 
+/* Moves the view to the specified coordinates.
+ *
+ * Note that this is done by setting geometry in the cursor and so all
+ * handling is done in cursor.c
+ */
+void wc_view_move(struct wc_view *view, struct wlr_box geo);
+
+/* Resize the view to the specified location.
+ * Note this is done by setting geometry in the cursor and so all
+ * handling is done in cursor.c
+ */
+void wc_view_resize(struct wc_view *view, struct wlr_box geo, uint32_t edges);
+
 // Set the new geometry of the view to be applied when the client commits to it.
 void wc_view_update_geometry(struct wc_view *view, struct wlr_box new_geo);
 

--- a/compositor/view.h
+++ b/compositor/view.h
@@ -7,11 +7,13 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/xwayland.h>
 
 #include "server.h"
 
 enum wc_surface_type {
 	WC_XDG,
+	WC_XWAYLAND,
 };
 
 struct wc_view {
@@ -21,6 +23,7 @@ struct wc_view {
 	enum wc_surface_type surface_type;
 	union {
 		struct wlr_xdg_surface *xdg_surface;
+		struct wlr_xwayland_surface *xwayland_surface;
 	};
 
 	bool mapped;
@@ -50,6 +53,7 @@ struct wc_view {
 	struct wl_listener destroy;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
+	struct wl_listener configure;
 };
 
 void wc_views_init(struct wc_server *server);

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -60,59 +60,22 @@ void wc_xdg_surface_destroy(struct wl_listener *listener, void *data) {
 static void wc_xdg_toplevel_request_move(
 		struct wl_listener *listener, void *data) {
 	struct wc_view *view = wl_container_of(listener, view, request_move);
-	struct wc_server *server = view->server;
-	struct wc_cursor *cursor = server->cursor;
-	struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
-	struct wlr_surface *focused_surface =
-			server->seat->seat->pointer_state.focused_surface;
-	struct wlr_surface *surface = wc_view_surface(view);
 
-	if (surface != focused_surface) {
-		return;
-	}
-	struct wlr_box geo_box;
-	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
+	struct wlr_box geo;
+	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo);
 
-	cursor->cursor_mode = WC_CURSOR_MOVE;
-	cursor->grabbed.view = view;
-	cursor->grabbed.original_x = wlr_cursor->x - view->geo.x;
-	cursor->grabbed.original_y = wlr_cursor->y - view->geo.y;
-
-	cursor->grabbed.original_view_geo.x = view->geo.x;
-	cursor->grabbed.original_view_geo.y = view->geo.y;
-	cursor->grabbed.original_view_geo.width = geo_box.width;
-	cursor->grabbed.original_view_geo.height = geo_box.height;
+	wc_view_move(view, geo);
 }
 
 static void wc_xdg_toplevel_request_resize(
 		struct wl_listener *listener, void *data) {
 	struct wc_view *view = wl_container_of(listener, view, request_resize);
 	struct wlr_xdg_toplevel_resize_event *event = data;
-	struct wc_server *server = view->server;
-	struct wc_cursor *cursor = server->cursor;
-	struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
-	struct wlr_surface *focused_surface =
-			server->seat->seat->pointer_state.focused_surface;
-	struct wlr_surface *surface = wc_view_surface(view);
 
-	if (surface != focused_surface) {
-		return;
-	}
+	struct wlr_box geo;
+	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo);
 
-	struct wlr_box geo_box;
-	wlr_xdg_surface_get_geometry(view->xdg_surface, &geo_box);
-
-	cursor->cursor_mode = WC_CURSOR_RESIZE;
-	cursor->grabbed.view = view;
-	cursor->grabbed.original_x = wlr_cursor->x;
-	cursor->grabbed.original_y = wlr_cursor->y;
-
-	cursor->grabbed.original_view_geo.x = view->geo.x;
-	cursor->grabbed.original_view_geo.y = view->geo.y;
-	cursor->grabbed.original_view_geo.width = geo_box.width;
-	cursor->grabbed.original_view_geo.height = geo_box.height;
-
-	cursor->grabbed.resize_edges = event->edges;
+	wc_view_resize(view, geo, event->edges);
 }
 
 static void wc_xdg_new_surface(struct wl_listener *listener, void *data) {

--- a/compositor/xdg.c
+++ b/compositor/xdg.c
@@ -165,12 +165,13 @@ static void wc_xdg_new_surface(struct wl_listener *listener, void *data) {
 	view->surface_type = WC_XDG;
 
 	view->map.notify = wc_xdg_surface_map;
-	wl_signal_add(&xdg_surface->events.map, &view->map);
 	view->unmap.notify = wc_xdg_surface_unmap;
-	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
 	view->commit.notify = wc_xdg_surface_commit;
-	wl_signal_add(&xdg_surface->surface->events.commit, &view->commit);
 	view->destroy.notify = wc_xdg_surface_destroy;
+
+	wl_signal_add(&xdg_surface->events.map, &view->map);
+	wl_signal_add(&xdg_surface->events.unmap, &view->unmap);
+	wl_signal_add(&xdg_surface->surface->events.commit, &view->commit);
 	wl_signal_add(&xdg_surface->events.destroy, &view->destroy);
 
 	struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;

--- a/compositor/xdg.h
+++ b/compositor/xdg.h
@@ -1,5 +1,5 @@
-#ifndef XDG_H
-#define XDG_H
+#ifndef WC_XDG_H
+#define WC_XDG_H
 
 #include "server.h"
 
@@ -9,4 +9,4 @@ void wc_xdg_fini(struct wc_server *server);
 
 void wc_xdg_surface_destroy(struct wl_listener *listener, void *data);
 
-#endif  // XDG_H
+#endif  // WC_XDG_H

--- a/compositor/xwayland.c
+++ b/compositor/xwayland.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "xwayland.h"
 
 #include <stdlib.h>
@@ -144,6 +145,8 @@ void wc_xwayland_init(struct wc_server *server) {
 	server->new_xwayland_surface.notify = wc_xwayland_new_surface;
 	wl_signal_add(&server->xwayland->events.new_surface,
 			&server->new_xwayland_surface);
+
+	setenv("DISPLAY", server->xwayland->display_name, true);
 
 	if (server->xwayland == NULL) {
 		abort();

--- a/compositor/xwayland.c
+++ b/compositor/xwayland.c
@@ -37,47 +37,16 @@ static void wc_xwayland_request_configure(
 
 static void wc_xwayland_commit(struct wl_listener *listener, void *data) {
 	struct wc_view *view = wl_container_of(listener, view, commit);
-	if (!view->mapped) {
-		return;
-	}
-
 	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
-	pixman_region32_t damage;
-	pixman_region32_init(&damage);
-	wlr_surface_get_effective_damage(xwayland_surface->surface, &damage);
-	wc_view_damage(view, &damage);
 
-	struct wlr_box size = {.x = xwayland_surface->x,
+	struct wlr_box size = {
+			.x = xwayland_surface->x,
 			.y = xwayland_surface->y,
 			.width = xwayland_surface->width,
-			.height = xwayland_surface->height};
+			.height = xwayland_surface->height,
+	};
 
-	bool size_changed =
-			view->geo.width != xwayland_surface->surface->current.width ||
-			view->geo.height != xwayland_surface->surface->current.height;
-
-	if (size_changed) {
-		wc_view_damage_whole(view);
-		view->geo.width = xwayland_surface->surface->current.width;
-		view->geo.height = xwayland_surface->surface->current.height;
-		wc_view_damage_whole(view);
-	}
-
-	if (view->pending_geometry.x != view->geo.x) {
-		view->geo.x = view->pending_geometry.x + view->pending_geometry.width -
-				size.width;
-	}
-	if (view->pending_geometry.y != view->geo.y) {
-		view->geo.y = view->pending_geometry.y + view->pending_geometry.height -
-				size.height;
-	}
-
-	wc_view_damage_whole(view);
-
-	view->pending_serial = 0;
-	view->is_pending_serial = false;
-
-	pixman_region32_fini(&damage);
+	wc_view_commit(view, size);
 }
 
 static void wc_xwayland_surface_map(struct wl_listener *listener, void *data) {

--- a/compositor/xwayland.c
+++ b/compositor/xwayland.c
@@ -44,8 +44,8 @@ static void wc_xwayland_commit(struct wl_listener *listener, void *data) {
 	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
 
 	struct wlr_box size = {
-			.x = xwayland_surface->x,
-			.y = xwayland_surface->y,
+			.x = view->geo.x,
+			.y = view->geo.y,
 			.width = xwayland_surface->width,
 			.height = xwayland_surface->height,
 	};
@@ -60,8 +60,6 @@ static void wc_xwayland_surface_map(struct wl_listener *listener, void *data) {
 	view->mapped = true;
 	wc_focus_view(view);
 
-	view->geo.x = surface->x;
-	view->geo.y = surface->y;
 	view->geo.width = surface->width;
 	view->geo.height = surface->height;
 
@@ -86,8 +84,8 @@ static void wc_xwayland_request_move(struct wl_listener *listener, void *data) {
 	struct wc_view *view = wl_container_of(listener, view, request_move);
 
 	struct wlr_box geo = {
-			.x = view->xwayland_surface->x,
-			.y = view->xwayland_surface->y,
+			.x = view->geo.x,
+			.y = view->geo.y,
 			.width = view->xwayland_surface->width,
 			.height = view->xwayland_surface->height,
 	};
@@ -101,8 +99,8 @@ static void wc_xwayland_request_resize(
 	struct wlr_xwayland_resize_event *event = data;
 
 	struct wlr_box geo = {
-			.x = view->xwayland_surface->x,
-			.y = view->xwayland_surface->y,
+			.x = view->geo.x,
+			.y = view->geo.y,
 			.width = view->xwayland_surface->width,
 			.height = view->xwayland_surface->height,
 	};

--- a/compositor/xwayland.c
+++ b/compositor/xwayland.c
@@ -82,17 +82,6 @@ static void wc_xwayland_surface_unmap(
 
 static void wc_xwayland_request_move(struct wl_listener *listener, void *data) {
 	struct wc_view *view = wl_container_of(listener, view, request_move);
-	// struct wlr_xwayland_move_event *event = data;
-	struct wc_server *server = view->server;
-	struct wc_cursor *cursor = server->cursor;
-	struct wlr_cursor *wlr_cursor = cursor->wlr_cursor;
-	struct wlr_surface *focused_surface =
-			server->seat->seat->pointer_state.focused_surface;
-	struct wlr_surface *surface = wc_view_surface(view);
-
-	if (surface != focused_surface) {
-		return;
-	}
 
 	struct wlr_box geo = {
 			.x = view->xwayland_surface->x,
@@ -101,15 +90,7 @@ static void wc_xwayland_request_move(struct wl_listener *listener, void *data) {
 			.height = view->xwayland_surface->height,
 	};
 
-	cursor->cursor_mode = WC_CURSOR_MOVE;
-	cursor->grabbed.view = view;
-	cursor->grabbed.original_x = wlr_cursor->x - view->geo.x;
-	cursor->grabbed.original_y = wlr_cursor->y - view->geo.y;
-
-	cursor->grabbed.original_view_geo.x = view->geo.x;
-	cursor->grabbed.original_view_geo.y = view->geo.y;
-	cursor->grabbed.original_view_geo.width = geo.width;
-	cursor->grabbed.original_view_geo.height = geo.height;
+	wc_view_move(view, geo);
 }
 
 static void wc_xwayland_new_surface(struct wl_listener *listener, void *data) {

--- a/compositor/xwayland.c
+++ b/compositor/xwayland.c
@@ -1,0 +1,154 @@
+#include "xwayland.h"
+
+#include <stdlib.h>
+
+#include <wlr/util/log.h>
+
+#include "server.h"
+#include "view.h"
+
+void wc_xwayland_surface_destroy(struct wl_listener *listener, void *data) {
+	struct wc_view *view = wl_container_of(listener, view, destroy);
+
+	wl_list_remove(&view->link);
+
+	wl_list_remove(&view->map.link);
+	wl_list_remove(&view->unmap.link);
+	wl_list_remove(&view->configure.link);
+	wl_list_remove(&view->destroy.link);
+
+	free(view);
+}
+
+static void wc_xwayland_request_configure(
+		struct wl_listener *listener, void *data) {
+	struct wc_view *view = wl_container_of(listener, view, configure);
+
+	struct wlr_xwayland_surface_configure_event *event = data;
+
+	view->geo.x = event->x;
+	view->geo.y = event->y;
+	view->geo.width = event->width;
+	view->geo.height = event->height;
+
+	wlr_xwayland_surface_configure(view->xwayland_surface, event->x, event->y,
+			event->width, event->height);
+}
+
+static void wc_xwayland_commit(struct wl_listener *listener, void *data) {
+	struct wc_view *view = wl_container_of(listener, view, commit);
+	if (!view->mapped) {
+		return;
+	}
+
+	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	wlr_surface_get_effective_damage(xwayland_surface->surface, &damage);
+	wc_view_damage(view, &damage);
+
+	struct wlr_box size = {.x = xwayland_surface->x,
+			.y = xwayland_surface->y,
+			.width = xwayland_surface->width,
+			.height = xwayland_surface->height};
+
+	bool size_changed =
+			view->geo.width != xwayland_surface->surface->current.width ||
+			view->geo.height != xwayland_surface->surface->current.height;
+
+	if (size_changed) {
+		wc_view_damage_whole(view);
+		view->geo.width = xwayland_surface->surface->current.width;
+		view->geo.height = xwayland_surface->surface->current.height;
+		wc_view_damage_whole(view);
+	}
+
+	if (view->pending_geometry.x != view->geo.x) {
+		view->geo.x = view->pending_geometry.x + view->pending_geometry.width -
+				size.width;
+	}
+	if (view->pending_geometry.y != view->geo.y) {
+		view->geo.y = view->pending_geometry.y + view->pending_geometry.height -
+				size.height;
+	}
+
+	wc_view_damage_whole(view);
+
+	view->pending_serial = 0;
+	view->is_pending_serial = false;
+
+	pixman_region32_fini(&damage);
+}
+
+static void wc_xwayland_surface_map(struct wl_listener *listener, void *data) {
+	struct wc_view *view = wl_container_of(listener, view, map);
+	struct wlr_xwayland_surface *surface = data;
+
+	view->mapped = true;
+	wc_focus_view(view);
+
+	view->geo.x = surface->x;
+	view->geo.y = surface->y;
+	view->geo.width = surface->width;
+	view->geo.height = surface->height;
+
+	view->commit.notify = wc_xwayland_commit;
+	wl_signal_add(
+			&view->xwayland_surface->surface->events.commit, &view->commit);
+
+	wc_view_damage_whole(view);
+}
+
+static void wc_xwayland_surface_unmap(
+		struct wl_listener *listener, void *data) {
+	struct wc_view *view = wl_container_of(listener, view, unmap);
+	view->mapped = false;
+
+	wl_list_remove(&view->commit.link);
+
+	wc_view_damage_whole(view);
+}
+
+static void wc_xwayland_new_surface(struct wl_listener *listener, void *data) {
+	struct wc_server *server =
+			wl_container_of(listener, server, new_xwayland_surface);
+	struct wlr_xwayland_surface *xwayland_surface = data;
+
+	struct wc_view *view = calloc(1, sizeof(struct wc_view));
+	view->server = server;
+	view->xwayland_surface = xwayland_surface;
+	view->surface_type = WC_XWAYLAND;
+
+	view->map.notify = wc_xwayland_surface_map;
+	view->unmap.notify = wc_xwayland_surface_unmap;
+	view->configure.notify = wc_xwayland_request_configure;
+	view->destroy.notify = wc_xwayland_surface_destroy;
+
+	wl_signal_add(&xwayland_surface->events.map, &view->map);
+	wl_signal_add(&xwayland_surface->events.unmap, &view->unmap);
+	wl_signal_add(
+			&xwayland_surface->events.request_configure, &view->configure);
+	wl_signal_add(&xwayland_surface->events.destroy, &view->destroy);
+
+	wl_list_insert(&server->views, &view->link);
+}
+
+void wc_xwayland_init(struct wc_server *server) {
+	server->xwayland =
+			wlr_xwayland_create(server->wl_display, server->compositor, false);
+
+	server->new_xwayland_surface.notify = wc_xwayland_new_surface;
+	wl_signal_add(&server->xwayland->events.new_surface,
+			&server->new_xwayland_surface);
+
+	if (server->xwayland == NULL) {
+		abort();
+	}
+}
+
+void wc_xwayland_fini(struct wc_server *server) {
+	wlr_xwayland_destroy(server->xwayland);
+	server->xwayland = NULL;
+
+	wl_list_remove(&server->new_xwayland_surface.link);
+}

--- a/compositor/xwayland.h
+++ b/compositor/xwayland.h
@@ -1,0 +1,12 @@
+#ifndef WC_XWAYLAND_H
+#define WC_XWAYLAND_H
+
+#include "server.h"
+
+void wc_xwayland_init(struct wc_server *server);
+
+void wc_xwayland_fini(struct wc_server *server);
+
+void wc_xwayland_surface_destroy(struct wl_listener *listener, void *data);
+
+#endif  // WC_XWAYLAND_H


### PR DESCRIPTION
Adds xwayland support to the compositor. This allows the client to run along with `way-cooler` in DRM, so that's nice.

At this point the compositor should be usable on its own, assuming you start it with some means to spawn other things (e.g a terminal).