### PR TITLE
Added mousegrabber api

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -884,7 +884,10 @@ dependencies = [
  "rlua 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-protocols 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xkbcommon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,6 +26,8 @@ libc = "0.2.*"
 glib = "0.5.0"
 tempfile = "3.0.*"
 xcb = { version = "0.8.1", features = ["xkb"] }
+wayland-commons = "0.23"
+wayland-sys = { version = "0.23", features = [ "dlopen" ] }
 wayland-client = { version = "0.23", features = [ "native_lib", "dlopen" ] }
 wayland-protocols = { version = "0.23", features = [ 'client', "unstable_protocols" ] }
 dbus = "0.6"
@@ -37,6 +39,7 @@ enumflags2_derive = "0.5"
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 pkg-config = "0.3.*"
+wayland-scanner = { version = "0.23" }
 
 
 [features]

--- a/client/build.rs
+++ b/client/build.rs
@@ -3,9 +3,12 @@ extern crate pkg_config;
 
 use std::{env, fs, io::Write, path::Path, process::Command};
 
+use wayland_scanner::{generate_code, Side};
+
 fn main() {
     dump_git_version();
     build_wayland_glib_interface();
+    generate_custom_protocols();
 }
 
 /// Writes the current git hash to a file that is read by Way Cooler
@@ -72,4 +75,15 @@ fn build_wayland_glib_interface() {
         .file("src/wayland_glib_interface.c")
         .compile("wayland_glib_interface");
     println!("cargo:rustc-flags=-l wayland-client");
+}
+
+fn generate_custom_protocols() {
+    let out_dir_str = env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir_str);
+
+    let protocol = "../protocols/way-cooler-mousegrabber-unstable-v1.xml";
+
+    generate_code(protocol, out_dir.join("mouse_grabber_api.rs"), Side::Client);
+
+    println!("cargo:rerun-if-changed={}", protocol);
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -60,7 +60,7 @@ use {
         global_filter,
         protocol::{wl_compositor, wl_output, wl_shm},
         sys::client::wl_display,
-        ConnectError, Display, EventQueue, GlobalError, GlobalManager
+        ConnectError, Display, EventQueue, GlobalManager
     },
     xcb::xkb
 };
@@ -292,54 +292,18 @@ fn init_wayland() -> (WaylandState, GlobalManager) {
     );
     event_queue.sync_roundtrip().unwrap();
 
-    globals.instantiate_exact(
+    wayland_obj::instantiate_global(
+        &globals,
         wayland_obj::LAYER_SHELL_VERSION,
-        wayland_obj::layer_shell_init
-    ).unwrap_or_else(|err| match err {
-        GlobalError::Missing => {
-            error!("Missing layer shell (version {})", wayland_obj::LAYER_SHELL_VERSION);
-            fail(
-                "Your compositor doesn't support the layer shell protocol. \
-                 This protocol is necessary for Awesome to function"
-            );
-        }
-        GlobalError::VersionTooLow(version) => {
-            error!(
-                "Got layer shell version {}, expected version {}",
-                version,
-                wayland_obj::LAYER_SHELL_VERSION
-            );
-            fail(&format!(
-                "Your compositor doesn't support version {} \
-                 of the layer shell protocol. Ensure your compositor is up to date",
-                wayland_obj::LAYER_SHELL_VERSION
-            ));
-        }
-    });
-    globals.instantiate_exact(
+        wayland_obj::layer_shell_init,
+        "layer shell"
+    );
+    wayland_obj::instantiate_global(
+        &globals,
         wayland_obj::MOUSEGRABBER_VERSION,
-        wayland_obj::mousegrabber_init
-    ).unwrap_or_else(|err| match err {
-        GlobalError::Missing => {
-            error!("Missing mousegrabber (version {})", wayland_obj::MOUSEGRABBER_VERSION);
-            fail(
-                "Your compositor doesn't support the mousegrabber protocol. \
-                 This protocol is necessary for Awesome to function"
-            );
-        }
-        GlobalError::VersionTooLow(version) => {
-            error!(
-                "Got mousegrabber version {}, expected version {}",
-                version,
-                wayland_obj::MOUSEGRABBER_VERSION
-            );
-            fail(&format!(
-                "Your compositor doesn't support version {} \
-                 of the mousegrabber protocol. Ensure your compositor is up to date",
-                wayland_obj::MOUSEGRABBER_VERSION
-            ));
-        }
-    });
+        wayland_obj::mousegrabber_init,
+        "mousegrabber"
+    );
 
     event_queue.sync_roundtrip().unwrap();
     (

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -316,6 +316,30 @@ fn init_wayland() -> (WaylandState, GlobalManager) {
             ));
         }
     });
