### PR TITLE
Remove global destruction

### DIFF
--- a/way-cooler/layer_shell.c
+++ b/way-cooler/layer_shell.c
@@ -285,7 +285,6 @@ void wc_layers_init(struct wc_server *server) {
 }
 
 void wc_layers_fini(struct wc_server *server) {
-	wlr_layer_shell_v1_destroy(server->layer_shell);
 	server->layer_shell = NULL;
 
 	wl_list_remove(&server->new_layer_surface.link);

--- a/way-cooler/xdg.c
+++ b/way-cooler/xdg.c
@@ -118,7 +118,6 @@ void wc_xdg_init(struct wc_server *server) {
 }
 
 void wc_xdg_fini(struct wc_server *server) {
-	wlr_xdg_shell_destroy(server->xdg_shell);
 	server->xdg_shell = NULL;
 
 	wl_list_remove(&server->new_xdg_surface.link);


### PR DESCRIPTION
This was removed in wlroots to simplify the destruction order since we
will never remove these globals before removing the wl_display these
functions are now gone.