### PR TITLE
Give startup client the wl_client connection

### DIFF
--- a/way-cooler/output.c
+++ b/way-cooler/output.c
@@ -207,7 +207,7 @@ static void wc_output_frame(struct wl_listener *listener, void *data) {
 		wlr_renderer_clear(renderer, (float[]){1, 1, 0, 1});
 	}
 
-	float background_color[4] = {0.25f, 0.25f, 0.25f, 1};
+	float background_color[4] = {0.0f, 0.0f, 0.0f, 1};
 	int nrects;
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; i++) {

--- a/way-cooler/server.c
+++ b/way-cooler/server.c
@@ -1,8 +1,12 @@
 #define _POSIX_C_SOURCE 200809L
 
-#include <stdlib.h>
-
 #include "server.h"
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <wayland-server.h>
 #include <wlr/backend.h>
@@ -14,6 +18,7 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/util/log.h>
 
 #include "cursor.h"
 #include "input.h"
@@ -24,6 +29,13 @@
 #include "seat.h"
 #include "view.h"
 #include "xwayland.h"
+
+static void startup_command_killed(struct wl_listener *listener, void *data) {
+	struct wc_server *server =
+			wl_container_of(listener, server, startup_client_destroyed);
+	wlr_log(WLR_INFO, "Startup command killed");
+	// TODO Something sophisticated - restart the client, shutdown, etc.
+}
 
 bool init_server(struct wc_server *server) {
 	if (server == NULL) {
@@ -90,4 +102,74 @@ void fini_server(struct wc_server *server) {
 	wc_xwayland_fini(server);
 	wl_display_destroy_clients(server->wl_display);
 	wl_display_destroy(server->wl_display);
+}
+
+static bool set_cloexec(int fd, bool cloexec) {
+	int flags = fcntl(fd, F_GETFD);
+	if (flags == -1) {
+		goto failed;
+	}
+	if (cloexec) {
+		flags = flags | FD_CLOEXEC;
+	} else {
+		flags = flags & ~FD_CLOEXEC;
+	}
+	if (fcntl(fd, F_SETFD, flags) == -1) {
+		goto failed;
+	}
+	return true;
+failed:
+	wlr_log(WLR_ERROR, "fcntl failed");
+	return false;
+}
+
+void wc_server_execute_startup_command(struct wc_server *server) {
+	int sockets[2];
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+		wlr_log(WLR_ERROR, "Failed to create client wayland socket pair");
+		abort();
+	}
+	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
+		wlr_log(WLR_ERROR, "Failed to set exec flag for socket");
+		abort();
+	}
+	server->startup_client = wl_client_create(server->wl_display, sockets[0]);
+	if (server->startup_client == NULL) {
+		wlr_log(WLR_ERROR, "Could not create startup wl_client");
+		abort();
+	}
+	server->startup_client_destroyed.notify = startup_command_killed;
+	wl_client_add_destroy_listener(
+			server->startup_client, &server->startup_client_destroyed);
+
+	wlr_log(WLR_INFO, "Executing \"%s\"", server->startup_cmd);
+	pid_t pid = fork();
+	if (pid < 0) {
+		wlr_log(WLR_ERROR, "Failed to fork for startup command");
+		abort();
+	} else if (pid == 0) {
+		/* Child process. Will be used to prevent zombie processes by
+		   killing its parent and having init be its new parent.
+		*/
+		pid = fork();
+		if (pid < 0) {
+			wlr_log(WLR_ERROR, "Failed to fork for second time");
+			abort();
+		} else if (pid == 0) {
+			if (!set_cloexec(sockets[1], false)) {
+				wlr_log(WLR_ERROR,
+						"Could not unset close exec flag for forked child");
+				abort();
+			}
+			char wayland_socket_str[16];
+			snprintf(wayland_socket_str, sizeof(wayland_socket_str), "%d",
+					sockets[1]);
+			setenv("WAYLAND_SOCKET", wayland_socket_str, true);
+			execl("/bin/sh", "/bin/sh", "-c", server->startup_cmd, NULL);
+			wlr_log(WLR_ERROR, "exec failed");
+			exit(1);
+		}
+		exit(0);
+	}
+	close(sockets[1]);
 }

--- a/way-cooler/server.h
+++ b/way-cooler/server.h
@@ -25,6 +25,8 @@ struct wc_server {
 	struct wlr_compositor *compositor;
 
 	const char *startup_cmd;
+	struct wl_client *startup_client;
+	struct wl_listener startup_client_destroyed;
 
 	struct wlr_xcursor_manager *xcursor_mgr;
 	struct wc_cursor *cursor;
@@ -63,5 +65,6 @@ struct wc_server {
 
 bool init_server(struct wc_server *server);
 void fini_server(struct wc_server *server);
+void wc_server_execute_startup_command(struct wc_server *server);
 
 #endif  // WC_SERVER_H

--- a/way-cooler/xwayland.c
+++ b/way-cooler/xwayland.c
@@ -144,10 +144,7 @@ static void wc_xwayland_ready(struct wl_listener *listener, void *data) {
 			wl_container_of(listener, server, xwayland_ready);
 	if (server->startup_cmd != NULL) {
 		// NOTE Executed here so that DISPLAY is correct for the client
-		wlr_log(WLR_INFO, "Executing \"%s\"", server->startup_cmd);
-		if (fork() == 0) {
-			execl("/bin/sh", "/bin/sh", "-c", server->startup_cmd, NULL);
-		}
+		wc_server_execute_startup_command(server);
 	}
 }
 


### PR DESCRIPTION
This will allow us to implement security going forward (i.e. only allow
that client to use those interfaces) and for us to handle client failure
more gracefully.

We don't actually do that, but this has the setup for it. It requires
more thought on how to do the latter gracefully and the former without
impacting development / debugging