### PR TITLE
Only block keys on exactish modifiers.

### DIFF
--- a/way-cooler/keybindings.c
+++ b/way-cooler/keybindings.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <wayland-server.h>
+#include <wlr/util/log.h>
 
 #include "seat.h"
 #include "server.h"
@@ -97,11 +98,7 @@ bool wc_keybindings_notify_key_if_registered(struct wc_keybindings *keybindings,
 
 	struct xkb_hash_set *registered_keys = keybindings->registered_keys;
 
-	xkb_mod_mask_t out_mask = 0;
-	bool present = xkb_hash_set_get_entry(registered_keys, key_code, &out_mask);
-	if (present) {
-		present = (out_mask & key_mask) == out_mask;
-	}
+	bool present = xkb_hash_set_get_entry(registered_keys, key_code, key_mask);
 
 	enum zway_cooler_keybindings_key_state press_state = pressed ?
 			ZWAY_COOLER_KEYBINDINGS_KEY_STATE_PRESSED :

--- a/way-cooler/xkb_hash_set.c
+++ b/way-cooler/xkb_hash_set.c
@@ -1,30 +1,59 @@
 #include "xkb_hash_set.h"
 
+#include <stdlib.h>
 #include <string.h>
 
+#include <xcb/xcb.h>
+
 void xkb_hash_set_clear(struct xkb_hash_set *hash_set) {
+	const size_t hash_set_size =
+			sizeof(hash_set->set) / sizeof(hash_set->set[0]);
+	for (size_t i = 0; i < hash_set_size; i++) {
+		struct hash_entry *entry = hash_set->set[i].next;
+		struct hash_entry *next;
+		while (entry != NULL) {
+			next = entry->next;
+			free(entry);
+			entry = next;
+		}
+	}
 	memset(&hash_set->set, 0, sizeof(hash_set->set));
 }
 
 void xkb_hash_set_add_entry(
 		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t mask) {
-	assert(key < sizeof(hash_set->set));
+	assert(key < (sizeof(hash_set->set) / sizeof(hash_set->set[0])));
+	// Strip out caps lock, mod 2, and any since those should be ignored.
+	mask &= ~(XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2 | XCB_MOD_MASK_ANY);
 
 	struct hash_entry *entry = &hash_set->set[key];
-	entry->present = true;
-	entry->mod_mask = mask;
+	if (!entry->present) {
+		entry->present = true;
+		entry->mod_mask = mask;
+	} else {
+		while (entry->next != NULL) {
+			entry = entry->next;
+		}
+		entry->next = calloc(1, sizeof(struct hash_entry));
+		entry->next->present = true;
+		entry->next->mod_mask = mask;
+	}
 }
 
 bool xkb_hash_set_get_entry(
-		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t *out_mask) {
-	assert(key < sizeof(hash_set->set));
+		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t mask) {
+	assert(key < sizeof(hash_set->set) / sizeof(hash_set->set[0]));
+	// Strip out caps lock, mod 2, and any since those should be ignored.
+	mask &= ~(XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2 | XCB_MOD_MASK_ANY);
 
 	struct hash_entry *entry = &hash_set->set[key];
 	if (entry->present) {
-		if (out_mask != NULL) {
-			*out_mask = entry->mod_mask;
+		while (entry != NULL) {
+			if (entry->mod_mask == mask) {
+				return true;
+			}
+			entry = entry->next;
 		}
-		return true;
 	}
 	return false;
 }

--- a/way-cooler/xkb_hash_set.h
+++ b/way-cooler/xkb_hash_set.h
@@ -7,6 +7,7 @@
 #define WC_XKB_HASH_SET_H
 
 struct hash_entry {
+	struct hash_entry *next;
 	xkb_mod_mask_t mod_mask;
 	bool present;
 };
@@ -21,6 +22,6 @@ void xkb_hash_set_add_entry(
 		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t mask);
 
 bool xkb_hash_set_get_entry(
-		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t *out_mask);
+		struct xkb_hash_set *hash_set, uint32_t key, xkb_mod_mask_t mask);
 
 #endif  // WC_XKB_HASH_SET_H


### PR DESCRIPTION
Exactish - don't take into account caps lock, mod2, or 'any'