+    globals.instantiate_exact(
+        wayland_obj::MOUSEGRABBER_VERSION,
+        wayland_obj::mousegrabber_init
+    ).unwrap_or_else(|err| match err {
+        GlobalError::Missing => {
+            error!("Missing mousegrabber (version {})", wayland_obj::MOUSEGRABBER_VERSION);
+            fail(
+                "Your compositor doesn't support the mousegrabber protocol. \
+                 This protocol is necessary for Awesome to function"
+            );
+        }
+        GlobalError::VersionTooLow(version) => {
+            error!(
+                "Got mousegrabber version {}, expected version {}",
+                version,
+                wayland_obj::MOUSEGRABBER_VERSION
+            );
+            fail(&format!(
+                "Your compositor doesn't support version {} \
+                 of the mousegrabber protocol. Ensure your compositor is up to date",
+                wayland_obj::MOUSEGRABBER_VERSION
+            ));
+        }
+    });
 
     event_queue.sync_roundtrip().unwrap();
     (

--- a/client/src/mousegrabber.rs
+++ b/client/src/mousegrabber.rs
@@ -19,7 +19,6 @@ pub fn init(lua: rlua::Context) -> rlua::Result<()> {
     globals.set(MOUSEGRABBER_TABLE, mousegrabber_table)
 }
 
-#[allow(dead_code)]
 pub fn mousegrabber_handle(
     x: i32,
     y: i32,
@@ -36,7 +35,6 @@ pub fn mousegrabber_handle(
     })
 }
 
-#[allow(dead_code)]
 fn call_mousegrabber(
     lua: rlua::Context,
     (x, y, button_events): (i32, i32, Vec<bool>)

--- a/client/src/mousegrabber.rs
+++ b/client/src/mousegrabber.rs
@@ -24,7 +24,7 @@ pub fn init(lua: rlua::Context) -> rlua::Result<()> {
 pub fn mousegrabber_handle(
     x: i32,
     y: i32,
-    button: Option<(u32, u32 /* TODO real button state */)>
+    button: Option<(u32, u32)>
 ) -> rlua::Result<()> {
     LUA.with(|lua| {
         let lua = lua.borrow();

--- a/client/src/mousegrabber.rs
+++ b/client/src/mousegrabber.rs
@@ -2,11 +2,13 @@
 
 use rlua::{self, Function, Value};
 
-use crate::LUA;
+use crate::{
+    wayland_obj::{grab_mouse, release_mouse},
+    LUA
+};
 
 pub const MOUSEGRABBER_TABLE: &str = "mousegrabber";
 const MOUSEGRABBER_CALLBACK: &str = "__callback";
-const MOUSEGRABBER_CURSOR: &str = "__cursor";
 
 /// Init the methods defined on this interface
 pub fn init(lua: rlua::Context) -> rlua::Result<()> {
@@ -65,12 +67,14 @@ fn run<'lua>(
         )),
         _ => {
             lua.set_named_registry_value(MOUSEGRABBER_CALLBACK, function)?;
-            lua.set_named_registry_value(MOUSEGRABBER_CURSOR, cursor)
+            grab_mouse(cursor);
+            Ok(())
         }
     }
 }
 
 fn stop(lua: rlua::Context, _: ()) -> rlua::Result<()> {
+    release_mouse();
     lua.set_named_registry_value(MOUSEGRABBER_CALLBACK, Value::Nil)
 }
 

--- a/client/src/wayland_obj/mod.rs
+++ b/client/src/wayland_obj/mod.rs
@@ -1,6 +1,7 @@
 //! Wrappers around Wayland objects
 
 mod layer_shell;
+mod mousegrabber;
 mod wl_compositor;
 mod wl_output;
 mod wl_shm;
@@ -10,6 +11,7 @@ pub use self::{
         create_layer_surface, layer_shell_init, Layer, LayerSurface,
         LAYER_SHELL_VERSION
     },
+    mousegrabber::{mousegrabber_init, MOUSEGRABBER_VERSION},
     wl_compositor::{
         create_surface, WlCompositorManager, WL_COMPOSITOR_VERSION
     },

--- a/client/src/wayland_obj/mod.rs
+++ b/client/src/wayland_obj/mod.rs
@@ -2,6 +2,7 @@
 
 mod layer_shell;
 mod mousegrabber;
+mod utils;
 mod wl_compositor;
 mod wl_output;
 mod wl_shm;
@@ -14,6 +15,7 @@ pub use self::{
     mousegrabber::{
         grab_mouse, mousegrabber_init, release_mouse, MOUSEGRABBER_VERSION
     },
+    utils::instantiate_global,
     wl_compositor::{
         create_surface, WlCompositorManager, WL_COMPOSITOR_VERSION
     },

--- a/client/src/wayland_obj/mod.rs
+++ b/client/src/wayland_obj/mod.rs
@@ -11,7 +11,9 @@ pub use self::{
         create_layer_surface, layer_shell_init, Layer, LayerSurface,
         LAYER_SHELL_VERSION
     },
-    mousegrabber::{mousegrabber_init, MOUSEGRABBER_VERSION},
+    mousegrabber::{
+        grab_mouse, mousegrabber_init, release_mouse, MOUSEGRABBER_VERSION
+    },
     wl_compositor::{
         create_surface, WlCompositorManager, WL_COMPOSITOR_VERSION
     },

--- a/client/src/wayland_obj/mousegrabber.rs
+++ b/client/src/wayland_obj/mousegrabber.rs
@@ -54,7 +54,7 @@ pub fn grab_mouse(cursor: String) {
         let mouse_grabber = mouse_grabber
             .as_ref()
             .expect("Mouse grabber has not been initialized");
-        mouse_grabber.grab_mouse();
+        mouse_grabber.grab_mouse(cursor);
     });
 }
 

--- a/client/src/wayland_obj/mousegrabber.rs
+++ b/client/src/wayland_obj/mousegrabber.rs
@@ -45,11 +45,35 @@ impl mouse_grabber::EventHandler for MousegrabberHandler {
     }
 }
 
