### PR TITLE
Execute command after X11 starts up

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <wordexp.h>
 
 #include <wlr/backend.h>
@@ -75,12 +74,7 @@ int main(int argc, char *argv[]) {
 	}
 	setenv("WAYLAND_DISPLAY", server.wayland_socket, true);
 
-	if (startup_cmd) {
-		wlr_log(WLR_INFO, "Executing \"%s\"", startup_cmd);
-		if (fork() == 0) {
-			execl("/bin/sh", "/bin/sh", "-c", startup_cmd, (void *)NULL);
-		}
-	}
+	server.startup_cmd = startup_cmd;
 
 	wl_display_run(server.wl_display);
 	fini_server(&server);

--- a/compositor/server.h
+++ b/compositor/server.h
@@ -23,6 +23,8 @@ struct wc_server {
 	struct wlr_renderer *renderer;
 	struct wlr_compositor *compositor;
 
+	const char *startup_cmd;
+
 	struct wlr_xcursor_manager *xcursor_mgr;
 	struct wc_cursor *cursor;
 
@@ -41,6 +43,7 @@ struct wc_server {
 
 	struct wlr_xwayland *xwayland;
 	struct wl_listener new_xwayland_surface;
+	struct wl_listener xwayland_ready;
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wl_listener new_xdg_surface;


### PR DESCRIPTION
This is done so that the client sees the updated DISPLAY environment
variable.

This is especially important to Awesome because it still uses legacy X11
commands for many of its functionality.