### PR TITLE
Fixed mousegrabber

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -35,6 +35,7 @@ tasks:
       rustup default stable
       rustup component add rustfmt-preview --toolchain nightly
       rustup component add clippy
+
   - wlroots: |
       cd wlroots
       git checkout 0.6.0
@@ -51,8 +52,3 @@ tasks:
   - way-cooler-clang: |
       cd way-cooler/build-clang
       ninja
-  - way-cooler-client-test: |
-      cd way-cooler/client
-      cargo test --verbose
-      cargo +nightly fmt --all -- --check
-      # TODO enable clippy

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -125,19 +125,16 @@ void wc_mousegrabber_notify_mouse_moved(
 		return;
 	}
 
-	zway_cooler_mousegrabber_send_mouse_moved(mousegrabber->resource, x, y);
+	zway_cooler_mousegrabber_send_mouse_moved(
+			mousegrabber->resource, x, y, mousegrabber->button);
 }
 
-void wc_mousegrabber_notify_mouse_button(struct wc_mousegrabber *mousegrabber,
-		int x, int y, struct wlr_event_pointer_button *event) {
+void wc_mousegrabber_notify_mouse_button(
+		struct wc_mousegrabber *mousegrabber, int x, int y) {
 	if (mousegrabber == NULL || mousegrabber->resource == NULL) {
 		return;
 	}
-	enum zway_cooler_mousegrabber_button_state pressed =
-			event->state == WLR_BUTTON_PRESSED ?
-			ZWAY_COOLER_MOUSEGRABBER_BUTTON_STATE_PRESSED :
-			ZWAY_COOLER_MOUSEGRABBER_BUTTON_STATE_RELEASED;
 
 	zway_cooler_mousegrabber_send_mouse_button(
-			mousegrabber->resource, x, y, pressed, event->button);
+			mousegrabber->resource, x, y, mousegrabber->button);
 }

--- a/compositor/mousegrabber.c
+++ b/compositor/mousegrabber.c
@@ -18,7 +18,7 @@ static void grab_mouse(struct wl_client *client, struct wl_resource *resource,
 	struct wc_server *server = mousegrabber->server;
 	struct wc_cursor *cursor = server->cursor;
 
-	if (mousegrabber->resource != NULL) {
+	if (mousegrabber->resource != NULL || server->mouse_grab) {
 		wl_resource_post_error(resource,
 				ZWAY_COOLER_MOUSEGRABBER_ERROR_ALREADY_GRABBED,
 				"mouse has already been grabbed");
@@ -37,7 +37,7 @@ static void grab_mouse(struct wl_client *client, struct wl_resource *resource,
 
 static void unset_mouse(struct wc_server *server) {
 	struct wc_cursor *cursor = server->cursor;
-	if (cursor == NULL) {
+	if (cursor == NULL || !server->mouse_grab) {
 		return;
 	}
 

--- a/compositor/mousegrabber.h
+++ b/compositor/mousegrabber.h
@@ -10,6 +10,9 @@
 struct wc_mousegrabber {
 	struct wc_server *server;
 
+	// down up right middle left
+	unsigned int button : 5;
+
 	struct wl_global *global;
 	struct wl_resource *resource;
 	struct wl_client *client;
@@ -22,7 +25,7 @@ void wc_mousegrabber_fini(struct wc_server *server);
 void wc_mousegrabber_notify_mouse_moved(
 		struct wc_mousegrabber *mousegrabber, int x, int y);
 
-void wc_mousegrabber_notify_mouse_button(struct wc_mousegrabber *mousegrabber,
-		int x, int y, struct wlr_event_pointer_button *event);
+void wc_mousegrabber_notify_mouse_button(
+		struct wc_mousegrabber *mousegrabber, int x, int y);
 
 #endif  // WC_MOUSEGRABBER_H

--- a/meson.build
+++ b/meson.build
@@ -36,4 +36,3 @@ add_project_arguments('-DWAY_COOLER_VERSION=@0@'.format(version), language: 'c')
 
 subdir('protocols')
 subdir('compositor')
-subdir('client')

--- a/protocols/way-cooler-mousegrabber-unstable-v1.xml
+++ b/protocols/way-cooler-mousegrabber-unstable-v1.xml
@@ -56,22 +56,17 @@
       <entry name="not_grabbed" value="1" summary="A client attempted to release the mouse when it was not acquired"/>
     </enum>
 
-    <enum name="button_state">
-      <entry name="released" value="0"/>
-      <entry name="pressed" value="1"/>
-    </enum>
-
     <event name="mouse_moved">
       <description summary="notify the client that the mouse has moved"/>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
+      <arg name="button" type="uint"/>
     </event>
 
     <event name="mouse_button">
       <description summary="notify the client that a mouse button was pressed"/>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
-      <arg name="pressed" type="uint" enum="button_state"/>
       <arg name="button" type="uint"/>
     </event>
 


### PR DESCRIPTION
Aborts were happening because of insufficient double lock / double lock
free checks.

Also fixed the type of button sent so it's more inline with what Awesome expects.

Turned off old Rust code from compiling.