+/// Grabs the mouse. Grabbing the mouse multiple times is a protocol error.
+///
+/// Only one client at a time can grab the mouse.
+pub fn grab_mouse(cursor: String) {
+    MOUSE_GRABBER.with(|mouse_grabber| {
+        let mouse_grabber = mouse_grabber.borrow();
+        let mouse_grabber = mouse_grabber
+            .as_ref()
+            .expect("Mouse grabber has not been initialized");
+        mouse_grabber.grab_mouse();
+    });
+}
+
+/// Release the mouse. Releasing the mouse when the client has not grabbed
+/// the mouse is a protocol error.
+pub fn release_mouse() {
+    MOUSE_GRABBER.with(|mouse_grabber| {
+        let mouse_grabber = mouse_grabber.borrow();
+        let mouse_grabber = mouse_grabber
+            .as_ref()
+            .expect("Mouse grabber has not been initialized");
+        mouse_grabber.release_mouse();
+    })
+}
+
 pub fn mousegrabber_init(
     new_proxy: NewProxy<ZwayCoolerMousegrabber>
 ) -> ZwayCoolerMousegrabber {
     let mouse_grabber = new_proxy.implement(MousegrabberHandler, ());
-    mouse_grabber.grab_mouse();
     MOUSE_GRABBER.with(|grabber| {
         *grabber.borrow_mut() = Some(mouse_grabber.clone());
     });

--- a/client/src/wayland_obj/mousegrabber.rs
+++ b/client/src/wayland_obj/mousegrabber.rs
@@ -1,0 +1,53 @@
+use std::cell::RefCell;
+
+use wayland_client::NewProxy;
+
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    dead_code,
+    unused_imports,
+    unused_variables
+)]
+mod mouse_grabber {
+    use wayland_client::{protocol::wl_surface, *};
+    pub(crate) use wayland_commons::{
+        map::{Object, ObjectMetadata},
+        wire::{Argument, ArgumentType, Message, MessageDesc},
+        Interface, MessageGroup
+    };
+    pub(crate) use wayland_sys as sys;
+    use wayland_sys::common::{wl_argument, wl_interface};
+
+    include!(concat!(env!("OUT_DIR"), "/mouse_grabber_api.rs"));
+
+    pub use zway_cooler_mousegrabber::*;
+}
+use mouse_grabber::ZwayCoolerMousegrabber;
+
+thread_local! {
+    static MOUSE_GRABBER: RefCell<Option<ZwayCoolerMousegrabber>> =
+        RefCell::new(None)
+}
+
+pub const MOUSEGRABBER_VERSION: u32 = 1;
+
+pub struct MousegrabberHandler;
+
+impl mouse_grabber::EventHandler for MousegrabberHandler {
+    fn mouse_moved(&mut self, _: ZwayCoolerMousegrabber, x: i32, y: i32) {
+        info!("Mouse moved to ({}, {})", x, y);
+    }
+}
+
+pub fn mousegrabber_init(
+    new_proxy: NewProxy<ZwayCoolerMousegrabber>
+) -> ZwayCoolerMousegrabber {
+    let mouse_grabber = new_proxy.implement(MousegrabberHandler, ());
+    mouse_grabber.grab_mouse();
+    MOUSE_GRABBER.with(|grabber| {
+        *grabber.borrow_mut() = Some(mouse_grabber.clone());
+    });
+    mouse_grabber
+}

--- a/client/src/wayland_obj/mousegrabber.rs
+++ b/client/src/wayland_obj/mousegrabber.rs
@@ -2,6 +2,8 @@ use std::cell::RefCell;
 
 use wayland_client::NewProxy;
 
+use crate::mousegrabber::mousegrabber_handle;
+
 #[allow(
     non_camel_case_types,
     non_snake_case,
@@ -37,7 +39,9 @@ pub struct MousegrabberHandler;
 
 impl mouse_grabber::EventHandler for MousegrabberHandler {
     fn mouse_moved(&mut self, _: ZwayCoolerMousegrabber, x: i32, y: i32) {
-        info!("Mouse moved to ({}, {})", x, y);
+        if let Err(err) = mousegrabber_handle(x, y, None) {
+            warn!("mousegrabber returned error {}", err);
+        }
     }
 }
 

--- a/client/src/wayland_obj/mousegrabber.rs
+++ b/client/src/wayland_obj/mousegrabber.rs
@@ -26,7 +26,7 @@ mod mouse_grabber {
 
     pub use zway_cooler_mousegrabber::*;
 }
-use mouse_grabber::ZwayCoolerMousegrabber;
+use mouse_grabber::{ButtonState, ZwayCoolerMousegrabber};
 
 thread_local! {
     static MOUSE_GRABBER: RefCell<Option<ZwayCoolerMousegrabber>> =
@@ -41,6 +41,21 @@ impl mouse_grabber::EventHandler for MousegrabberHandler {
     fn mouse_moved(&mut self, _: ZwayCoolerMousegrabber, x: i32, y: i32) {
         if let Err(err) = mousegrabber_handle(x, y, None) {
             warn!("mousegrabber returned error {}", err);
+        }
+    }
+
+    fn mouse_button(
+        &mut self,
+        _: ZwayCoolerMousegrabber,
+        x: i32,
+        y: i32,
+        pressed: ButtonState,
+        button: u32
+    ) {
+        if let Err(err) =
+            mousegrabber_handle(x, y, Some((pressed as u32, button)))
+        {
+            warn!("mousegrabber returned error {}", err)
         }
     }
 }

--- a/client/src/wayland_obj/utils.rs
+++ b/client/src/wayland_obj/utils.rs
@@ -1,0 +1,35 @@
+use wayland_client::{GlobalError, GlobalManager, Interface, NewProxy, Proxy};
+
+pub fn instantiate_global<F, I>(
+    globals: &GlobalManager,
+    version: u32,
+    implementor: F,
+    name: &str
+) where
+    I: Interface + From<Proxy<I>>,
+    F: FnOnce(NewProxy<I>) -> I
+{
+    globals
+        .instantiate_exact(version, implementor)
+        .unwrap_or_else(|err| match err {
+            GlobalError::Missing => {
+                error!("Missing {} protocol (need version {})", name, version);
+                crate::fail(&format!(
+                    "Your compositor doesn't support the {} protocol. \
+                     This protocol is necessary for Awesome to function",
+                    name
+                ));
+            },
+            GlobalError::VersionTooLow(actual_version) => {
+                error!(
+                    "Got version {} of the {} protocol, expected version {}",
+                    actual_version, name, version
+                );
+                crate::fail(&format!(
+                    "Your compositor doesn't support version {} \
+                     of the {} protocol. Ensure your compositor is up to date",
+                    name, version
+                ));
+            }
+        });
+}

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -118,6 +118,9 @@ static void wc_cursor_button(struct wl_listener *listener, void *data) {
 	struct wc_server *server = cursor->server;
 	struct wlr_event_pointer_button *event = data;
 
+	wc_mousegrabber_notify_mouse_button(server->mousegrabber,
+			cursor->wlr_cursor->x, cursor->wlr_cursor->y, event);
+
 	if (server->mouse_grab) {
 		return;
 	}

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -6,6 +6,7 @@
 
 #include <wlr/util/log.h>
 
+#include "mousegrabber.h"
 #include "output.h"
 #include "seat.h"
 #include "server.h"
@@ -91,6 +92,8 @@ static void wc_process_motion(struct wc_server *server, uint32_t time) {
 			}
 		}
 	}
+
+	wc_mousegrabber_notify_mouse_moved(server, wlr_cursor->x, wlr_cursor->y);
 }
 
 static void wc_cursor_motion(struct wl_listener *listener, void *data) {

--- a/compositor/cursor.c
+++ b/compositor/cursor.c
@@ -117,6 +117,11 @@ static void wc_cursor_button(struct wl_listener *listener, void *data) {
 	struct wc_cursor *cursor = wl_container_of(listener, cursor, button);
 	struct wc_server *server = cursor->server;
 	struct wlr_event_pointer_button *event = data;
+
+	if (server->mouse_grab) {
+		return;
+	}
+
 	wlr_seat_pointer_notify_button(
 			server->seat->seat, event->time_msec, event->button, event->state);
 

--- a/compositor/cursor.h
+++ b/compositor/cursor.h
@@ -4,6 +4,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_seat.h>
 
 enum wc_cursor_mode {
 	WC_CURSOR_PASSTHROUGH = 0,
@@ -15,7 +16,14 @@ struct wc_cursor {
 	struct wc_server *server;
 	struct wlr_cursor *wlr_cursor;
 
-	char *image;
+	// When non-NULL, this takes precedence over all other cursor images.
+	char *compositor_image;
+	// Flag to determine if we are using the client provided image.
+	bool use_client_image;
+	/* The image to use if there is no compositor_image or use_client_image is
+	 * not set.
+	 */
+	const char *default_image;
 
 	enum wc_cursor_mode cursor_mode;
 	/*
@@ -43,5 +51,28 @@ struct wc_cursor {
 void wc_cursor_init(struct wc_server *server);
 
 void wc_cursor_fini(struct wc_server *server);
+
+/* Sets the cursor image, given from the client. If cursor_name is NULL then
+ * it will defer to the default compositor cursor.
+ *
+ * If the compositor cursor is set to a non-NULL value then this value will be
+ * ignored until that is null. Once the compositor cursor becomes non-NULL
+ * there is no need to recall this, it will be done automatically.
+ *
+ * To switch to using the compositor cursor again, use wc_set_compositor_cursor.
+ */
+void wc_cursor_set_client_cursor(struct wc_cursor *cursor,
+		struct wlr_seat_pointer_request_set_cursor_event *event);
+
+/* Sets the current image used by the compositor. If cursor_name is NULL then
+ * it will set the cursor to the client provided cursor, or to the default
+ * cursor if there is no current client provided one.
+ *
+ * This is primarily used by mousegrabber, and is only intended to allow the
+ * special Awesome client to change the cursor. This is basically a huge
+ * subversion of how Wayland is supposed to work.
+ */
+void wc_cursor_set_compositor_cursor(
+		struct wc_cursor *cursor, const char *cursor_name);
 
 #endif  // WC_CURSOR_H

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -44,6 +44,7 @@ way_cooler_sources = files(
 	'keyboard.c',
 	'layer_shell.c',
 	'main.c',
+	'mousegrabber.c',
 	'output.c',
 	'pointer.c',
 	'seat.c',

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -27,6 +27,9 @@ static void grab_mouse(struct wl_client *client, struct wl_resource *resource,
 
 	mousegrabber->resource = resource;
 	mousegrabber->client = client;
+
+	server->mouse_grab = true;
+	cursor->cursor_mode = WC_CURSOR_PASSTHROUGH;
 	wc_cursor_set_compositor_cursor(cursor, new_cursor_name);
 
 	wlr_log(WLR_DEBUG, "mousegrabber: mouse grabbed");
@@ -49,6 +52,7 @@ static void release_mouse(
 		return;
 	}
 
+	server->mouse_grab = false;
 	wc_cursor_set_compositor_cursor(cursor, NULL);
 
 	// NOTE: Calls our destroy event, which clears client resource pointers.

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -91,15 +91,6 @@ static void mousegrabber_bind(struct wl_client *wl_client, void *data,
 			mousegrabber_handle_resource_destroy);
 }
 
-void wc_mousegrabber_notify_mouse_moved(
-		struct wc_mousegrabber *mousegrabber, int x, int y) {
-	if (mousegrabber == NULL || mousegrabber->resource == NULL) {
-		return;
-	}
-
-	zway_cooler_mousegrabber_send_mouse_moved(mousegrabber->resource, x, y);
-}
-
 void wc_mousegrabber_init(struct wc_server *server) {
 	struct wc_mousegrabber *mousegrabber = calloc(1, sizeof(mousegrabber));
 	mousegrabber->server = server;
@@ -117,4 +108,27 @@ void wc_mousegrabber_fini(struct wc_server *server) {
 	free(server->mousegrabber);
 
 	server->mousegrabber = NULL;
+}
+
+void wc_mousegrabber_notify_mouse_moved(
+		struct wc_mousegrabber *mousegrabber, int x, int y) {
+	if (mousegrabber == NULL || mousegrabber->resource == NULL) {
+		return;
+	}
+
+	zway_cooler_mousegrabber_send_mouse_moved(mousegrabber->resource, x, y);
+}
+
+void wc_mousegrabber_notify_mouse_button(struct wc_mousegrabber *mousegrabber,
+		int x, int y, struct wlr_event_pointer_button *event) {
+	if (mousegrabber == NULL || mousegrabber->resource == NULL) {
+		return;
+	}
+	enum zway_cooler_mousegrabber_button_state pressed =
+			event->state == WLR_BUTTON_PRESSED ?
+			ZWAY_COOLER_MOUSEGRABBER_BUTTON_STATE_PRESSED :
+			ZWAY_COOLER_MOUSEGRABBER_BUTTON_STATE_RELEASED;
+
+	zway_cooler_mousegrabber_send_mouse_button(
+			mousegrabber->resource, x, y, pressed, event->button);
 }

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -92,7 +92,8 @@ static void mousegrabber_bind(struct wl_client *wl_client, void *data,
 }
 
 void wc_mousegrabber_init(struct wc_server *server) {
-	struct wc_mousegrabber *mousegrabber = calloc(1, sizeof(mousegrabber));
+	struct wc_mousegrabber *mousegrabber =
+			calloc(1, sizeof(struct wc_mousegrabber));
 	mousegrabber->server = server;
 	mousegrabber->global = wl_global_create(server->wl_display,
 			&zway_cooler_mousegrabber_interface, MOUSEGRABBER_VERSION,

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -1,0 +1,70 @@
+#include "mousegrabber.h"
+
+#include <stdlib.h>
+
+#include <wayland-server.h>
+#include <wlr/util/log.h>
+
+#include "server.h"
+#include "way-cooler-mousegrabber-unstable-v1-protocol.h"
+
+static void grab_mouse(struct wl_client *client, struct wl_resource *resource) {
+	struct wc_mousegrabber *mousegrabber = wl_resource_get_user_data(resource);
+
+	mousegrabber->resource = resource;
+	wlr_log(WLR_DEBUG, "mouse grabbed!");
+}
+
+static const struct zway_cooler_mousegrabber_interface mousegrabber_impl = {
+		.grab_mouse = grab_mouse,
+};
+
+static void mousegrabber_handle_resource_destroy(struct wl_resource *resource) {
+	struct wc_mousegrabber *mousegrabber = wl_resource_get_user_data(resource);
+	mousegrabber->resource = NULL;
+}
+
+static void mousegrabber_bind(struct wl_client *wl_client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wc_mousegrabber *mousegrabber = data;
+	struct wl_resource *resource = wl_resource_create(
+			wl_client, &zway_cooler_mousegrabber_interface, version, id);
+	wl_resource_set_user_data(resource, mousegrabber);
+
+	if (resource == NULL) {
+		wl_client_post_no_memory(wl_client);
+		return;
+	}
+
+	wl_resource_set_implementation(resource, &mousegrabber_impl, mousegrabber,
+			mousegrabber_handle_resource_destroy);
+}
+
+void wc_mousegrabber_notify_mouse_moved(
+		struct wc_server *server, int x, int y) {
+	struct wc_mousegrabber *mousegrabber = server->mousegrabber;
+
+	if (mousegrabber == NULL || mousegrabber->resource == NULL) {
+		return;
+	}
+
+	zway_cooler_mousegrabber_send_mouse_moved(mousegrabber->resource, x, y);
+}
+
+void wc_mousegrabber_init(struct wc_server *server) {
+	struct wc_mousegrabber *mousegrabber = calloc(1, sizeof(mousegrabber));
+	mousegrabber->global = wl_global_create(server->wl_display,
+			&zway_cooler_mousegrabber_interface, MOUSEGRABBER_VERSION,
+			mousegrabber, mousegrabber_bind);
+
+	server->mousegrabber = mousegrabber;
+}
+
+void wc_mousegrabber_fini(struct wc_server *server) {
+	wl_list_remove(wl_resource_get_link(server->mousegrabber->resource));
+	wl_global_destroy(server->mousegrabber->global);
+
+	free(server->mousegrabber);
+
+	server->mousegrabber = NULL;
+}

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -11,6 +11,13 @@
 static void grab_mouse(struct wl_client *client, struct wl_resource *resource) {
 	struct wc_mousegrabber *mousegrabber = wl_resource_get_user_data(resource);
 
+	if (mousegrabber->resource != NULL) {
+		wl_resource_post_error(resource,
+				ZWAY_COOLER_MOUSEGRABBER_ERROR_ALREADY_GRABBED,
+				"mouse has already been grabbed");
+		return;
+	}
+
 	mousegrabber->resource = resource;
 	wlr_log(WLR_DEBUG, "mouse grabbed!");
 }

--- a/compositor/mousegrabber.h
+++ b/compositor/mousegrabber.h
@@ -22,4 +22,7 @@ void wc_mousegrabber_fini(struct wc_server *server);
 void wc_mousegrabber_notify_mouse_moved(
 		struct wc_mousegrabber *mousegrabber, int x, int y);
 
+void wc_mousegrabber_notify_mouse_button(struct wc_mousegrabber *mousegrabber,
+		int x, int y, struct wlr_event_pointer_button *event);
+
 #endif  // WC_MOUSEGRABBER_H

--- a/compositor/mousegrabber.h
+++ b/compositor/mousegrabber.h
@@ -10,6 +10,7 @@
 struct wc_mousegrabber {
 	struct wl_global *global;
 	struct wl_resource *resource;
+	struct wl_client *client;
 };
 
 void wc_mousegrabber_init(struct wc_server *server);

--- a/compositor/mousegrabber.h
+++ b/compositor/mousegrabber.h
@@ -1,0 +1,21 @@
+#ifndef WC_MOUSEGRABBER_H
+#define WC_MOUSEGRABBER_H
+
+#include <wayland-server.h>
+
+#include "server.h"
+
+#define MOUSEGRABBER_VERSION 1
+
+struct wc_mousegrabber {
+	struct wl_global *global;
+	struct wl_resource *resource;
+};
+
+void wc_mousegrabber_init(struct wc_server *server);
+
+void wc_mousegrabber_fini(struct wc_server *server);
+
+void wc_mousegrabber_notify_mouse_moved(struct wc_server *server, int x, int y);
+
+#endif  // WC_MOUSEGRABBER_H

--- a/compositor/mousegrabber.h
+++ b/compositor/mousegrabber.h
@@ -8,6 +8,8 @@
 #define MOUSEGRABBER_VERSION 1
 
 struct wc_mousegrabber {
+	struct wc_server *server;
+
 	struct wl_global *global;
 	struct wl_resource *resource;
 	struct wl_client *client;
@@ -17,6 +19,7 @@ void wc_mousegrabber_init(struct wc_server *server);
 
 void wc_mousegrabber_fini(struct wc_server *server);
 
-void wc_mousegrabber_notify_mouse_moved(struct wc_server *server, int x, int y);
+void wc_mousegrabber_notify_mouse_moved(
+		struct wc_mousegrabber *mousegrabber, int x, int y);
 
 #endif  // WC_MOUSEGRABBER_H

--- a/compositor/seat.c
+++ b/compositor/seat.c
@@ -25,7 +25,9 @@ static void wc_seat_request_cursor(struct wl_listener *listener, void *data) {
 void wc_seat_update_surface_focus(struct wc_seat *seat,
 		struct wlr_surface *surface, double sx, double sy, uint32_t time) {
 	struct wlr_seat *wlr_seat = seat->seat;
-	if (surface == NULL) {
+	struct wc_server *server = seat->server;
+
+	if (surface == NULL || server->mouse_grab) {
 		wlr_seat_pointer_clear_focus(wlr_seat);
 		return;
 	}

--- a/compositor/seat.c
+++ b/compositor/seat.c
@@ -18,9 +18,7 @@ static void wc_seat_request_cursor(struct wl_listener *listener, void *data) {
 			server->seat->seat->pointer_state.focused_client;
 
 	if (focused_client == event->seat_client) {
-		cursor->image = NULL;
-		wlr_cursor_set_surface(cursor->wlr_cursor, event->surface,
-				event->hotspot_x, event->hotspot_y);
+		wc_cursor_set_client_cursor(cursor, event);
 	}
 }
 

--- a/compositor/server.c
+++ b/compositor/server.c
@@ -18,6 +18,7 @@
 #include "cursor.h"
 #include "input.h"
 #include "layer_shell.h"
+#include "mousegrabber.h"
 #include "output.h"
 #include "seat.h"
 #include "view.h"
@@ -50,6 +51,7 @@ bool init_server(struct wc_server *server) {
 			wlr_data_device_manager_create(server->wl_display);
 
 	wc_xwayland_init(server);
+	wc_mousegrabber_init(server);
 	wc_seat_init(server);
 	wc_output_init(server);
 	wc_inputs_init(server);

--- a/compositor/server.c
+++ b/compositor/server.c
@@ -51,13 +51,14 @@ bool init_server(struct wc_server *server) {
 			wlr_data_device_manager_create(server->wl_display);
 
 	wc_xwayland_init(server);
-	wc_mousegrabber_init(server);
 	wc_seat_init(server);
 	wc_output_init(server);
 	wc_inputs_init(server);
 	wc_views_init(server);
 	wc_layers_init(server);
 	wc_cursor_init(server);
+
+	wc_mousegrabber_init(server);
 
 	return true;
 }
@@ -73,6 +74,8 @@ void fini_server(struct wc_server *server) {
 
 	wlr_screencopy_manager_v1_destroy(server->screencopy_manager);
 	wlr_data_device_manager_destroy(server->data_device_manager);
+
+	wc_mousegrabber_init(server);
 
 	wlr_compositor_destroy(server->compositor);
 

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -50,6 +50,8 @@ struct wc_server {
 
 	struct wlr_screencopy_manager_v1 *screencopy_manager;
 	struct wlr_data_device_manager *data_device_manager;
+
+	struct wc_mousegrabber *mousegrabber;
 };
 
 bool init_server(struct wc_server *server);

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -52,6 +52,7 @@ struct wc_server {
 	struct wlr_data_device_manager *data_device_manager;
 
 	struct wc_mousegrabber *mousegrabber;
+	bool mouse_grab;
 };
 
 bool init_server(struct wc_server *server);

--- a/config/rc.lua
+++ b/config/rc.lua
@@ -588,3 +588,12 @@ end)
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)
 client.connect_signal("unfocus", function(c) c.border_color = beautiful.border_normal end)
 -- }}}
+
+mousegrabber.run(
+  function(mouse)
+    print(mouse["x"], mouse[y])
+    if (mouse["x"] < 100) then
+      return false
+    end
+    return true
+  end, "cross")

--- a/config/rc.lua
+++ b/config/rc.lua
@@ -590,8 +590,8 @@ client.connect_signal("unfocus", function(c) c.border_color = beautiful.border_n
 -- }}}
 
 mousegrabber.run(
-  function(mouse)
-    print(mouse["x"], mouse[y])
+  function(mouse, button)
+    print(mouse["x"], button)
     if (mouse["x"] < 100) then
       return false
     end

--- a/config/rc.lua
+++ b/config/rc.lua
@@ -588,12 +588,3 @@ end)
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)
 client.connect_signal("unfocus", function(c) c.border_color = beautiful.border_normal end)
 -- }}}
-
-mousegrabber.run(
-  function(mouse, button)
-    print(mouse["x"], button)
-    if (mouse["x"] < 100) then
-      return false
-    end
-    return true
-  end, "cross")

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -27,6 +27,7 @@ wayland_scanner_server = generator(
 server_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
+	['way-cooler-mousegrabber-unstable-v1.xml'],
 ]
 
 server_protos_src = []

--- a/protocols/way-cooler-mousegrabber-unstable-v1.xml
+++ b/protocols/way-cooler-mousegrabber-unstable-v1.xml
@@ -40,6 +40,7 @@
         Only one client can grab the mouse at a time. Attempts to grab while
         another client is already grabbing is a protocol error.
       </description>
+      <arg name="cursor" type="string"/>
     </request>
 
     <request name="release_mouse">

--- a/protocols/way-cooler-mousegrabber-unstable-v1.xml
+++ b/protocols/way-cooler-mousegrabber-unstable-v1.xml
@@ -56,10 +56,23 @@
       <entry name="not_grabbed" value="1" summary="A client attempted to release the mouse when it was not acquired"/>
     </enum>
 
+    <enum name="button_state">
+      <entry name="released" value="0"/>
+      <entry name="pressed" value="1"/>
+    </enum>
+
     <event name="mouse_moved">
       <description summary="notify the client that the mouse has moved"/>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
+    </event>
+
+    <event name="mouse_button">
+      <description summary="notify the client that a mouse button was pressed"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="pressed" type="uint" enum="button_state"/>
+      <arg name="button" type="uint"/>
     </event>
 
   </interface>

--- a/protocols/way-cooler-mousegrabber-unstable-v1.xml
+++ b/protocols/way-cooler-mousegrabber-unstable-v1.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="way_cooler_mousegrabber_unstable_v1">
+  <copyright>
+    Copyright © 2019 Preston Carpenter
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+  <interface name="zway_cooler_mousegrabber" version="1">
+    <description summary="manipulate the compositor's cursor">
+      This interface allows clients to manipulate the compositor's cursor
+      position on the screen.
+
+      The intended use case of this is to re-implement AwesomeWM's original
+      "keygrabber" Lua interface.
+    </description>
+
+    <request name="grab_mouse">
+      <description summary="grab the mouse">
+        Attempts to grab the mouse from the compositor. 
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="already_grabbed" value="0" summary="the mouse has already been grabbed by another client"/>
+    </enum>
+
+    <event name="mouse_moved">
+      <description summary="notify the client that the mouse has moved"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+    </event>
+
+  </interface>
+</protocol>

--- a/protocols/way-cooler-mousegrabber-unstable-v1.xml
+++ b/protocols/way-cooler-mousegrabber-unstable-v1.xml
@@ -35,12 +35,24 @@
 
     <request name="grab_mouse">
       <description summary="grab the mouse">
-        Attempts to grab the mouse from the compositor. 
+        Attempts to grab the mouse from the compositor.
+
+        Only one client can grab the mouse at a time. Attempts to grab while
+        another client is already grabbing is a protocol error.
+      </description>
+    </request>
+
+    <request name="release_mouse">
+      <description summary="release the mouse">
+        Relinquishes control of the mouse back to the compositor.
+
+        It is a protocol error to call this when the client has not grabbed the mouse.
       </description>
     </request>
 
     <enum name="error">
       <entry name="already_grabbed" value="0" summary="the mouse has already been grabbed by another client"/>
+      <entry name="not_grabbed" value="1" summary="A client attempted to release the mouse when it was not acquired"/>
     </enum>
 
     <event name="mouse_moved">


### PR DESCRIPTION
This adds the mousegrabber api support. It should do _exactly_ what it does in AwesomeWM - e.g. being able to arbitrary set the cursor and not send input to other clients.

# TODO
- [x] ~There's a use double free causing a segfault~ allocating a word size not the size of the struct
- [x] Double check the button is getting to Lua correctly.